### PR TITLE
chore: remove `lazy_static` from Cargo.toml

### DIFF
--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -38,7 +38,6 @@ file_store = ["bdk_file_store"]
 test-utils = ["std"]
 
 [dev-dependencies]
-lazy_static = "1.4"
 assert_matches = "1.5.0"
 tempfile = "3"
 bdk_chain = { version = "0.21.1", features = ["rusqlite"] }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

This PR removes `lazy_static` from `Cargo.toml`. Apparently it wasn't being imported anywhere.

#### All Submissions:

* [X] I've signed all my commits
* [X] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [X] I ran `cargo fmt` and `cargo clippy` before committing
