### PR TITLE
Allow serialization of Update

### DIFF
--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -113,7 +113,7 @@ pub struct Wallet {
 /// An update to [`Wallet`].
 ///
 /// It updates [`KeychainTxOutIndex`], [`bdk_chain::TxGraph`] and [`LocalChain`] atomically.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Deserialize, serde::Serialize)]
 pub struct Update {
     /// Contains the last active derivation indices per keychain (`K`), which is used to update the
     /// [`KeychainTxOutIndex`].


### PR DESCRIPTION
### Description

The rationale behind this is to allow a separate instance of the same wallet be updated on a device that's not necessarily connected. Like a hardware wallet.

A connected device gets the response, serializes it with serde and passes the `Update` to the air-gapped one.

Depends on https://github.com/bitcoindevkit/bdk/pull/1954

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing