### PR TITLE
Feature/anti fee sniping

### DIFF
--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -23,6 +23,7 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
 bdk_chain = { version = "0.21.1", features = [ "miniscript", "serde" ], default-features = false }
 bdk_file_store = { version = "0.18.1", optional = true }
+rand = "^0.8"
 
 # Optional dependencies
 bip39 = { version = "2.0", optional = true }
@@ -45,7 +46,6 @@ bdk_chain = { version = "0.21.1", features = ["rusqlite"] }
 bdk_wallet = { path = ".", features = ["rusqlite", "file_store", "test-utils"] }
 bdk_file_store = { version = "0.18.1" }
 anyhow = "1"
-rand = "^0.8"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -23,7 +23,6 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
 bdk_chain = { version = "0.21.1", features = [ "miniscript", "serde" ], default-features = false }
 bdk_file_store = { version = "0.18.1", optional = true }
-rand = "^0.8"
 
 # Optional dependencies
 bip39 = { version = "2.0", optional = true }
@@ -46,6 +45,7 @@ bdk_chain = { version = "0.21.1", features = ["rusqlite"] }
 bdk_wallet = { path = ".", features = ["rusqlite", "file_store", "test-utils"] }
 bdk_file_store = { version = "0.18.1" }
 anyhow = "1"
+rand = "^0.8"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description
This PR implements Anti-Fee-Sniping with randomization as discussed in issue #47. 


<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers
The implementation adds randomization to anti-fee-sniping behavior:

1. Uses a 50/50 chance to choose between nLockTime and nSequence (when possible)
2. Adds a 10% chance to set either value further back in time (by a random value between 0-99)
3. Detects taproot inputs and their confirmation status

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature

Closes #47