### PR TITLE
deps!: update `bdk_chain` to 0.22.0

### DIFF
--- a/ci/pin-msrv.sh
+++ b/ci/pin-msrv.sh
@@ -10,13 +10,4 @@ set -euo pipefail
 # cargo clean
 # rustup override set 1.63.0
 
-cargo update -p home --precise "0.5.5"
-cargo update -p url --precise "2.5.0"
-cargo update -p tokio --precise "1.38.1"
-cargo update -p tokio-util --precise "0.7.11"
-cargo update -p indexmap --precise "2.5.0"
-cargo update -p security-framework-sys --precise "2.11.1"
-cargo update -p ring --precise "0.17.12"
 cargo update -p once_cell --precise "1.20.3"
-cargo update -p minreq --precise "2.13.2"
-cargo update -p native-tls --precise "0.2.13"

--- a/examples/example_wallet_electrum/Cargo.toml
+++ b/examples/example_wallet_electrum/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 
 [dependencies]
 bdk_wallet = { path = "../../wallet", features = ["file_store"] }
-bdk_electrum = { version = "0.21" }
+bdk_electrum = { version = "0.22.0" }
 anyhow = "1"

--- a/examples/example_wallet_electrum/src/main.rs
+++ b/examples/example_wallet_electrum/src/main.rs
@@ -22,7 +22,7 @@ const ELECTRUM_URL: &str = "ssl://electrum.blockstream.info:60002";
 fn main() -> Result<(), anyhow::Error> {
     let db_path = "bdk-electrum-example.db";
 
-    let mut db = Store::<bdk_wallet::ChangeSet>::open_or_create_new(DB_MAGIC.as_bytes(), db_path)?;
+    let (mut db, _) = Store::<bdk_wallet::ChangeSet>::load_or_create(DB_MAGIC.as_bytes(), db_path)?;
 
     let wallet_opt = Wallet::load()
         .descriptor(KeychainKind::External, Some(EXTERNAL_DESC))

--- a/examples/example_wallet_esplora_async/Cargo.toml
+++ b/examples/example_wallet_esplora_async/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 
 [dependencies]
 bdk_wallet = { path = "../../wallet", features = ["rusqlite"] }
-bdk_esplora = { version = "0.20", features = ["async-https", "tokio"] }
+bdk_esplora = { version = "0.21.0", features = ["async-https", "tokio"] }
 tokio = { version = "1.38.1", features = ["rt", "rt-multi-thread", "macros"] }
 anyhow = "1"

--- a/examples/example_wallet_esplora_blocking/Cargo.toml
+++ b/examples/example_wallet_esplora_blocking/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 
 [dependencies]
 bdk_wallet = { path = "../../wallet", features = ["file_store"] }
-bdk_esplora = { version = "0.20", features = ["blocking"] }
+bdk_esplora = { version = "0.21.0", features = ["blocking"] }
 anyhow = "1"

--- a/examples/example_wallet_esplora_blocking/src/main.rs
+++ b/examples/example_wallet_esplora_blocking/src/main.rs
@@ -19,7 +19,7 @@ const INTERNAL_DESC: &str = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7
 const ESPLORA_URL: &str = "http://signet.bitcoindevkit.net";
 
 fn main() -> Result<(), anyhow::Error> {
-    let mut db = Store::<bdk_wallet::ChangeSet>::open_or_create_new(DB_MAGIC.as_bytes(), DB_PATH)?;
+    let (mut db, _) = Store::<bdk_wallet::ChangeSet>::load_or_create(DB_MAGIC.as_bytes(), DB_PATH)?;
 
     let wallet_opt = Wallet::load()
         .descriptor(KeychainKind::External, Some(EXTERNAL_DESC))

--- a/examples/example_wallet_rpc/Cargo.toml
+++ b/examples/example_wallet_rpc/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 bdk_wallet = { path = "../../wallet", features = ["file_store"] }
-bdk_bitcoind_rpc = { version = "0.18" }
+bdk_bitcoind_rpc = { version = "0.19.0" }
 
 anyhow = "1"
 clap = { version = "4.5.17", features = ["derive", "env"] }

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -21,11 +21,11 @@ miniscript = { version = "12.3.1", features = [ "serde" ], default-features = fa
 bitcoin = { version = "0.32.4", features = [ "serde", "base64" ], default-features = false }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
-bdk_chain = { version = "0.21.1", features = [ "miniscript", "serde" ], default-features = false }
-bdk_file_store = { version = "0.18.1", optional = true }
+bdk_chain = { version = "0.22.0", features = [ "miniscript", "serde" ], default-features = false }
 
 # Optional dependencies
 bip39 = { version = "2.0", optional = true }
+bdk_file_store = { version = "0.20.0", optional = true }
 
 [features]
 default = ["std"]
@@ -40,9 +40,8 @@ test-utils = ["std"]
 [dev-dependencies]
 assert_matches = "1.5.0"
 tempfile = "3"
-bdk_chain = { version = "0.21.1", features = ["rusqlite"] }
+bdk_chain = { version = "0.22.0", features = ["rusqlite"] }
 bdk_wallet = { path = ".", features = ["rusqlite", "file_store", "test-utils"] }
-bdk_file_store = { version = "0.18.1" }
 anyhow = "1"
 rand = "^0.8"
 

--- a/wallet/README.md
+++ b/wallet/README.md
@@ -65,13 +65,12 @@ To persist `Wallet` state data use a data store crate that reads and writes [`Ch
 
 **Example**
 
-<!-- compile_fail because outpoint and txout are fake variables -->
 ```rust,no_run
 use bdk_wallet::{bitcoin::Network, KeychainKind, ChangeSet, Wallet};
 
 // Open or create a new file store for wallet data.
-let mut db =
-    bdk_file_store::Store::<ChangeSet>::open_or_create_new(b"magic_bytes", "/tmp/my_wallet.db")
+let (mut db, _changeset) =
+    bdk_file_store::Store::<ChangeSet>::load_or_create(b"magic_bytes", "/tmp/my_wallet.db")
         .expect("create store");
 
 // Create a wallet with initial wallet data read from the file store.

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -30,8 +30,8 @@ use bdk_chain::{
         SyncResponse,
     },
     tx_graph::{CalculateFeeError, CanonicalTx, TxGraph, TxUpdate},
-    BlockId, ChainPosition, ConfirmationBlockTime, DescriptorExt, FullTxOut, Indexed,
-    IndexedTxGraph, Indexer, Merge,
+    BlockId, CanonicalizationParams, ChainPosition, ConfirmationBlockTime, DescriptorExt,
+    FullTxOut, Indexed, IndexedTxGraph, Indexer, Merge,
 };
 use bitcoin::{
     absolute,
@@ -816,6 +816,7 @@ impl Wallet {
             .filter_chain_unspents(
                 &self.chain,
                 self.chain.tip().block_id(),
+                CanonicalizationParams::default(),
                 self.indexed_graph.index.outpoints().iter().cloned(),
             )
             .map(|((k, i), full_txo)| new_local_utxo(k, i, full_txo))
@@ -830,6 +831,7 @@ impl Wallet {
             .filter_chain_txouts(
                 &self.chain,
                 self.chain.tip().block_id(),
+                CanonicalizationParams::default(),
                 self.indexed_graph.index.outpoints().iter().cloned(),
             )
             .map(|((k, i), full_txo)| new_local_utxo(k, i, full_txo))
@@ -883,6 +885,7 @@ impl Wallet {
             .filter_chain_unspents(
                 &self.chain,
                 self.chain.tip().block_id(),
+                CanonicalizationParams::default(),
                 core::iter::once(((), op)),
             )
             .map(|(_, full_txo)| new_local_utxo(keychain, index, full_txo))
@@ -1058,7 +1061,11 @@ impl Wallet {
     pub fn get_tx(&self, txid: Txid) -> Option<WalletTx> {
         let graph = self.indexed_graph.graph();
         graph
-            .list_canonical_txs(&self.chain, self.chain.tip().block_id())
+            .list_canonical_txs(
+                &self.chain,
+                self.chain.tip().block_id(),
+                CanonicalizationParams::default(),
+            )
             .find(|tx| tx.tx_node.txid == txid)
     }
 
@@ -1077,7 +1084,11 @@ impl Wallet {
         let tx_graph = self.indexed_graph.graph();
         let tx_index = &self.indexed_graph.index;
         tx_graph
-            .list_canonical_txs(&self.chain, self.chain.tip().block_id())
+            .list_canonical_txs(
+                &self.chain,
+                self.chain.tip().block_id(),
+                CanonicalizationParams::default(),
+            )
             .filter(|c_tx| tx_index.is_tx_relevant(&c_tx.tx_node.tx))
     }
 
@@ -1112,6 +1123,7 @@ impl Wallet {
         self.indexed_graph.graph().balance(
             &self.chain,
             self.chain.tip().block_id(),
+            CanonicalizationParams::default(),
             self.indexed_graph.index.outpoints().iter().cloned(),
             |&(k, _), _| k == KeychainKind::Internal,
         )
@@ -1590,7 +1602,7 @@ impl Wallet {
         let txout_index = &self.indexed_graph.index;
         let chain_tip = self.chain.tip().block_id();
         let chain_positions = graph
-            .list_canonical_txs(&self.chain, chain_tip)
+            .list_canonical_txs(&self.chain, chain_tip, CanonicalizationParams::default())
             .map(|canon_tx| (canon_tx.tx_node.txid, canon_tx.chain_position))
             .collect::<HashMap<Txid, _>>();
 
@@ -1858,7 +1870,7 @@ impl Wallet {
         let confirmation_heights = self
             .indexed_graph
             .graph()
-            .list_canonical_txs(&self.chain, chain_tip)
+            .list_canonical_txs(&self.chain, chain_tip, CanonicalizationParams::default())
             .filter(|canon_tx| prev_txids.contains(&canon_tx.tx_node.txid))
             // This is for a small performance gain. Although `.filter` filters out excess txs, it
             // will still consume the internal `CanonicalIter` entirely. Having a `.take` here
@@ -2010,6 +2022,7 @@ impl Wallet {
                 .filter_chain_unspents(
                     &self.chain,
                     self.chain.tip().block_id(),
+                    CanonicalizationParams::default(),
                     self.indexed_graph.index.outpoints().iter().cloned(),
                 )
                 // only create LocalOutput if UTxO is mature
@@ -2219,31 +2232,7 @@ impl Wallet {
     ///
     /// After applying updates you should persist the staged wallet changes. For an example of how
     /// to persist staged wallet changes see [`Wallet::reveal_next_address`].
-    #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn apply_update(&mut self, update: impl Into<Update>) -> Result<(), CannotConnectError> {
-        use std::time::*;
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("time now must surpass epoch anchor");
-        self.apply_update_at(update, now.as_secs())
-    }
-
-    /// Applies an `update` alongside a `seen_at` timestamp and stages the changes.
-    ///
-    /// `seen_at` represents when the update is seen (in unix seconds). It is used to determine the
-    /// `last_seen`s for all transactions in the update which have no corresponding anchor(s). The
-    /// `last_seen` value is used internally to determine precedence of conflicting unconfirmed
-    /// transactions (where the transaction with the lower `last_seen` value is omitted from the
-    /// canonical history).
-    ///
-    /// Use [`apply_update`](Wallet::apply_update) to have the `seen_at` value automatically set to
-    /// the current time.
-    pub fn apply_update_at(
-        &mut self,
-        update: impl Into<Update>,
-        seen_at: u64,
-    ) -> Result<(), CannotConnectError> {
         let update = update.into();
         let mut changeset = match update.chain {
             Some(chain_update) => ChangeSet::from(self.chain.apply_update(chain_update)?),
@@ -2255,11 +2244,7 @@ impl Wallet {
             .index
             .reveal_to_target_multi(&update.last_active_indices);
         changeset.merge(index_changeset.into());
-        changeset.merge(
-            self.indexed_graph
-                .apply_update_at(update.tx_update, Some(seen_at))
-                .into(),
-        );
+        changeset.merge(self.indexed_graph.apply_update(update.tx_update).into());
         self.stage.merge(changeset);
         Ok(())
     }
@@ -2397,16 +2382,48 @@ impl Wallet {
 
 /// Methods to construct sync/full-scan requests for spk-based chain sources.
 impl Wallet {
+    /// Create a partial [`SyncRequest`] for all revealed spks at `start_time`.
+    ///
+    /// The `start_time` is used to record the time that a mempool transaction was last seen
+    /// (or evicted). See [`Wallet::start_sync_with_revealed_spks`] for more.
+    pub fn start_sync_with_revealed_spks_at(
+        &self,
+        start_time: u64,
+    ) -> SyncRequestBuilder<(KeychainKind, u32)> {
+        use bdk_chain::keychain_txout::SyncRequestBuilderExt;
+        SyncRequest::builder_at(start_time)
+            .chain_tip(self.chain.tip())
+            .revealed_spks_from_indexer(&self.indexed_graph.index, ..)
+            .expected_spk_txids(self.indexed_graph.list_expected_spk_txids(
+                &self.chain,
+                self.chain.tip().block_id(),
+                ..,
+            ))
+    }
+
     /// Create a partial [`SyncRequest`] for this wallet for all revealed spks.
     ///
     /// This is the first step when performing a spk-based wallet partial sync, the returned
     /// [`SyncRequest`] collects all revealed script pubkeys from the wallet keychain needed to
     /// start a blockchain sync with a spk based blockchain client.
+    ///
+    /// The time of the sync is the current system time and is used to record the
+    /// tx last-seen for mempool transactions. Or if an expected transaction is missing
+    /// or evicted, it is the time of the eviction. Note that timestamps may only increase
+    /// to be counted by the tx graph. To supply your own start time see
+    /// [`Wallet::start_sync_with_revealed_spks_at`].
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    #[cfg(feature = "std")]
     pub fn start_sync_with_revealed_spks(&self) -> SyncRequestBuilder<(KeychainKind, u32)> {
         use bdk_chain::keychain_txout::SyncRequestBuilderExt;
         SyncRequest::builder()
             .chain_tip(self.chain.tip())
             .revealed_spks_from_indexer(&self.indexed_graph.index, ..)
+            .expected_spk_txids(self.indexed_graph.list_expected_spk_txids(
+                &self.chain,
+                self.chain.tip().block_id(),
+                ..,
+            ))
     }
 
     /// Create a [`FullScanRequest] for this wallet.
@@ -2417,9 +2434,22 @@ impl Wallet {
     ///
     /// This operation is generally only used when importing or restoring a previously used wallet
     /// in which the list of used scripts is not known.
+    ///
+    /// The time of the scan is the current system time and is used to record the tx last-seen for
+    /// mempool transactions. To supply your own start time see [`Wallet::start_full_scan_at`].
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    #[cfg(feature = "std")]
     pub fn start_full_scan(&self) -> FullScanRequestBuilder<KeychainKind> {
         use bdk_chain::keychain_txout::FullScanRequestBuilderExt;
         FullScanRequest::builder()
+            .chain_tip(self.chain.tip())
+            .spks_from_indexer(&self.indexed_graph.index)
+    }
+
+    /// Create a [`FullScanRequest`] builder at `start_time`.
+    pub fn start_full_scan_at(&self, start_time: u64) -> FullScanRequestBuilder<KeychainKind> {
+        use bdk_chain::keychain_txout::FullScanRequestBuilderExt;
+        FullScanRequest::builder_at(start_time)
             .chain_tip(self.chain.tip())
             .spks_from_indexer(&self.indexed_graph.index)
     }

--- a/wallet/src/wallet/persisted.rs
+++ b/wallet/src/wallet/persisted.rs
@@ -291,7 +291,7 @@ impl WalletPersister for bdk_chain::rusqlite::Connection {
 #[derive(Debug)]
 pub enum FileStoreError {
     /// Error when loading from the store.
-    Load(bdk_file_store::AggregateChangesetsError<ChangeSet>),
+    Load(bdk_file_store::StoreErrorWithDump<ChangeSet>),
     /// Error when writing to the store.
     Write(std::io::Error),
 }
@@ -316,15 +316,13 @@ impl WalletPersister for bdk_file_store::Store<ChangeSet> {
 
     fn initialize(persister: &mut Self) -> Result<ChangeSet, Self::Error> {
         persister
-            .aggregate_changesets()
+            .dump()
             .map(Option::unwrap_or_default)
             .map_err(FileStoreError::Load)
     }
 
     fn persist(persister: &mut Self, changeset: &ChangeSet) -> Result<(), Self::Error> {
-        persister
-            .append_changeset(changeset)
-            .map_err(FileStoreError::Write)
+        persister.append(changeset).map_err(FileStoreError::Write)
     }
 }
 


### PR DESCRIPTION
This PR updates `bdk_chain` dependency to the latest version 0.22.0

### Notes to the reviewers

This PR doesn't make use of `CanonicalizationParams` for any advanced use cases - instead we rely on the default params for all tx-graph queries.

fixes #202
fixes #224

### Changelog notice

- deps: bump `bdk_chain` to 0.22.0
- deps: bump `bdk_file_store` to 0.20.0

#### Added

- Added `start_sync_with_revealed_spks_at`
- Added `start_full_scan_at`
- Added `apply_evicted_txs`

#### Changed

- `start_sync_with_revealed_spks` is feature gated by "std", as it uses the system time to provide the time of the sync and also the tx last-seen.
- `apply_update` no longer requires std, as the timestamp is provided in the sync / full scan request
- `start_full_scan` is also gated behind "std"
- `start_sync_*` now includes the expected SPK history (via `list_expected_spk_txids`)

#### Removed

- Removed `apply_update_at`

#### BREAKING

- `bdk_core::TxUpdate` is non-exhaustive bitcoindevkit/bdk#1838
- For the optional file_store feature, the Load variant of the `FileStoreError` is changed to hold a new inner type bitcoindevkit/bdk#1684

#### Changes to persisted data

The `tx_graph::ChangeSet` gained a new default-able field `last_evicted` to persist the fact that a tx is no longer part of the canonical chain.


### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [x] I've added docs for the new feature
* [x] This pull request breaks the existng API
* [x] I'm linking the issue being fixed by this PR
