### PR TITLE
ci: Add Ubuntu 24.04 ARM support for build-test job

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -20,9 +20,12 @@ jobs:
   build-test:
     needs: prepare
     name: Build & Test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
         rust:
           - version: ${{ needs.prepare.outputs.rust_version }}
             clippy: true


### PR DESCRIPTION
## Description
This PR adds Ubuntu 24.04 ARM as a target platform for the build-test job in our CI workflow. This change will help ensure our codebase works correctly on ARM architecture.

## Changes
- Added `ubuntu-24.04-arm` to the matrix of operating systems in the build-test job
- Modified `runs-on` to use the matrix variable for OS selection
- Maintained existing test configurations (Rust versions and features)

## Testing
The CI workflow will now run in parallel on both:
- Ubuntu latest (x86_64)
- Ubuntu 24.04 ARM

Each platform will test all combinations of:
- Rust versions (latest and MSRV 1.63.0)
- Feature combinations (no-std and all-features)

## Benefits
- Ensures compatibility with ARM-based systems
- Expands test coverage to include ARM architecture
- Helps catch potential architecture-specific issues early

Issue: https://github.com/bitcoindevkit/bdk_wallet/issues/23