### PR TITLE
chore(example_wallet_esplora_async): bump tokio to 1.38.1

### DIFF
--- a/examples/example_wallet_esplora_async/Cargo.toml
+++ b/examples/example_wallet_esplora_async/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2021"
 [dependencies]
 bdk_wallet = { path = "../../wallet", features = ["rusqlite"] }
 bdk_esplora = { version = "0.20", features = ["async-https", "tokio"] }
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
+tokio = { version = "1.38.1", features = ["rt", "rt-multi-thread", "macros"] }
 anyhow = "1"


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

This PR bumps `tokio` to 1.38.1 on `example_wallet_esplora_async` due to a security vulnerability.

### Checklists

#### All Submissions:

* [X] I've signed all my commits
* [X] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [X] I ran `cargo fmt` and `cargo clippy` before committing

