### PR TITLE
chore(example_wallet_rpc): bump `ctrlc` to 3.4.6

### DIFF
--- a/examples/example_wallet_rpc/Cargo.toml
+++ b/examples/example_wallet_rpc/Cargo.toml
@@ -11,4 +11,4 @@ bdk_bitcoind_rpc = { version = "0.18" }
 
 anyhow = "1"
 clap = { version = "4.5.17", features = ["derive", "env"] }
-ctrlc = "2.0.1"
+ctrlc = "3.4.6"

--- a/examples/example_wallet_rpc/src/main.rs
+++ b/examples/example_wallet_rpc/src/main.rs
@@ -123,7 +123,7 @@ fn main() -> anyhow::Result<()> {
     let (sender, receiver) = sync_channel::<Emission>(21);
 
     let signal_sender = sender.clone();
-    ctrlc::set_handler(move || {
+    let _ = ctrlc::set_handler(move || {
         signal_sender
             .send(Emission::SigTerm)
             .expect("failed to send sigterm")


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

This PR bumps `ctrlc` to 3.4.6 (latest) on `example_wallet_rpc` and also fixes a clippy warning.

### Checklists

#### All Submissions:

* [X] I've signed all my commits
* [X] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [X] I ran `cargo fmt` and `cargo clippy` before committing

