### PR TITLE
Fix Inconsistent checking of RBF rules.

### DIFF
--- a/wallet/tests/wallet.rs
+++ b/wallet/tests/wallet.rs
@@ -1976,7 +1976,7 @@ fn test_bump_fee_reduce_change() {
     assert_fee_rate!(psbt, fee.unwrap_or(Amount::ZERO), feerate, @add_signature);
 
     let mut builder = wallet.build_fee_bump(txid).unwrap();
-    builder.fee_absolute(Amount::from_sat(200));
+    builder.fee_absolute(Amount::from_sat(283));
     let psbt = builder.finish().unwrap();
     let sent_received =
         wallet.sent_and_received(&psbt.clone().extract_tx().expect("failed to extract tx"));
@@ -2013,7 +2013,7 @@ fn test_bump_fee_reduce_change() {
         sent_received.1
     );
 
-    assert_eq!(fee.unwrap_or(Amount::ZERO), Amount::from_sat(200));
+    assert_eq!(fee.unwrap_or(Amount::ZERO), Amount::from_sat(283));
 }
 
 #[test]
@@ -2566,7 +2566,7 @@ fn test_bump_fee_absolute_force_add_input() {
     builder
         .add_utxo(incoming_op)
         .unwrap()
-        .fee_absolute(Amount::from_sat(250));
+        .fee_absolute(Amount::from_sat(351));
     let psbt = builder.finish().unwrap();
     let sent_received =
         wallet.sent_and_received(&psbt.clone().extract_tx().expect("failed to extract tx"));
@@ -2601,7 +2601,7 @@ fn test_bump_fee_absolute_force_add_input() {
         sent_received.1
     );
 
-    assert_eq!(fee.unwrap_or(Amount::ZERO), Amount::from_sat(250));
+    assert_eq!(fee.unwrap_or(Amount::ZERO), Amount::from_sat(351));
 }
 
 #[test]

--- a/wallet/tests/wallet.rs
+++ b/wallet/tests/wallet.rs
@@ -1880,8 +1880,7 @@ fn test_bump_fee_low_fee_rate() {
         "expected FeeRateTooLow error"
     );
 
-    let required = feerate.to_sat_per_kwu() + 250; // +1 sat/vb
-    let sat_vb = required as f64 / 250.0;
+    let sat_vb = (feerate.to_sat_per_kwu() as f64 + 1.0) / 250.0;
     let expect = format!("Fee rate too low: required {} sat/vb", sat_vb);
     assert_eq!(res.unwrap_err().to_string(), expect);
 }


### PR DESCRIPTION
### Description
This PR adds checks based on RBF policy ([BIP125](https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki) and [Bitcoin Core's Replacement Policy](https://github.com/bitcoin/bitcoin/blob/master/doc/policy/mempool-replacements.md)). 
More specifically it checks transactions:
1. Have a higher absolute fee than the original transaction
2. Pay enough for their bandwidth.
3. Have a higher feerate than conflicting transactions.

Fixes: #192 

### Notes to the reviewers

The addition of `satisfaction_weight` to `CoinSelectionResult` would be a breaking change, it isn't entirely necessary, as I could duplicate that functionality in wallet itself by making an `estimated_weight(psbt: Psbt)` function, but this was one of the cleaner ways to go about this, and I'm not entirely sure how acceptable breaking changes are in the project.

### Changelog notice
#### Changed
- RBF Policies (BIP125 and Bitcoin Core's) are now checked correctly when creating a transaction with `bumping_fee`.

#### BREAKING

- `CoinSelectionResult` now has a `satisfaction_weight` field, giving the max weight required to satisfy the selected inputs

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature

#### Bugfixes:

* [x] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR

