### PR TITLE
Explorations for support of N keychains

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,11 @@
 resolver = "2"
 members = [
     "wallet",
-    "examples/example_wallet_electrum",
-    "examples/example_wallet_esplora_blocking",
-    "examples/example_wallet_esplora_async",
-    "examples/example_wallet_rpc",
+    "examples/example_wallet_n_keychains"
+#    "examples/example_wallet_electrum",
+#    "examples/example_wallet_esplora_blocking",
+#    "examples/example_wallet_esplora_async",
+#    "examples/example_wallet_rpc",
 ]
 
 [workspace.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "wallet",
+    "examples/example_n_keychains",
 #    "examples/example_wallet_electrum",
 #    "examples/example_wallet_esplora_blocking",
 #    "examples/example_wallet_esplora_async",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,6 @@
 resolver = "2"
 members = [
     "wallet",
-    "examples/example_wallet_n_keychains"
 #    "examples/example_wallet_electrum",
 #    "examples/example_wallet_esplora_blocking",
 #    "examples/example_wallet_esplora_async",

--- a/examples/example_n_keychains/Cargo.toml
+++ b/examples/example_n_keychains/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "example_wallet_esplora_blocking"
+version = "0.2.0"
+edition = "2021"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+bdk_wallet = { path = "../../wallet" }
+bdk_esplora = { version = "0.20", features = ["blocking"] }
+anyhow = "1"

--- a/examples/example_n_keychains/src/main.rs
+++ b/examples/example_n_keychains/src/main.rs
@@ -1,16 +1,21 @@
-use bdk_chain::DescriptorId;
+use bdk_esplora::{esplora_client, EsploraExt};
+use bdk_wallet::chain::DescriptorId;
 use bdk_wallet::{KeyRing, Wallet};
 use bdk_wallet::bitcoin::Network;
 use bdk_wallet::KeychainKind;
 
+const ESPLORA_URL: &str = "http://signet.bitcoindevkit.net";
+const STOP_GAP: usize = 5;
+const PARALLEL_REQUESTS: usize = 5;
+
 const EXTERNAL_DESC: &str = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/1'/0'/0/*)";
 const OTHER_DESC_21: &str = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/1'/0'/21/*)";
-const OTHER_DESC_31: &str = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/1'/0'/33/*)";
-const OTHER_DESC_41: &str = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/1'/0'/44/*)";
+const OTHER_DESC_31: &str = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/1'/0'/31/*)";
+const OTHER_DESC_41: &str = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/1'/0'/41/*)";
 
 fn main() -> Result<(), anyhow::Error> {
     // Create a keyring with a single, default descriptor (aka the KeychainKind::External from the 1.2.0 API)
-    let mut keyring = KeyRing::new(EXTERNAL_DESC, Network::Testnet4);
+    let mut keyring = KeyRing::new(EXTERNAL_DESC, Network::Signet);
 
     // Add 3 new custom descriptors
     keyring.add_other_descriptor(OTHER_DESC_21);
@@ -21,7 +26,7 @@ fn main() -> Result<(), anyhow::Error> {
     println!("{:?}", keychain_ids);
 
     // Create the wallet and peek addresses on each of the descriptors
-    let wallet: Wallet = Wallet::new(keyring).create_wallet_no_persist()?;
+    let mut wallet: Wallet = Wallet::new(keyring, Network::Signet).create_wallet_no_persist()?;
     let address_1 = wallet.peek_address(KeychainKind::Default, 0).unwrap();
     let address_2 = wallet.peek_address(KeychainKind::Other(keychain_ids[1]), 0).unwrap();
     let address_3 = wallet.peek_address(KeychainKind::Other(keychain_ids[2]), 0).unwrap();
@@ -33,10 +38,15 @@ fn main() -> Result<(), anyhow::Error> {
     println!("Address 4 {:?} at index {:?} on keychain {:?}", address_4.address, address_4.index, address_4.keychain);
 
     let balance = wallet.balance();
-    println!("Balance {:?}", balance);
+    println!("Balance before sync {:?}", balance);
 
+    let client = esplora_client::Builder::new(ESPLORA_URL).build_blocking();
     let full_scan_request = wallet.start_full_scan().build();
+    let update = client.full_scan(full_scan_request, STOP_GAP, PARALLEL_REQUESTS)?;
+    wallet.apply_update(update)?;
 
+    let new_balance = wallet.balance();
+    println!("Wallet balance after syncing: {}", new_balance.total());
 
     Ok(())
 }

--- a/examples/example_n_keychains/src/main.rs
+++ b/examples/example_n_keychains/src/main.rs
@@ -1,8 +1,9 @@
 use bdk_esplora::{esplora_client, EsploraExt};
 use bdk_wallet::chain::DescriptorId;
-use bdk_wallet::{KeyRing, Wallet};
+use bdk_wallet::Wallet;
 use bdk_wallet::bitcoin::Network;
 use bdk_wallet::KeychainKind;
+use bdk_wallet::keyring::KeyRing;
 
 const ESPLORA_URL: &str = "http://signet.bitcoindevkit.net";
 const STOP_GAP: usize = 5;
@@ -26,7 +27,7 @@ fn main() -> Result<(), anyhow::Error> {
     println!("{:?}", keychain_ids);
 
     // Create the wallet and peek addresses on each of the descriptors
-    let mut wallet: Wallet = Wallet::new(keyring, Network::Signet).create_wallet_no_persist()?;
+    let mut wallet: Wallet = Wallet::new(keyring).create_wallet_no_persist()?;
     let address_1 = wallet.peek_address(KeychainKind::Default, 0).unwrap();
     let address_2 = wallet.peek_address(KeychainKind::Other(keychain_ids[1]), 0).unwrap();
     let address_3 = wallet.peek_address(KeychainKind::Other(keychain_ids[2]), 0).unwrap();

--- a/examples/example_n_keychains/src/main.rs
+++ b/examples/example_n_keychains/src/main.rs
@@ -27,7 +27,7 @@ fn main() -> Result<(), anyhow::Error> {
     println!("{:?}", keychain_ids);
 
     // Create the wallet and peek addresses on each of the descriptors
-    let mut wallet: Wallet = Wallet::new(keyring).create_wallet_no_persist()?;
+    let mut wallet: Wallet = Wallet::create(keyring).create_wallet_no_persist()?;
     let address_1 = wallet.peek_address(KeychainKind::Default, 0).unwrap();
     let address_2 = wallet.peek_address(KeychainKind::Other(keychain_ids[1]), 0).unwrap();
     let address_3 = wallet.peek_address(KeychainKind::Other(keychain_ids[2]), 0).unwrap();

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bdk_wallet"
 homepage = "https://bitcoindevkit.org"
-version = "2.0.0-alpha.0"
+version = "1.3.0-alpha.0"
 repository = "https://github.com/bitcoindevkit/bdk_wallet"
 documentation = "https://docs.rs/bdk_wallet"
 description = "A modern, lightweight, descriptor-based wallet library"

--- a/wallet/examples/n_keychains.rs
+++ b/wallet/examples/n_keychains.rs
@@ -1,7 +1,8 @@
 use bdk_chain::DescriptorId;
-use bdk_wallet::{KeyRing, Wallet};
+use bdk_wallet::Wallet;
 use bdk_wallet::bitcoin::Network;
 use bdk_wallet::KeychainKind;
+use bdk_wallet::keyring::KeyRing;
 
 const EXTERNAL_DESC: &str = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/1'/0'/0/*)";
 const OTHER_DESC_21: &str = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/1'/0'/21/*)";
@@ -10,7 +11,7 @@ const OTHER_DESC_41: &str = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7
 
 fn main() -> Result<(), anyhow::Error> {
     // Create a keyring with a single, default descriptor (aka the KeychainKind::External from the 1.2.0 API)
-    let mut keyring = KeyRing::new(EXTERNAL_DESC, Network::Testnet4);
+    let mut keyring = KeyRing::new(EXTERNAL_DESC, Network::Testnet);
 
     // Add 3 new custom descriptors
     keyring.add_other_descriptor(OTHER_DESC_21);
@@ -36,7 +37,6 @@ fn main() -> Result<(), anyhow::Error> {
     println!("Balance {:?}", balance);
 
     let full_scan_request = wallet.start_full_scan().build();
-
 
     Ok(())
 }

--- a/wallet/examples/n_keychains.rs
+++ b/wallet/examples/n_keychains.rs
@@ -1,0 +1,23 @@
+use bdk_wallet::{KeyRing, Wallet};
+use bdk_wallet::bitcoin::Network;
+use bdk_wallet::KeychainKind;
+
+const EXTERNAL_DESC: &str = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/1'/0'/0/*)";
+const OTHER_DESC_21: &str = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/1'/0'/21/*)";
+const OTHER_DESC_33: &str = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/1'/0'/33/*)";
+const OTHER_DESC_44: &str = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/1'/0'/44/*)";
+
+fn main() -> Result<(), anyhow::Error> {
+    let mut keyring = KeyRing::new(EXTERNAL_DESC, Network::Testnet4);
+    // keyring.add_other_descriptor(OTHER_DESC_21);
+    // let keychains = keyring.list_keychains();
+    // println!("{:?}", keychains);
+
+    let wallet: Wallet = Wallet::new(keyring).create_wallet_no_persist()?;
+    let address_1 = wallet.peek_address(KeychainKind::Default, 0).unwrap();
+    // let address_2 = wallet.peek_address((KeychainKind::Other(), 0).unwrap();
+
+    println!("Address {:?} at index {:?} on keychain {:?}", address_1.address, address_1.index, address_1.keychain);
+
+    Ok(())
+}

--- a/wallet/examples/n_keychains.rs
+++ b/wallet/examples/n_keychains.rs
@@ -1,23 +1,36 @@
+use bdk_chain::DescriptorId;
 use bdk_wallet::{KeyRing, Wallet};
 use bdk_wallet::bitcoin::Network;
 use bdk_wallet::KeychainKind;
 
 const EXTERNAL_DESC: &str = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/1'/0'/0/*)";
 const OTHER_DESC_21: &str = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/1'/0'/21/*)";
-const OTHER_DESC_33: &str = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/1'/0'/33/*)";
-const OTHER_DESC_44: &str = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/1'/0'/44/*)";
+const OTHER_DESC_31: &str = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/1'/0'/33/*)";
+const OTHER_DESC_41: &str = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/1'/0'/44/*)";
 
 fn main() -> Result<(), anyhow::Error> {
+    // Create a keyring with a single, default descriptor (aka the KeychainKind::External from the 1.2.0 API)
     let mut keyring = KeyRing::new(EXTERNAL_DESC, Network::Testnet4);
-    // keyring.add_other_descriptor(OTHER_DESC_21);
-    // let keychains = keyring.list_keychains();
-    // println!("{:?}", keychains);
 
+    // Add 3 new custom descriptors
+    keyring.add_other_descriptor(OTHER_DESC_21);
+    keyring.add_other_descriptor(OTHER_DESC_31);
+    keyring.add_other_descriptor(OTHER_DESC_41);
+
+    let keychain_ids: Vec<DescriptorId> = keyring.list_keychain_ids();
+    println!("{:?}", keychain_ids);
+
+    // Create the wallet and peek addresses on each of the descriptors
     let wallet: Wallet = Wallet::new(keyring).create_wallet_no_persist()?;
     let address_1 = wallet.peek_address(KeychainKind::Default, 0).unwrap();
-    // let address_2 = wallet.peek_address((KeychainKind::Other(), 0).unwrap();
+    let address_2 = wallet.peek_address(KeychainKind::Other(keychain_ids[1]), 0).unwrap();
+    let address_3 = wallet.peek_address(KeychainKind::Other(keychain_ids[2]), 0).unwrap();
+    let address_4 = wallet.peek_address(KeychainKind::Other(keychain_ids[3]), 0).unwrap();
 
-    println!("Address {:?} at index {:?} on keychain {:?}", address_1.address, address_1.index, address_1.keychain);
+    println!("Address 1 {:?} at index {:?} on keychain {:?}", address_1.address, address_1.index, address_1.keychain);
+    println!("Address 2 {:?} at index {:?} on keychain {:?}", address_2.address, address_2.index, address_2.keychain);
+    println!("Address 3 {:?} at index {:?} on keychain {:?}", address_3.address, address_3.index, address_3.keychain);
+    println!("Address 4 {:?} at index {:?} on keychain {:?}", address_4.address, address_4.index, address_4.keychain);
 
     Ok(())
 }

--- a/wallet/examples/n_keychains.rs
+++ b/wallet/examples/n_keychains.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), anyhow::Error> {
     println!("{:?}", keychain_ids);
 
     // Create the wallet and peek addresses on each of the descriptors
-    let wallet: Wallet = Wallet::new(keyring).create_wallet_no_persist()?;
+    let mut wallet: Wallet = Wallet::create(keyring).create_wallet_no_persist()?;
     let address_1 = wallet.peek_address(KeychainKind::Default, 0).unwrap();
     let address_2 = wallet.peek_address(KeychainKind::Other(keychain_ids[1]), 0).unwrap();
     let address_3 = wallet.peek_address(KeychainKind::Other(keychain_ids[2]), 0).unwrap();

--- a/wallet/examples/n_keychains.rs
+++ b/wallet/examples/n_keychains.rs
@@ -36,7 +36,13 @@ fn main() -> Result<(), anyhow::Error> {
     let balance = wallet.balance();
     println!("Balance {:?}", balance);
 
-    let full_scan_request = wallet.start_full_scan().build();
+    let revealed_address_1 = wallet.reveal_next_address(KeychainKind::Default);
+    let revealed_address_2 = wallet.reveal_next_address(KeychainKind::Default);
+    println!("Revealed next address {:?}", revealed_address_1);
+    println!("Revealed next address {:?}", revealed_address_2);
+
+    // Will error out because there is no change keychain defined
+    // wallet.reveal_next_address(KeychainKind::Change).unwrap();
 
     Ok(())
 }

--- a/wallet/src/descriptor/template.rs
+++ b/wallet/src/descriptor/template.rs
@@ -23,10 +23,16 @@ use super::{ExtendedDescriptor, IntoWalletDescriptor, KeyMap};
 use crate::descriptor::DescriptorError;
 use crate::keys::{DerivableKey, IntoDescriptorKey, ValidNetworks};
 use crate::wallet::utils::SecpCtx;
-use crate::{descriptor, KeychainKind};
+use crate::descriptor;
 
 /// Type alias for the return type of [`DescriptorTemplate`], [`descriptor!`](crate::descriptor!) and others
 pub type DescriptorTemplateOut = (ExtendedDescriptor, KeyMap, ValidNetworks);
+
+#[derive(Clone, Debug)]
+pub enum TemplateKeychainKind {
+    External,
+    Internal,
+}
 
 /// Trait for descriptor templates that can be built into a full descriptor
 ///
@@ -232,7 +238,7 @@ impl<K: IntoDescriptorKey<Tap>> DescriptorTemplate for P2TR<K> {
 /// # Ok::<_, Box<dyn std::error::Error>>(())
 /// ```
 #[derive(Debug, Clone)]
-pub struct Bip44<K: DerivableKey<Legacy>>(pub K, pub KeychainKind);
+pub struct Bip44<K: DerivableKey<Legacy>>(pub K, pub TemplateKeychainKind);
 
 impl<K: DerivableKey<Legacy>> DescriptorTemplate for Bip44<K> {
     fn build(self, network: Network) -> Result<DescriptorTemplateOut, DescriptorError> {
@@ -271,7 +277,7 @@ impl<K: DerivableKey<Legacy>> DescriptorTemplate for Bip44<K> {
 /// # Ok::<_, Box<dyn std::error::Error>>(())
 /// ```
 #[derive(Debug, Clone)]
-pub struct Bip44Public<K: DerivableKey<Legacy>>(pub K, pub bip32::Fingerprint, pub KeychainKind);
+pub struct Bip44Public<K: DerivableKey<Legacy>>(pub K, pub bip32::Fingerprint, pub TemplateKeychainKind);
 
 impl<K: DerivableKey<Legacy>> DescriptorTemplate for Bip44Public<K> {
     fn build(self, network: Network) -> Result<DescriptorTemplateOut, DescriptorError> {
@@ -309,7 +315,7 @@ impl<K: DerivableKey<Legacy>> DescriptorTemplate for Bip44Public<K> {
 /// # Ok::<_, Box<dyn std::error::Error>>(())
 /// ```
 #[derive(Debug, Clone)]
-pub struct Bip49<K: DerivableKey<Segwitv0>>(pub K, pub KeychainKind);
+pub struct Bip49<K: DerivableKey<Segwitv0>>(pub K, pub TemplateKeychainKind);
 
 impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for Bip49<K> {
     fn build(self, network: Network) -> Result<DescriptorTemplateOut, DescriptorError> {
@@ -348,7 +354,7 @@ impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for Bip49<K> {
 /// # Ok::<_, Box<dyn std::error::Error>>(())
 /// ```
 #[derive(Debug, Clone)]
-pub struct Bip49Public<K: DerivableKey<Segwitv0>>(pub K, pub bip32::Fingerprint, pub KeychainKind);
+pub struct Bip49Public<K: DerivableKey<Segwitv0>>(pub K, pub bip32::Fingerprint, pub TemplateKeychainKind);
 
 impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for Bip49Public<K> {
     fn build(self, network: Network) -> Result<DescriptorTemplateOut, DescriptorError> {
@@ -386,7 +392,7 @@ impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for Bip49Public<K> {
 /// # Ok::<_, Box<dyn std::error::Error>>(())
 /// ```
 #[derive(Debug, Clone)]
-pub struct Bip84<K: DerivableKey<Segwitv0>>(pub K, pub KeychainKind);
+pub struct Bip84<K: DerivableKey<Segwitv0>>(pub K, pub TemplateKeychainKind);
 
 impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for Bip84<K> {
     fn build(self, network: Network) -> Result<DescriptorTemplateOut, DescriptorError> {
@@ -425,7 +431,7 @@ impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for Bip84<K> {
 /// # Ok::<_, Box<dyn std::error::Error>>(())
 /// ```
 #[derive(Debug, Clone)]
-pub struct Bip84Public<K: DerivableKey<Segwitv0>>(pub K, pub bip32::Fingerprint, pub KeychainKind);
+pub struct Bip84Public<K: DerivableKey<Segwitv0>>(pub K, pub bip32::Fingerprint, pub TemplateKeychainKind);
 
 impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for Bip84Public<K> {
     fn build(self, network: Network) -> Result<DescriptorTemplateOut, DescriptorError> {
@@ -463,7 +469,7 @@ impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for Bip84Public<K> {
 /// # Ok::<_, Box<dyn std::error::Error>>(())
 /// ```
 #[derive(Debug, Clone)]
-pub struct Bip86<K: DerivableKey<Tap>>(pub K, pub KeychainKind);
+pub struct Bip86<K: DerivableKey<Tap>>(pub K, pub TemplateKeychainKind);
 
 impl<K: DerivableKey<Tap>> DescriptorTemplate for Bip86<K> {
     fn build(self, network: Network) -> Result<DescriptorTemplateOut, DescriptorError> {
@@ -502,7 +508,7 @@ impl<K: DerivableKey<Tap>> DescriptorTemplate for Bip86<K> {
 /// # Ok::<_, Box<dyn std::error::Error>>(())
 /// ```
 #[derive(Debug, Clone)]
-pub struct Bip86Public<K: DerivableKey<Tap>>(pub K, pub bip32::Fingerprint, pub KeychainKind);
+pub struct Bip86Public<K: DerivableKey<Tap>>(pub K, pub bip32::Fingerprint, pub TemplateKeychainKind);
 
 impl<K: DerivableKey<Tap>> DescriptorTemplate for Bip86Public<K> {
     fn build(self, network: Network) -> Result<DescriptorTemplateOut, DescriptorError> {
@@ -521,7 +527,7 @@ macro_rules! expand_make_bipxx {
             pub(super) fn make_bipxx_private<K: DerivableKey<$ctx>>(
                 bip: u32,
                 key: K,
-                keychain: KeychainKind,
+                keychain: TemplateKeychainKind,
                 network: Network,
             ) -> Result<impl IntoDescriptorKey<$ctx>, DescriptorError> {
                 let mut derivation_path = alloc::vec::Vec::with_capacity(4);
@@ -538,10 +544,10 @@ macro_rules! expand_make_bipxx {
                 derivation_path.push(bip32::ChildNumber::from_hardened_idx(0)?);
 
                 match keychain {
-                    KeychainKind::External => {
+                    TemplateKeychainKind::External => {
                         derivation_path.push(bip32::ChildNumber::from_normal_idx(0)?)
                     }
-                    KeychainKind::Internal => {
+                    TemplateKeychainKind::Internal => {
                         derivation_path.push(bip32::ChildNumber::from_normal_idx(1)?)
                     }
                 };
@@ -554,12 +560,12 @@ macro_rules! expand_make_bipxx {
                 bip: u32,
                 key: K,
                 parent_fingerprint: bip32::Fingerprint,
-                keychain: KeychainKind,
+                keychain: TemplateKeychainKind,
                 network: Network,
             ) -> Result<impl IntoDescriptorKey<$ctx>, DescriptorError> {
                 let derivation_path: bip32::DerivationPath = match keychain {
-                    KeychainKind::External => vec![bip32::ChildNumber::from_normal_idx(0)?].into(),
-                    KeychainKind::Internal => vec![bip32::ChildNumber::from_normal_idx(1)?].into(),
+                    TemplateKeychainKind::External => vec![bip32::ChildNumber::from_normal_idx(0)?].into(),
+                    TemplateKeychainKind::Internal => vec![bip32::ChildNumber::from_normal_idx(1)?].into(),
                 };
 
                 let source_path = bip32::DerivationPath::from(vec![

--- a/wallet/src/test_utils.rs
+++ b/wallet/src/test_utils.rs
@@ -17,122 +17,122 @@ use crate::{KeychainKind, Update, Wallet};
 /// The funded wallet contains a tx with a 76_000 sats input and two outputs, one spending 25_000
 /// to a foreign address and one returning 50_000 back to the wallet. The remaining 1000
 /// sats are the transaction fee.
-pub fn get_funded_wallet(descriptor: &str, change_descriptor: &str) -> (Wallet, Txid) {
-    new_funded_wallet(descriptor, Some(change_descriptor))
-}
+// pub fn get_funded_wallet(descriptor: &str, change_descriptor: &str) -> (Wallet, Txid) {
+//     new_funded_wallet(descriptor, Some(change_descriptor))
+// }
 
-fn new_funded_wallet(descriptor: &str, change_descriptor: Option<&str>) -> (Wallet, Txid) {
-    let params = if let Some(change_desc) = change_descriptor {
-        Wallet::create(descriptor.to_string(), change_desc.to_string())
-    } else {
-        Wallet::create_single(descriptor.to_string())
-    };
-
-    let mut wallet = params
-        .network(Network::Regtest)
-        .create_wallet_no_persist()
-        .expect("descriptors must be valid");
-
-    let receive_address = wallet.peek_address(KeychainKind::External, 0).address;
-    let sendto_address = Address::from_str("bcrt1q3qtze4ys45tgdvguj66zrk4fu6hq3a3v9pfly5")
-        .expect("address")
-        .require_network(Network::Regtest)
-        .unwrap();
-
-    let tx0 = Transaction {
-        output: vec![TxOut {
-            value: Amount::from_sat(76_000),
-            script_pubkey: receive_address.script_pubkey(),
-        }],
-        ..new_tx(0)
-    };
-
-    let tx1 = Transaction {
-        input: vec![TxIn {
-            previous_output: OutPoint {
-                txid: tx0.compute_txid(),
-                vout: 0,
-            },
-            ..Default::default()
-        }],
-        output: vec![
-            TxOut {
-                value: Amount::from_sat(50_000),
-                script_pubkey: receive_address.script_pubkey(),
-            },
-            TxOut {
-                value: Amount::from_sat(25_000),
-                script_pubkey: sendto_address.script_pubkey(),
-            },
-        ],
-        ..new_tx(0)
-    };
-
-    insert_checkpoint(
-        &mut wallet,
-        BlockId {
-            height: 42,
-            hash: BlockHash::all_zeros(),
-        },
-    );
-    insert_checkpoint(
-        &mut wallet,
-        BlockId {
-            height: 1_000,
-            hash: BlockHash::all_zeros(),
-        },
-    );
-    insert_checkpoint(
-        &mut wallet,
-        BlockId {
-            height: 2_000,
-            hash: BlockHash::all_zeros(),
-        },
-    );
-
-    insert_tx(&mut wallet, tx0.clone());
-    insert_anchor(
-        &mut wallet,
-        tx0.compute_txid(),
-        ConfirmationBlockTime {
-            block_id: BlockId {
-                height: 1_000,
-                hash: BlockHash::all_zeros(),
-            },
-            confirmation_time: 100,
-        },
-    );
-
-    insert_tx(&mut wallet, tx1.clone());
-    insert_anchor(
-        &mut wallet,
-        tx1.compute_txid(),
-        ConfirmationBlockTime {
-            block_id: BlockId {
-                height: 2_000,
-                hash: BlockHash::all_zeros(),
-            },
-            confirmation_time: 200,
-        },
-    );
-
-    (wallet, tx1.compute_txid())
-}
+// fn new_funded_wallet(descriptor: &str, change_descriptor: Option<&str>) -> (Wallet, Txid) {
+//     let params = if let Some(change_desc) = change_descriptor {
+//         Wallet::create(descriptor.to_string(), change_desc.to_string())
+//     } else {
+//         Wallet::create_single(descriptor.to_string())
+//     };
+//
+//     let mut wallet = params
+//         .network(Network::Regtest)
+//         .create_wallet_no_persist()
+//         .expect("descriptors must be valid");
+//
+//     let receive_address = wallet.peek_address(KeychainKind::External, 0).address;
+//     let sendto_address = Address::from_str("bcrt1q3qtze4ys45tgdvguj66zrk4fu6hq3a3v9pfly5")
+//         .expect("address")
+//         .require_network(Network::Regtest)
+//         .unwrap();
+//
+//     let tx0 = Transaction {
+//         output: vec![TxOut {
+//             value: Amount::from_sat(76_000),
+//             script_pubkey: receive_address.script_pubkey(),
+//         }],
+//         ..new_tx(0)
+//     };
+//
+//     let tx1 = Transaction {
+//         input: vec![TxIn {
+//             previous_output: OutPoint {
+//                 txid: tx0.compute_txid(),
+//                 vout: 0,
+//             },
+//             ..Default::default()
+//         }],
+//         output: vec![
+//             TxOut {
+//                 value: Amount::from_sat(50_000),
+//                 script_pubkey: receive_address.script_pubkey(),
+//             },
+//             TxOut {
+//                 value: Amount::from_sat(25_000),
+//                 script_pubkey: sendto_address.script_pubkey(),
+//             },
+//         ],
+//         ..new_tx(0)
+//     };
+//
+//     insert_checkpoint(
+//         &mut wallet,
+//         BlockId {
+//             height: 42,
+//             hash: BlockHash::all_zeros(),
+//         },
+//     );
+//     insert_checkpoint(
+//         &mut wallet,
+//         BlockId {
+//             height: 1_000,
+//             hash: BlockHash::all_zeros(),
+//         },
+//     );
+//     insert_checkpoint(
+//         &mut wallet,
+//         BlockId {
+//             height: 2_000,
+//             hash: BlockHash::all_zeros(),
+//         },
+//     );
+//
+//     insert_tx(&mut wallet, tx0.clone());
+//     insert_anchor(
+//         &mut wallet,
+//         tx0.compute_txid(),
+//         ConfirmationBlockTime {
+//             block_id: BlockId {
+//                 height: 1_000,
+//                 hash: BlockHash::all_zeros(),
+//             },
+//             confirmation_time: 100,
+//         },
+//     );
+//
+//     insert_tx(&mut wallet, tx1.clone());
+//     insert_anchor(
+//         &mut wallet,
+//         tx1.compute_txid(),
+//         ConfirmationBlockTime {
+//             block_id: BlockId {
+//                 height: 2_000,
+//                 hash: BlockHash::all_zeros(),
+//             },
+//             confirmation_time: 200,
+//         },
+//     );
+//
+//     (wallet, tx1.compute_txid())
+// }
 
 /// Return a fake wallet that appears to be funded for testing.
 ///
 /// The funded wallet contains a tx with a 76_000 sats input and two outputs, one spending 25_000
 /// to a foreign address and one returning 50_000 back to the wallet. The remaining 1000
 /// sats are the transaction fee.
-pub fn get_funded_wallet_single(descriptor: &str) -> (Wallet, Txid) {
-    new_funded_wallet(descriptor, None)
-}
+// pub fn get_funded_wallet_single(descriptor: &str) -> (Wallet, Txid) {
+//     new_funded_wallet(descriptor, None)
+// }
 
 /// Get funded segwit wallet
-pub fn get_funded_wallet_wpkh() -> (Wallet, Txid) {
-    let (desc, change_desc) = get_test_wpkh_and_change_desc();
-    get_funded_wallet(desc, change_desc)
-}
+// pub fn get_funded_wallet_wpkh() -> (Wallet, Txid) {
+//     let (desc, change_desc) = get_test_wpkh_and_change_desc();
+//     get_funded_wallet(desc, change_desc)
+// }
 
 /// `wpkh` single key descriptor
 pub fn get_test_wpkh() -> &'static str {
@@ -246,29 +246,29 @@ impl From<ConfirmationBlockTime> for ReceiveTo {
 }
 
 /// Receive a tx output with the given value in the latest block
-pub fn receive_output_in_latest_block(wallet: &mut Wallet, value: u64) -> OutPoint {
-    let latest_cp = wallet.latest_checkpoint();
-    let height = latest_cp.height();
-    assert!(height > 0, "cannot receive tx into genesis block");
-    receive_output(
-        wallet,
-        value,
-        ConfirmationBlockTime {
-            block_id: latest_cp.block_id(),
-            confirmation_time: 0,
-        },
-    )
-}
+// pub fn receive_output_in_latest_block(wallet: &mut Wallet, value: u64) -> OutPoint {
+//     let latest_cp = wallet.latest_checkpoint();
+//     let height = latest_cp.height();
+//     assert!(height > 0, "cannot receive tx into genesis block");
+//     receive_output(
+//         wallet,
+//         value,
+//         ConfirmationBlockTime {
+//             block_id: latest_cp.block_id(),
+//             confirmation_time: 0,
+//         },
+//     )
+// }
 
 /// Receive a tx output with the given value and chain position
-pub fn receive_output(
-    wallet: &mut Wallet,
-    value: u64,
-    receive_to: impl Into<ReceiveTo>,
-) -> OutPoint {
-    let addr = wallet.next_unused_address(KeychainKind::External).address;
-    receive_output_to_address(wallet, addr, value, receive_to)
-}
+// pub fn receive_output(
+//     wallet: &mut Wallet,
+//     value: u64,
+//     receive_to: impl Into<ReceiveTo>,
+// ) -> OutPoint {
+//     let addr = wallet.next_unused_address(KeychainKind::External).address;
+//     receive_output_to_address(wallet, addr, value, receive_to)
+// }
 
 /// Receive a tx output to an address with the given value and chain position
 pub fn receive_output_to_address(

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -131,6 +131,17 @@ impl KeyRing {
         &self.keychains
     }
 
+    pub fn list_keychain_ids(&self) -> Vec<DescriptorId> {
+        self.keychains
+            .iter()
+            .map(|keychain| match keychain.0 {
+                KeychainKind::Other(descriptor_id) => descriptor_id,
+                KeychainKind::Default => keychain.1.0.descriptor_id(),
+                KeychainKind::Change => keychain.1.0.descriptor_id(),
+            })
+            .collect()
+    }
+
     // pub fn add_change_keychain(&mut self, keychain: (DescriptorToExtract, KeyMap), keychain_identifier: KeychainIdentifier) {
     //
     // }

--- a/wallet/src/wallet/error.rs
+++ b/wallet/src/wallet/error.rs
@@ -46,7 +46,7 @@ impl std::error::Error for MiniscriptPsbtError {}
 #[derive(Debug)]
 pub enum KeychainNotInKeyRingError {
     NoChangeKeychain,
-    KeychainNotFound,
+    KeychainNotFound(KeychainKind),
 }
 
 #[derive(Debug)]

--- a/wallet/src/wallet/error.rs
+++ b/wallet/src/wallet/error.rs
@@ -44,6 +44,12 @@ impl fmt::Display for MiniscriptPsbtError {
 impl std::error::Error for MiniscriptPsbtError {}
 
 #[derive(Debug)]
+pub enum KeychainNotInKeyRingError {
+    NoChangeKeychain,
+    KeychainNotFound,
+}
+
+#[derive(Debug)]
 /// Error returned from [`TxBuilder::finish`]
 ///
 /// [`TxBuilder::finish`]: crate::wallet::tx_builder::TxBuilder::finish

--- a/wallet/src/wallet/export.rs
+++ b/wallet/src/wallet/export.rs
@@ -112,55 +112,55 @@ impl FullyNodedExport {
     ///
     /// If the database is empty or `include_blockheight` is false, the `blockheight` field
     /// returned will be `0`.
-    pub fn export_wallet(
-        wallet: &Wallet,
-        label: &str,
-        include_blockheight: bool,
-    ) -> Result<Self, &'static str> {
-        let descriptor = wallet
-            .public_descriptor(KeychainKind::External)
-            .to_string_with_secret(
-                &wallet
-                    .get_signers(KeychainKind::External)
-                    .as_key_map(wallet.secp_ctx()),
-            );
-        let descriptor = remove_checksum(descriptor);
-        Self::is_compatible_with_core(&descriptor)?;
-
-        let blockheight = if include_blockheight {
-            wallet.transactions().next().map_or(0, |canonical_tx| {
-                canonical_tx
-                    .chain_position
-                    .confirmation_height_upper_bound()
-                    .unwrap_or(0)
-            })
-        } else {
-            0
-        };
-
-        let export = FullyNodedExport {
-            descriptor,
-            label: label.into(),
-            blockheight,
-        };
-
-        let change_descriptor = {
-            let descriptor = wallet
-                .public_descriptor(KeychainKind::Internal)
-                .to_string_with_secret(
-                    &wallet
-                        .get_signers(KeychainKind::Internal)
-                        .as_key_map(wallet.secp_ctx()),
-                );
-            Some(remove_checksum(descriptor))
-        };
-
-        if export.change_descriptor() != change_descriptor {
-            return Err("Incompatible change descriptor");
-        }
-
-        Ok(export)
-    }
+    // pub fn export_wallet(
+    //     wallet: &Wallet,
+    //     label: &str,
+    //     include_blockheight: bool,
+    // ) -> Result<Self, &'static str> {
+    //     let descriptor = wallet
+    //         .public_descriptor(KeychainKind::External)
+    //         .to_string_with_secret(
+    //             &wallet
+    //                 .get_signers(KeychainKind::External)
+    //                 .as_key_map(wallet.secp_ctx()),
+    //         );
+    //     let descriptor = remove_checksum(descriptor);
+    //     Self::is_compatible_with_core(&descriptor)?;
+    //
+    //     let blockheight = if include_blockheight {
+    //         wallet.transactions().next().map_or(0, |canonical_tx| {
+    //             canonical_tx
+    //                 .chain_position
+    //                 .confirmation_height_upper_bound()
+    //                 .unwrap_or(0)
+    //         })
+    //     } else {
+    //         0
+    //     };
+    //
+    //     let export = FullyNodedExport {
+    //         descriptor,
+    //         label: label.into(),
+    //         blockheight,
+    //     };
+    //
+    //     let change_descriptor = {
+    //         let descriptor = wallet
+    //             .public_descriptor(KeychainKind::Internal)
+    //             .to_string_with_secret(
+    //                 &wallet
+    //                     .get_signers(KeychainKind::Internal)
+    //                     .as_key_map(wallet.secp_ctx()),
+    //             );
+    //         Some(remove_checksum(descriptor))
+    //     };
+    //
+    //     if export.change_descriptor() != change_descriptor {
+    //         return Err("Incompatible change descriptor");
+    //     }
+    //
+    //     Ok(export)
+    // }
 
     fn is_compatible_with_core(descriptor: &str) -> Result<(), &'static str> {
         fn check_ms<Ctx: ScriptContext>(

--- a/wallet/src/wallet/keyring.rs
+++ b/wallet/src/wallet/keyring.rs
@@ -1,0 +1,87 @@
+// Bitcoin Dev Kit
+// Written in 2020 by Alekos Filini <alekos.filini@gmail.com>
+//
+// Copyright (c) 2020-2025 Bitcoin Dev Kit Developers
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.
+
+use std::prelude::rust_2021::Vec;
+use bitcoin::Network;
+use chain::{DescriptorExt, DescriptorId};
+use miniscript::{Descriptor, DescriptorPublicKey};
+use miniscript::descriptor::KeyMap;
+use crate::descriptor::IntoWalletDescriptor;
+use crate::{DescriptorToExtract, KeychainKind};
+use crate::wallet::make_descriptor_to_extract;
+use crate::wallet::utils::SecpCtx;
+
+/// A `WalletKeychain` is mostly a descriptor with metadata associated with it. It states whether the
+/// keychain is the default keychain for the wallet, and provides an identifier for it which can be
+/// used for retrieval.
+pub type WalletKeychain = (KeychainKind, (Descriptor<DescriptorPublicKey>, KeyMap));
+
+#[derive(Debug, Clone)]
+pub struct KeyRing {
+    keychains: Vec<WalletKeychain>,
+    network: Network,
+}
+
+impl KeyRing {
+    pub fn new<D: IntoWalletDescriptor + Send + 'static>(
+        default_descriptor: D,
+        network: Network,
+    ) -> Self {
+        let secp = SecpCtx::new();
+        let descriptor_to_extract: DescriptorToExtract = make_descriptor_to_extract(default_descriptor);
+        let public_descriptor: (Descriptor<DescriptorPublicKey>, KeyMap) = descriptor_to_extract(&secp, network).unwrap();
+        let wallet_keychain = (KeychainKind::Default, public_descriptor);
+
+        KeyRing {
+            keychains: vec![wallet_keychain],
+            network,
+        }
+    }
+
+    // TODO #226: This needs to never fail because there is always a default keychain.
+    pub fn get_default_keychain(&self) -> WalletKeychain {
+        self.keychains.iter().find(|keychain| matches!(keychain.0, KeychainKind::Default)).unwrap().clone()
+    }
+
+    pub fn get_change_keychain(&self) -> Option<WalletKeychain> {
+        self.keychains.iter().find(|keychain| matches!(keychain.0, KeychainKind::Change)).cloned()
+    }
+
+    pub fn add_other_descriptor<D: IntoWalletDescriptor + Send + 'static>(
+        &mut self,
+        other_descriptor: D
+    ) -> &mut KeyRing {
+        let secp = SecpCtx::new();
+        let descriptor_to_extract: DescriptorToExtract = make_descriptor_to_extract(other_descriptor);
+        let public_descriptor = descriptor_to_extract(&secp, self.network).unwrap();
+        let descriptor_id = public_descriptor.0.descriptor_id();
+
+        let wallet_keychain = ((KeychainKind::Other(descriptor_id)), public_descriptor);
+
+        self.keychains.push(wallet_keychain);
+        self
+    }
+
+    pub fn list_keychains(&self) -> &Vec<WalletKeychain> {
+        &self.keychains
+    }
+
+    pub fn list_keychain_ids(&self) -> Vec<DescriptorId> {
+        self.keychains
+            .iter()
+            .map(|keychain| match keychain.0 {
+                KeychainKind::Other(descriptor_id) => descriptor_id,
+                KeychainKind::Default => keychain.1.0.descriptor_id(),
+                KeychainKind::Change => keychain.1.0.descriptor_id(),
+            })
+            .collect()
+    }
+}

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -286,8 +286,8 @@ impl std::error::Error for ApplyBlockError {}
 pub type WalletTx<'a> = CanonicalTx<'a, Arc<Transaction>, ConfirmationBlockTime>;
 
 impl Wallet {
-    pub fn new(keychain_set: KeyRing) -> CreateParams {
-        CreateParams::new_with_keychain_set(keychain_set)
+    pub fn new(keychain_set: KeyRing, network: Network) -> CreateParams {
+        CreateParams::new_with_keychain_set(keychain_set, network)
     }
 
     /// Build a new single descriptor [`Wallet`].

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -59,6 +59,7 @@ mod persisted;
 pub mod signer;
 pub mod tx_builder;
 pub(crate) mod utils;
+mod keyring;
 
 use crate::collections::{BTreeMap, HashMap, HashSet};
 use crate::descriptor::{
@@ -85,6 +86,7 @@ pub use persisted::*;
 pub use utils::IsDust;
 use crate::error::KeychainNotInKeyRingError;
 use crate::error::KeychainNotInKeyRingError::KeychainNotFound;
+use crate::wallet::keyring::KeyRing;
 
 /// A Bitcoin wallet
 ///

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -2544,7 +2544,7 @@ fn new_local_utxo(
 }
 
 fn create_indexer(
-    keychain_set: KeyRing,
+    keyring: KeyRing,
     // descriptor: ExtendedDescriptor,
     // change_descriptor: Option<ExtendedDescriptor>,
     lookahead: u32,
@@ -2553,10 +2553,17 @@ fn create_indexer(
 
     // let (descriptor, keymap) = descriptor;
     // let signers = Arc::new(SignersContainer::build(keymap, &descriptor, secp));
-    let default_keychain = keychain_set.get_default_keychain().clone();
-    assert!(indexer
-        .insert_descriptor(default_keychain.0, default_keychain.1.0)
-        .expect("first descriptor introduced must succeed"));
+    let default_keychain = keyring.get_default_keychain().clone();
+    // TODO: KeyRings always have at least one descriptor, so I think we don't need this assert
+    // assert!(indexer
+    //     .insert_descriptor(default_keychain.0, default_keychain.1.0)
+    //     .expect("first descriptor introduced must succeed"));
+
+    // TODO: I'm here, May 2
+    keyring.list_keychains().iter().for_each(|k| {
+        indexer.insert_descriptor(k.0, k.1.0.clone()).expect("This should work");
+        dbg!("Inserting descriptor into indexer");
+    });
 
     // let (descriptor, keymap) = change_descriptor;
     // let change_signers = Arc::new(SignersContainer::build(keymap, &descriptor, secp));

--- a/wallet/src/wallet/params.rs
+++ b/wallet/src/wallet/params.rs
@@ -3,7 +3,7 @@ use bdk_chain::keychain_txout::DEFAULT_LOOKAHEAD;
 use bitcoin::{BlockHash, Network};
 use miniscript::descriptor::KeyMap;
 
-use crate::{descriptor::{DescriptorError, ExtendedDescriptor, IntoWalletDescriptor}, utils::SecpCtx, AsyncWalletPersister, CreateWithPersistError, KeyRing, LoadWithPersistError, Wallet, WalletPersister};
+use crate::{descriptor::{DescriptorError, ExtendedDescriptor, IntoWalletDescriptor}, utils::SecpCtx, AsyncWalletPersister, CreateWithPersistError, wallet::keyring::KeyRing, LoadWithPersistError, Wallet, WalletPersister};
 
 use super::{ChangeSet, LoadError, PersistedWallet};
 
@@ -27,11 +27,7 @@ where
 /// Parameters for [`Wallet::create`] or [`PersistedWallet::create`].
 #[must_use]
 pub struct CreateParams {
-    pub(crate) keychain_set: KeyRing,
-    // pub(crate) descriptor: DescriptorToExtract,
-    // pub(crate) descriptor_keymap: KeyMap,
-    // pub(crate) change_descriptor: Option<DescriptorToExtract>,
-    // pub(crate) change_descriptor_keymap: KeyMap,
+    pub(crate) key_ring: KeyRing,
     pub(crate) network: Network,
     pub(crate) genesis_hash: Option<BlockHash>,
     pub(crate) lookahead: u32,
@@ -81,12 +77,12 @@ impl CreateParams {
     //     }
     // }
 
-    pub fn new_with_keychain_set(
-        keychain_set: KeyRing,
+    pub fn new_with_keyring(
+        key_ring: KeyRing,
         network: Network,
     ) -> Self {
         Self {
-            keychain_set,
+            key_ring,
             network,
             genesis_hash: None,
             lookahead: DEFAULT_LOOKAHEAD,

--- a/wallet/src/wallet/params.rs
+++ b/wallet/src/wallet/params.rs
@@ -83,10 +83,11 @@ impl CreateParams {
 
     pub fn new_with_keychain_set(
         keychain_set: KeyRing,
+        network: Network,
     ) -> Self {
         Self {
             keychain_set,
-            network: Network::Bitcoin,
+            network,
             genesis_hash: None,
             lookahead: DEFAULT_LOOKAHEAD,
         }

--- a/wallet/src/wallet/params.rs
+++ b/wallet/src/wallet/params.rs
@@ -34,53 +34,16 @@ pub struct CreateParams {
 }
 
 impl CreateParams {
-    /// Construct parameters with provided `descriptor`.
+    /// Construct parameters with provided `KeyRing`.
     ///
     /// Default values:
-    /// * `change_descriptor` = `None`
-    /// * `network` = [`Network::Bitcoin`]
+    /// * `network` = Provided by your KeyRing
     /// * `genesis_hash` = `None`
     /// * `lookahead` = [`DEFAULT_LOOKAHEAD`]
-    ///
-    /// Use this method only when building a wallet with a single descriptor. See
-    /// also [`Wallet::create_single`].
-    // pub fn new_single<D: IntoWalletDescriptor + Send + 'static>(descriptor: D) -> Self {
-    //     Self {
-    //         descriptor: make_descriptor_to_extract(descriptor),
-    //         descriptor_keymap: KeyMap::default(),
-    //         change_descriptor: None,
-    //         change_descriptor_keymap: KeyMap::default(),
-    //         network: Network::Bitcoin,
-    //         genesis_hash: None,
-    //         lookahead: DEFAULT_LOOKAHEAD,
-    //     }
-    // }
-
-    /// Construct parameters with provided `descriptor` and `change_descriptor`.
-    ///
-    /// Default values:
-    /// * `network` = [`Network::Bitcoin`]
-    /// * `genesis_hash` = `None`
-    /// * `lookahead` = [`DEFAULT_LOOKAHEAD`]
-    // pub fn new<D: IntoWalletDescriptor + Send + 'static>(
-    //     descriptor: D,
-    //     change_descriptor: D,
-    // ) -> Self {
-    //     Self {
-    //         descriptor: make_descriptor_to_extract(descriptor),
-    //         descriptor_keymap: KeyMap::default(),
-    //         change_descriptor: Some(make_descriptor_to_extract(change_descriptor)),
-    //         change_descriptor_keymap: KeyMap::default(),
-    //         network: Network::Bitcoin,
-    //         genesis_hash: None,
-    //         lookahead: DEFAULT_LOOKAHEAD,
-    //     }
-    // }
-
-    pub fn new_with_keyring(
+    pub fn new(
         key_ring: KeyRing,
-        network: Network,
     ) -> Self {
+        let network = key_ring.network();
         Self {
             key_ring,
             network,

--- a/wallet/src/wallet/persisted.rs
+++ b/wallet/src/wallet/persisted.rs
@@ -160,20 +160,20 @@ impl<P: WalletPersister> PersistedWallet<P> {
     }
 
     /// Load a previously [`PersistedWallet`] from the given `persister` and `params`.
-    pub fn load(
-        persister: &mut P,
-        params: LoadParams,
-    ) -> Result<Option<Self>, LoadWithPersistError<P::Error>> {
-        let changeset = P::initialize(persister).map_err(LoadWithPersistError::Persist)?;
-        Wallet::load_with_params(changeset, params)
-            .map(|opt| {
-                opt.map(|inner| PersistedWallet {
-                    inner,
-                    _marker: PhantomData,
-                })
-            })
-            .map_err(LoadWithPersistError::InvalidChangeSet)
-    }
+    // pub fn load(
+    //     persister: &mut P,
+    //     params: LoadParams,
+    // ) -> Result<Option<Self>, LoadWithPersistError<P::Error>> {
+    //     let changeset = P::initialize(persister).map_err(LoadWithPersistError::Persist)?;
+    //     Wallet::load_with_params(changeset, params)
+    //         .map(|opt| {
+    //             opt.map(|inner| PersistedWallet {
+    //                 inner,
+    //                 _marker: PhantomData,
+    //             })
+    //         })
+    //         .map_err(LoadWithPersistError::InvalidChangeSet)
+    // }
 
     /// Persist staged changes of wallet into `persister`.
     ///
@@ -219,22 +219,22 @@ impl<P: AsyncWalletPersister> PersistedWallet<P> {
     }
 
     /// Load a previously [`PersistedWallet`] from the given async `persister` and `params`.
-    pub async fn load_async(
-        persister: &mut P,
-        params: LoadParams,
-    ) -> Result<Option<Self>, LoadWithPersistError<P::Error>> {
-        let changeset = P::initialize(persister)
-            .await
-            .map_err(LoadWithPersistError::Persist)?;
-        Wallet::load_with_params(changeset, params)
-            .map(|opt| {
-                opt.map(|inner| PersistedWallet {
-                    inner,
-                    _marker: PhantomData,
-                })
-            })
-            .map_err(LoadWithPersistError::InvalidChangeSet)
-    }
+    // pub async fn load_async(
+    //     persister: &mut P,
+    //     params: LoadParams,
+    // ) -> Result<Option<Self>, LoadWithPersistError<P::Error>> {
+    //     let changeset = P::initialize(persister)
+    //         .await
+    //         .map_err(LoadWithPersistError::Persist)?;
+    //     Wallet::load_with_params(changeset, params)
+    //         .map(|opt| {
+    //             opt.map(|inner| PersistedWallet {
+    //                 inner,
+    //                 _marker: PhantomData,
+    //             })
+    //         })
+    //         .map_err(LoadWithPersistError::InvalidChangeSet)
+    // }
 
     /// Persist staged changes of wallet into an async `persister`.
     ///

--- a/wallet/src/wallet/tx_builder.rs
+++ b/wallet/src/wallet/tx_builder.rs
@@ -253,19 +253,19 @@ impl<'a, Cs> TxBuilder<'a, Cs> {
     ///
     /// # Ok::<(), anyhow::Error>(())
     /// ```
-    pub fn policy_path(
-        &mut self,
-        policy_path: BTreeMap<String, Vec<usize>>,
-        keychain: KeychainKind,
-    ) -> &mut Self {
-        let to_update = match keychain {
-            KeychainKind::Internal => &mut self.params.internal_policy_path,
-            KeychainKind::External => &mut self.params.external_policy_path,
-        };
-
-        *to_update = Some(policy_path);
-        self
-    }
+    // pub fn policy_path(
+    //     &mut self,
+    //     policy_path: BTreeMap<String, Vec<usize>>,
+    //     keychain: KeychainKind,
+    // ) -> &mut Self {
+    //     let to_update = match keychain {
+    //         KeychainKind::Internal => &mut self.params.internal_policy_path,
+    //         KeychainKind::External => &mut self.params.external_policy_path,
+    //     };
+    //
+    //     *to_update = Some(policy_path);
+    //     self
+    // }
 
     /// Add the list of outpoints to the internal list of UTXOs that **must** be spent.
     ///
@@ -273,40 +273,40 @@ impl<'a, Cs> TxBuilder<'a, Cs> {
     ///
     /// These have priority over the "unspendable" utxos, meaning that if a utxo is present both in
     /// the "utxos" and the "unspendable" list, it will be spent.
-    pub fn add_utxos(&mut self, outpoints: &[OutPoint]) -> Result<&mut Self, AddUtxoError> {
-        let utxo_batch = outpoints
-            .iter()
-            .map(|outpoint| {
-                self.wallet
-                    .get_utxo(*outpoint)
-                    .ok_or(AddUtxoError::UnknownUtxo(*outpoint))
-                    .map(|output| {
-                        (
-                            *outpoint,
-                            WeightedUtxo {
-                                satisfaction_weight: self
-                                    .wallet
-                                    .public_descriptor(output.keychain)
-                                    .max_weight_to_satisfy()
-                                    .unwrap(),
-                                utxo: Utxo::Local(output),
-                            },
-                        )
-                    })
-            })
-            .collect::<Result<HashMap<OutPoint, WeightedUtxo>, AddUtxoError>>()?;
-        self.params.utxos.extend(utxo_batch);
-
-        Ok(self)
-    }
+    // pub fn add_utxos(&mut self, outpoints: &[OutPoint]) -> Result<&mut Self, AddUtxoError> {
+    //     let utxo_batch = outpoints
+    //         .iter()
+    //         .map(|outpoint| {
+    //             self.wallet
+    //                 .get_utxo(*outpoint)
+    //                 .ok_or(AddUtxoError::UnknownUtxo(*outpoint))
+    //                 .map(|output| {
+    //                     (
+    //                         *outpoint,
+    //                         WeightedUtxo {
+    //                             satisfaction_weight: self
+    //                                 .wallet
+    //                                 .public_descriptor(output.keychain)
+    //                                 .max_weight_to_satisfy()
+    //                                 .unwrap(),
+    //                             utxo: Utxo::Local(output),
+    //                         },
+    //                     )
+    //                 })
+    //         })
+    //         .collect::<Result<HashMap<OutPoint, WeightedUtxo>, AddUtxoError>>()?;
+    //     self.params.utxos.extend(utxo_batch);
+    //
+    //     Ok(self)
+    // }
 
     /// Add a utxo to the internal list of utxos that **must** be spent
     ///
     /// These have priority over the "unspendable" utxos, meaning that if a utxo is present both in
     /// the "utxos" and the "unspendable" list, it will be spent.
-    pub fn add_utxo(&mut self, outpoint: OutPoint) -> Result<&mut Self, AddUtxoError> {
-        self.add_utxos(&[outpoint])
-    }
+    // pub fn add_utxo(&mut self, outpoint: OutPoint) -> Result<&mut Self, AddUtxoError> {
+    //     self.add_utxos(&[outpoint])
+    // }
 
     /// Add a foreign UTXO i.e. a UTXO not known by this wallet.
     ///
@@ -669,34 +669,34 @@ impl<'a, Cs> TxBuilder<'a, Cs> {
 }
 
 impl<Cs: CoinSelectionAlgorithm> TxBuilder<'_, Cs> {
-    /// Finish building the transaction.
-    ///
-    /// Uses the thread-local random number generator (rng).
-    ///
-    /// Returns a new [`Psbt`] per [`BIP174`].
-    ///
-    /// [`BIP174`]: https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki
-    ///
-    /// **WARNING**: To avoid change address reuse you must persist the changes resulting from one
-    /// or more calls to this method before closing the wallet. See [`Wallet::reveal_next_address`].
-    #[cfg(feature = "std")]
-    pub fn finish(self) -> Result<Psbt, CreateTxError> {
-        self.finish_with_aux_rand(&mut bitcoin::key::rand::thread_rng())
-    }
+    // /// Finish building the transaction.
+    // ///
+    // /// Uses the thread-local random number generator (rng).
+    // ///
+    // /// Returns a new [`Psbt`] per [`BIP174`].
+    // ///
+    // /// [`BIP174`]: https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki
+    // ///
+    // /// **WARNING**: To avoid change address reuse you must persist the changes resulting from one
+    // /// or more calls to this method before closing the wallet. See [`Wallet::reveal_next_address`].
+    // #[cfg(feature = "std")]
+    // pub fn finish(self) -> Result<Psbt, CreateTxError> {
+    //     self.finish_with_aux_rand(&mut bitcoin::key::rand::thread_rng())
+    // }
 
-    /// Finish building the transaction.
-    ///
-    /// Uses a provided random number generator (rng).
-    ///
-    /// Returns a new [`Psbt`] per [`BIP174`].
-    ///
-    /// [`BIP174`]: https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki
-    ///
-    /// **WARNING**: To avoid change address reuse you must persist the changes resulting from one
-    /// or more calls to this method before closing the wallet. See [`Wallet::reveal_next_address`].
-    pub fn finish_with_aux_rand(self, rng: &mut impl RngCore) -> Result<Psbt, CreateTxError> {
-        self.wallet.create_tx(self.coin_selection, self.params, rng)
-    }
+    // /// Finish building the transaction.
+    // ///
+    // /// Uses a provided random number generator (rng).
+    // ///
+    // /// Returns a new [`Psbt`] per [`BIP174`].
+    // ///
+    // /// [`BIP174`]: https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki
+    // ///
+    // /// **WARNING**: To avoid change address reuse you must persist the changes resulting from one
+    // /// or more calls to this method before closing the wallet. See [`Wallet::reveal_next_address`].
+    // pub fn finish_with_aux_rand(self, rng: &mut impl RngCore) -> Result<Psbt, CreateTxError> {
+    //     self.wallet.create_tx(self.coin_selection, self.params, rng)
+    // }
 }
 
 #[derive(Debug)]
@@ -820,6 +820,7 @@ impl TxOrdering {
     }
 }
 
+// TODO: This doesn't make as much sense if you have N keychains. Needs reworking.
 /// Policy regarding the use of change outputs when creating a transaction
 #[derive(Default, Debug, Ord, PartialOrd, Eq, PartialEq, Hash, Clone, Copy)]
 pub enum ChangeSpendPolicy {
@@ -836,8 +837,8 @@ impl ChangeSpendPolicy {
     pub(crate) fn is_satisfied_by(&self, utxo: &LocalOutput) -> bool {
         match self {
             ChangeSpendPolicy::ChangeAllowed => true,
-            ChangeSpendPolicy::OnlyChange => utxo.keychain == KeychainKind::Internal,
-            ChangeSpendPolicy::ChangeForbidden => utxo.keychain == KeychainKind::External,
+            ChangeSpendPolicy::OnlyChange => utxo.keychain == KeychainKind::Change,
+            ChangeSpendPolicy::ChangeForbidden => utxo.keychain == KeychainKind::Default,
         }
     }
 }


### PR DESCRIPTION
Just pushing here to show/discuss as I explore the potential for support of any number of descriptors for the Wallet type for maybe a 3.0.

# Overview

The gist of my idea is a `KeyRing` (KeychainRing? KeychainSet?), which is basically a structure that holds a vector of keychains. You create a key ring with any number of descriptors (_must have_ 1 default, _can have_ 1 change, plus any number of others). The wallet constructors take this KeyRing as an argument, and from there the wallet methods need to be adjusted to work with the new paradigm.

The `KeyRing` has methods to add/check/query descriptors it holds, and is where the domain logic of ensuring only 1 descriptor is the default, that all descriptors use the same network, and any other requirements we have for basically this group of keychains lives. The wallet type then gets a new field key_ring, which it can use to query things like `KeyRing::get_default_descriptor()` or `KeyRing::list_keychains()`.

```rust
pub enum KeychainKind {
    Default,
    Change,
    Other(DescriptorId),
}

pub type WalletKeychain = (KeychainKind, Descriptor<DescriptorPublicKey>);

pub struct KeyRing {
    keychains: Vec<WalletKeychain>,
}
```

# Resulting API

The API is showcased in the `wallet/examples/n_keychains.rs` file.

```rust
// Create a keyring with a single, default descriptor (aka the KeychainKind::External from the 1.2.0 API)
let mut keyring = KeyRing::new(EXTERNAL_DESC, Network::Testnet4);

// Add 3 new custom descriptors
keyring.add_other_descriptor(OTHER_DESC_21);
keyring.add_other_descriptor(OTHER_DESC_31);
keyring.add_other_descriptor(OTHER_DESC_41);

let keychain_ids: Vec<DescriptorId> = keyring.list_keychain_ids();
println!("{:?}", keychain_ids);

// Create the wallet and peek addresses on each of the descriptors
let wallet: Wallet = Wallet::new(keyring).create_wallet_no_persist()?;
let address_1 = wallet.peek_address(KeychainKind::Default, 0).unwrap();
let address_2 = wallet.peek_address(KeychainKind::Other(keychain_ids[1]), 0).unwrap();
let address_3 = wallet.peek_address(KeychainKind::Other(keychain_ids[2]), 0).unwrap();
let address_4 = wallet.peek_address(KeychainKind::Other(keychain_ids[3]), 0).unwrap();

println!("Address 1 {:?} at index {:?} on keychain {:?}", address_1.address, address_1.index, address_1.keychain);
println!("Address 2 {:?} at index {:?} on keychain {:?}", address_2.address, address_2.index, address_2.keychain);
println!("Address 3 {:?} at index {:?} on keychain {:?}", address_3.address, address_3.index, address_3.keychain);
println!("Address 4 {:?} at index {:?} on keychain {:?}", address_4.address, address_4.index, address_4.keychain);
```