### PR TITLE
Chore: migrate library version naming convention on master

### DIFF
--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bdk_wallet"
 homepage = "https://bitcoindevkit.org"
-version = "1.2.0"
+version = "2.0.0-alpha.0"
 repository = "https://github.com/bitcoindevkit/bdk_wallet"
 documentation = "https://docs.rs/bdk_wallet"
 description = "A modern, lightweight, descriptor-based wallet library"


### PR DESCRIPTION
This PR implements the discussion started on #19, as well as discussions over a few dev calls.

The preferred approach is the one used by [rust-bitcoin](https://github.com/rust-bitcoin/rust-bitcoin/blob/master/bitcoin/Cargo.toml).

### Notes to the reviewers

The core workflow for this is to keep the version on the master branch always an `alpha.0`, and simply update it to the next planned release once a branch has been created for a release.

So for example, the master branch could be on `1.3.0-alpha.0` until the branch for 1.3.0 is cut, at which moment the master moves on to `1.4.0-alpha.0`. Someone pulling the master branch is always building one of those `-alpha.0` versions.

### Changelog notice

None.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
