### PR TITLE
fix: Validate prevouts in `get_psbt_input`

### DIFF
--- a/wallet/src/wallet/error.rs
+++ b/wallet/src/wallet/error.rs
@@ -223,6 +223,8 @@ pub enum BuildFeeBumpError {
     IrreplaceableTransaction(Txid),
     /// Node doesn't have data to estimate a fee rate
     FeeRateUnavailable,
+    /// Input references an invalid output index in the previous transaction
+    InvalidOutputIndex(OutPoint),
 }
 
 impl fmt::Display for BuildFeeBumpError {
@@ -247,6 +249,9 @@ impl fmt::Display for BuildFeeBumpError {
                 write!(f, "Transaction can't be replaced with txid: {}", txid)
             }
             Self::FeeRateUnavailable => write!(f, "Fee rate unavailable"),
+            Self::InvalidOutputIndex(op) => {
+                write!(f, "A txin referenced an invalid output: {}", op)
+            }
         }
     }
 }

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -2211,8 +2211,12 @@ impl Wallet {
 
         let prev_output = utxo.outpoint;
         if let Some(prev_tx) = self.indexed_graph.graph().get_tx(prev_output.txid) {
+            // We want to check that the prevout actually exists in the tx before continuing.
+            let prevout = prev_tx.output.get(prev_output.vout as usize).ok_or(
+                MiniscriptPsbtError::UtxoUpdate(miniscript::psbt::UtxoUpdateError::UtxoCheck),
+            )?;
             if desc.is_witness() || desc.is_taproot() {
-                psbt_input.witness_utxo = Some(prev_tx.output[prev_output.vout as usize].clone());
+                psbt_input.witness_utxo = Some(prevout.clone());
             }
             if !desc.is_taproot() && (!desc.is_witness() || !only_witness_utxo) {
                 psbt_input.non_witness_utxo = Some(prev_tx.as_ref().clone());


### PR DESCRIPTION
Fixes #50
Fixes #51
Replaces bitcoindevkit/bdk#1911
Replaces bitcoindevkit/bdk#1913

### Description

We should check the bounds of the prev txs.

### Changelog notice

```md
Fixed:
    - Wallet::get_psbt_input method now checks bounds when fetching prevout
    - Wallet::build_fee_bump method now checks bounds when fetching prevout
```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

~~* [ ] I've added tests to reproduce the issue which are now passing~~
* [x] I'm linking the issue being fixed by this PR
