### PR TITLE
feat(test): add legacy descriptor tests

### DIFF
--- a/wallet/src/test_utils.rs
+++ b/wallet/src/test_utils.rs
@@ -134,6 +134,11 @@ pub fn get_funded_wallet_wpkh() -> (Wallet, Txid) {
     get_funded_wallet(desc, change_desc)
 }
 
+/// `pkh` single key descriptor
+pub fn get_test_pkh() -> &'static str {
+    "pkh(cNJFgo1driFnPcBdBX8BrJrpxchBWXwXCvNH5SoSkdcF6JXXwHMm)"
+}
+
 /// `wpkh` single key descriptor
 pub fn get_test_wpkh() -> &'static str {
     "wpkh(cVpPVruEDdmutPzisEsYvtST1usBR3ntr8pXSyt6D2YYqXRyPcFW)"

--- a/wallet/tests/wallet.rs
+++ b/wallet/tests/wallet.rs
@@ -39,8 +39,8 @@ fn parse_descriptor(s: &str) -> (Descriptor<DescriptorPublicKey>, KeyMap) {
 /// The satisfaction size of P2WPKH is 108 WU =
 /// 1 (elements in witness) + 1 (size)
 /// + 72 (signature + sighash) + 1 (size) + 33 (pubkey).
-const P2WPKH_FAKE_PK_SIZE: usize = 72;
-const P2WPKH_FAKE_SIG_SIZE: usize = 33;
+const P2WPKH_FAKE_PK_SIZE: usize = 33;
+const P2WPKH_FAKE_SIG_SIZE: usize = 72;
 
 /// The satisfaction size of P2PKH is 107 =
 /// 1 (OP_PUSH) + 72 (signature + sighash) + 1 (OP_PUSH) + 33 (pubkey).

--- a/wallet/tests/wallet.rs
+++ b/wallet/tests/wallet.rs
@@ -946,6 +946,20 @@ fn test_create_tx_custom_fee_rate() {
 }
 
 #[test]
+fn test_legacy_create_tx_custom_fee_rate() {
+    let (mut wallet, _) = get_funded_wallet_single(get_test_pkh());
+    let addr = wallet.next_unused_address(KeychainKind::External);
+    let mut builder = wallet.build_tx();
+    builder
+        .add_recipient(addr.script_pubkey(), Amount::from_sat(25_000))
+        .fee_rate(FeeRate::from_sat_per_vb_unchecked(5));
+    let psbt = builder.finish().unwrap();
+    let fee = check_fee!(wallet, psbt);
+
+    assert_fee_rate_legacy!(psbt, fee.unwrap_or(Amount::ZERO), FeeRate::from_sat_per_vb_unchecked(5), @add_signature);
+}
+
+#[test]
 fn test_create_tx_absolute_fee() {
     let (mut wallet, _) = get_funded_wallet_wpkh();
     let addr = wallet.next_unused_address(KeychainKind::External);

--- a/wallet/tests/wallet.rs
+++ b/wallet/tests/wallet.rs
@@ -2074,6 +2074,24 @@ fn test_bump_fee_zero_abs() {
 }
 
 #[test]
+#[should_panic(expected = "FeeTooLow")]
+fn test_legacy_bump_fee_zero_abs() {
+    let (mut wallet, _) = get_funded_wallet_single(get_test_pkh());
+    let addr = wallet.next_unused_address(KeychainKind::External);
+    let mut builder = wallet.build_tx();
+    builder.add_recipient(addr.script_pubkey(), Amount::from_sat(25_000));
+    let psbt = builder.finish().unwrap();
+
+    let tx = psbt.extract_tx().expect("failed to extract tx");
+    let txid = tx.compute_txid();
+    insert_tx(&mut wallet, tx);
+
+    let mut builder = wallet.build_fee_bump(txid).unwrap();
+    builder.fee_absolute(Amount::ZERO);
+    builder.finish().unwrap();
+}
+
+#[test]
 fn test_bump_fee_reduce_change() {
     let (mut wallet, _) = get_funded_wallet_wpkh();
     let addr = Address::from_str("2N1Ffz3WaNzbeLFBb51xyFMHYSEUXcbiSoX")

--- a/wallet/tests/wallet.rs
+++ b/wallet/tests/wallet.rs
@@ -437,6 +437,26 @@ fn test_get_funded_wallet_tx_fee_rate() {
 }
 
 #[test]
+fn test_legacy_get_funded_wallet_tx_fee_rate() {
+    let (wallet, txid) = get_funded_wallet_single(get_test_pkh());
+
+    let tx = wallet.get_tx(txid).expect("transaction").tx_node.tx;
+    let tx_fee_rate = wallet
+        .calculate_fee_rate(&tx)
+        .expect("transaction fee rate");
+
+    // The funded wallet contains a tx with a 76_000 sats input and two outputs, one spending 25_000
+    // to a foreign address and one returning 50_000 back to the wallet as change. The remaining 1000
+    // sats are the transaction fee.
+
+    // tx weight = 464 wu, as vbytes = (464)/4 = 116
+    // fee rate (sats per kwu) = fee / weight = 1000sat / 0.464kwu = 2155
+    // fee rate (sats per vbyte ceil) = fee / kwu = 1000 / 116 = 8.621
+    assert_eq!(tx_fee_rate.to_sat_per_kwu(), 2155);
+    assert_eq!(tx_fee_rate.to_sat_per_vb_ceil(), 9);
+}
+
+#[test]
 fn test_list_output() {
     let (wallet, txid) = get_funded_wallet_wpkh();
     let txos = wallet

--- a/wallet/tests/wallet.rs
+++ b/wallet/tests/wallet.rs
@@ -1196,6 +1196,22 @@ fn test_create_tx_custom_sighash() {
 }
 
 #[test]
+fn test_legacy_create_tx_custom_sighash() {
+    let (mut wallet, _) = get_funded_wallet_single(get_test_pkh());
+    let addr = wallet.next_unused_address(KeychainKind::External);
+    let mut builder = wallet.build_tx();
+    builder
+        .add_recipient(addr.script_pubkey(), Amount::from_sat(30_000))
+        .sighash(EcdsaSighashType::Single.into());
+    let psbt = builder.finish().unwrap();
+
+    assert_eq!(
+        psbt.inputs[0].sighash_type,
+        Some(EcdsaSighashType::Single.into())
+    );
+}
+
+#[test]
 fn test_create_tx_input_hd_keypaths() {
     use bitcoin::bip32::{DerivationPath, Fingerprint};
     use core::str::FromStr;

--- a/wallet/tests/wallet.rs
+++ b/wallet/tests/wallet.rs
@@ -1057,6 +1057,19 @@ fn test_create_tx_absolute_high_fee() {
 }
 
 #[test]
+#[should_panic(expected = "InsufficientFunds")]
+fn test_legacy_create_tx_absolute_high_fee() {
+    let (mut wallet, _) = get_funded_wallet_single(get_test_pkh());
+    let addr = wallet.next_unused_address(KeychainKind::External);
+    let mut builder = wallet.build_tx();
+    builder
+        .drain_to(addr.script_pubkey())
+        .drain_wallet()
+        .fee_absolute(Amount::from_sat(60_000));
+    let _ = builder.finish().unwrap();
+}
+
+#[test]
 fn test_create_tx_add_change() {
     use bdk_wallet::tx_builder::TxOrdering;
     let seed = [0; 32];

--- a/wallet/tests/wallet.rs
+++ b/wallet/tests/wallet.rs
@@ -446,8 +446,8 @@ fn test_legacy_get_funded_wallet_tx_fee_rate() {
         .expect("transaction fee rate");
 
     // The funded wallet contains a tx with a 76_000 sats input and two outputs, one spending 25_000
-    // to a foreign address and one returning 50_000 back to the wallet as change. The remaining 1000
-    // sats are the transaction fee.
+    // to a foreign address and one returning 50_000 back to the wallet as change. The remaining
+    // 1000 sats are the transaction fee.
 
     // tx weight = 464 wu, as vbytes = (464)/4 = 116
     // fee rate (sats per kwu) = fee / weight = 1000sat / 0.464kwu = 2155
@@ -832,6 +832,9 @@ fn test_create_tx_default_sequence() {
     assert_eq!(psbt.unsigned_tx.input[0].sequence, Sequence(0xFFFFFFFD));
 }
 
+/// Validate and return the transaction fee from a PSBT.
+/// Panics if extraction fails, fee calculation fails, or if calculated fee doesn't match PSBT's
+/// fee.
 macro_rules! check_fee {
     ($wallet:expr, $psbt: expr) => {{
         let tx = $psbt.clone().extract_tx().expect("failed to extract tx");

--- a/wallet/tests/wallet.rs
+++ b/wallet/tests/wallet.rs
@@ -1169,6 +1169,17 @@ fn test_create_tx_default_sighash() {
 }
 
 #[test]
+fn test_legacy_create_tx_default_sighash() {
+    let (mut wallet, _) = get_funded_wallet_single(get_test_pkh());
+    let addr = wallet.next_unused_address(KeychainKind::External);
+    let mut builder = wallet.build_tx();
+    builder.add_recipient(addr.script_pubkey(), Amount::from_sat(30_000));
+    let psbt = builder.finish().unwrap();
+
+    assert_eq!(psbt.inputs[0].sighash_type, None);
+}
+
+#[test]
 fn test_create_tx_custom_sighash() {
     let (mut wallet, _) = get_funded_wallet_wpkh();
     let addr = wallet.next_unused_address(KeychainKind::External);


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

This PR closes #134 and is a revival of https://github.com/bitcoindevkit/bdk/pull/1130, which adds the following tests:
- `test_legacy_bump_fee_no_change_add_input_and_change()`
- `test_legacy_bump_fee_add_input()`
- `test_legacy_bump_fee_drain_wallet()`
- `test_legacy_bump_fee_zero_abs()`
- `test_legacy_create_tx_custom_sighash()`
- `test_legacy_create_tx_default_sighash()`
- `test_legacy_create_tx_absolute_high_fee()`
- `test_legacy_create_tx_absolute_zero_fee()`
- `test_legacy_create_tx_absolute_fee()`
- `test_legacy_create_tx_custom_fee_rate()`
- `test_legacy_get_funded_wallet_tx_fee_rate()`

### Changelog:
- Add the above mentioned tests.
- Add a new `assert_fee_rate_legacy!` macro for legacy transactions.
- The `check_fee!` macro now returns `Amount` instead of `Result<Amount>`.
- All `wallet.sent_and_received` got destructured to `(sent, received)` instead of `sent_and_received.{0,1}`.
- ~Swap `TweakedKeypair::to_inner()` for `TweakedKeypair::to_keypair()`.~

### Checklists

#### All Submissions:

* [X] I've signed all my commits
* [X] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [X] I ran `cargo fmt` and `cargo clippy` before committing