### PR TITLE
Add `Wallet::apply_changeset`

### DIFF
--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -2249,6 +2249,23 @@ impl Wallet {
         Ok(())
     }
 
+    /// Applies a changeset.
+    ///
+    /// # Warning
+    ///
+    /// Applying changesets out of order may leave your wallet in an inconsistent state.
+    pub fn apply_changeset(&mut self, changeset: ChangeSet) {
+        self.chain
+            .apply_changeset(&changeset.local_chain)
+            .expect("must not remove genesis block");
+        self.indexed_graph
+            .apply_changeset(indexed_tx_graph::ChangeSet {
+                tx_graph: changeset.tx_graph.clone(),
+                indexer: changeset.indexer.clone(),
+            });
+        self.stage.merge(changeset);
+    }
+
     /// Get a reference of the staged [`ChangeSet`] that is yet to be committed (if any).
     pub fn staged(&self) -> Option<&ChangeSet> {
         if self.stage.is_empty() {


### PR DESCRIPTION
### Description

My proposed alternative for #229.

**To Do:**

Expand on the "Warning" for the `apply_changeset` doc comments. We really don't want most users doing this until `LocalChain` changesets become monotone.

### Changelog notice

* Add `Wallet::apply_chaneset` method.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature