### PR TITLE
chore(deps): bump `rand` to `0.9.1`, remove `rand_core`

### DIFF
--- a/wallet/.cargo/config.toml
+++ b/wallet/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+rustflags = ["--cfg", "getrandom_backend=\"wasm_js\""]

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -27,6 +27,9 @@ bdk_chain = { version = "0.22.0", features = [ "miniscript", "serde" ], default-
 bip39 = { version = "2.0", optional = true }
 bdk_file_store = { version = "0.20.0", optional = true }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.3", features = ["wasm_js"] }
+
 [features]
 default = ["std"]
 std = ["bitcoin/std", "bitcoin/rand-std", "miniscript/std", "bdk_chain/std"]

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.63"
 workspace = true
 
 [dependencies]
-rand_core = { version = "0.6.0" }
+rand = { version = "0.9.1" }
 miniscript = { version = "12.3.1", features = [ "serde" ], default-features = false }
 bitcoin = { version = "0.32.4", features = [ "serde", "base64" ], default-features = false }
 serde = { version = "^1.0", features = ["derive"] }
@@ -43,7 +43,6 @@ tempfile = "3"
 bdk_chain = { version = "0.22.0", features = ["rusqlite"] }
 bdk_wallet = { path = ".", features = ["rusqlite", "file_store", "test-utils"] }
 anyhow = "1"
-rand = "^0.8"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/wallet/src/keys/mod.rs
+++ b/wallet/src/keys/mod.rs
@@ -20,7 +20,7 @@ use core::marker::PhantomData;
 use core::ops::Deref;
 use core::str::FromStr;
 
-use rand_core::{CryptoRng, RngCore};
+use rand::CryptoRng;
 
 use bitcoin::secp256k1::{self, Secp256k1, Signing};
 
@@ -645,7 +645,7 @@ pub trait GeneratableKey<Ctx: ScriptContext>: Sized {
     /// Uses the thread-local random number generator.
     #[cfg(feature = "std")]
     fn generate(options: Self::Options) -> Result<GeneratedKey<Self, Ctx>, Self::Error> {
-        Self::generate_with_aux_rand(options, &mut bitcoin::key::rand::thread_rng())
+        Self::generate_with_aux_rand(options, &mut rand::rng())
     }
 
     /// Generate a key given the options with random entropy.
@@ -653,7 +653,7 @@ pub trait GeneratableKey<Ctx: ScriptContext>: Sized {
     /// Uses a provided random number generator (rng).
     fn generate_with_aux_rand(
         options: Self::Options,
-        rng: &mut (impl CryptoRng + RngCore),
+        rng: &mut impl CryptoRng,
     ) -> Result<GeneratedKey<Self, Ctx>, Self::Error> {
         let mut entropy = Self::Entropy::default();
         rng.fill_bytes(entropy.as_mut());
@@ -682,14 +682,14 @@ where
     /// Uses the thread-local random number generator.
     #[cfg(feature = "std")]
     fn generate_default() -> Result<GeneratedKey<Self, Ctx>, Self::Error> {
-        Self::generate_with_aux_rand(Default::default(), &mut bitcoin::key::rand::thread_rng())
+        Self::generate_with_aux_rand(Default::default(), &mut rand::rng())
     }
 
     /// Generate a key with the default options and a random entropy
     ///
     /// Uses a provided random number generator (rng).
     fn generate_default_with_aux_rand(
-        rng: &mut (impl CryptoRng + RngCore),
+        rng: &mut impl CryptoRng,
     ) -> Result<GeneratedKey<Self, Ctx>, Self::Error> {
         Self::generate_with_aux_rand(Default::default(), rng)
     }

--- a/wallet/src/wallet/coin_selection.rs
+++ b/wallet/src/wallet/coin_selection.rs
@@ -31,7 +31,7 @@
 //! # use bdk_wallet::*;
 //! # use bdk_wallet::coin_selection::decide_change;
 //! # use anyhow::Error;
-//! # use rand_core::RngCore;
+//! # use rand::RngCore;
 //! #[derive(Debug)]
 //! struct AlwaysSpendEverything;
 //!
@@ -113,7 +113,7 @@ use bitcoin::{Script, Weight};
 
 use core::convert::TryInto;
 use core::fmt::{self, Formatter};
-use rand_core::RngCore;
+use rand::RngCore;
 
 use super::utils::shuffle_slice;
 /// Default coin selection algorithm used by [`TxBuilder`](super::tx_builder::TxBuilder) if not
@@ -737,7 +737,7 @@ mod test {
     use crate::types::*;
 
     use rand::prelude::SliceRandom;
-    use rand::{thread_rng, Rng, RngCore, SeedableRng};
+    use rand::{rng, Rng, RngCore, SeedableRng};
 
     // signature len (1WU) + signature and sighash (72WU)
     // + pubkey len (1WU) + pubkey (33WU)
@@ -832,13 +832,13 @@ mod test {
                     ))
                     .unwrap(),
                     txout: TxOut {
-                        value: Amount::from_sat(rng.gen_range(0..200000000)),
+                        value: Amount::from_sat(rng.random_range(0..200000000)),
                         script_pubkey: ScriptBuf::new(),
                     },
                     keychain: KeychainKind::External,
                     is_spent: false,
                     derivation_index: rng.next_u32(),
-                    chain_position: if rng.gen_bool(0.5) {
+                    chain_position: if rng.random_bool(0.5) {
                         ChainPosition::Confirmed {
                             anchor: ConfirmationBlockTime {
                                 block_id: chain::BlockId {
@@ -882,7 +882,7 @@ mod test {
     }
 
     fn sum_random_utxos(mut rng: &mut StdRng, utxos: &mut [WeightedUtxo]) -> Amount {
-        let utxos_picked_len = rng.gen_range(2..utxos.len() / 2);
+        let utxos_picked_len = rng.random_range(2..utxos.len() / 2);
         utxos.shuffle(&mut rng);
         utxos[..utxos_picked_len]
             .iter()
@@ -913,7 +913,7 @@ mod test {
                 FeeRate::from_sat_per_vb_unchecked(1),
                 target_amount,
                 &drain_script,
-                &mut thread_rng(),
+                &mut rng(),
             )
             .unwrap();
 
@@ -935,7 +935,7 @@ mod test {
                 FeeRate::from_sat_per_vb_unchecked(1),
                 target_amount,
                 &drain_script,
-                &mut thread_rng(),
+                &mut rng(),
             )
             .unwrap();
 
@@ -957,7 +957,7 @@ mod test {
                 FeeRate::from_sat_per_vb_unchecked(1),
                 target_amount,
                 &drain_script,
-                &mut thread_rng(),
+                &mut rng(),
             )
             .unwrap();
 
@@ -978,7 +978,7 @@ mod test {
             FeeRate::from_sat_per_vb_unchecked(1),
             target_amount,
             &drain_script,
-            &mut thread_rng(),
+            &mut rng(),
         );
         assert!(matches!(result, Err(InsufficientFunds { .. })));
     }
@@ -995,7 +995,7 @@ mod test {
             FeeRate::from_sat_per_vb_unchecked(1000),
             target_amount,
             &drain_script,
-            &mut thread_rng(),
+            &mut rng(),
         );
         assert!(matches!(result, Err(InsufficientFunds { .. })));
     }
@@ -1013,7 +1013,7 @@ mod test {
                 FeeRate::from_sat_per_vb_unchecked(1),
                 target_amount,
                 &drain_script,
-                &mut thread_rng(),
+                &mut rng(),
             )
             .unwrap();
 
@@ -1035,7 +1035,7 @@ mod test {
                 FeeRate::from_sat_per_vb_unchecked(1),
                 target_amount,
                 &drain_script,
-                &mut thread_rng(),
+                &mut rng(),
             )
             .unwrap();
 
@@ -1057,7 +1057,7 @@ mod test {
                 FeeRate::from_sat_per_vb_unchecked(1),
                 target_amount,
                 &drain_script,
-                &mut thread_rng(),
+                &mut rng(),
             )
             .unwrap();
 
@@ -1078,7 +1078,7 @@ mod test {
             FeeRate::from_sat_per_vb_unchecked(1),
             target_amount,
             &drain_script,
-            &mut thread_rng(),
+            &mut rng(),
         );
         assert!(matches!(result, Err(InsufficientFunds { .. })));
     }
@@ -1097,7 +1097,7 @@ mod test {
             FeeRate::from_sat_per_vb_unchecked(1000),
             target_amount,
             &drain_script,
-            &mut thread_rng(),
+            &mut rng(),
         );
         assert!(matches!(result, Err(InsufficientFunds { .. })));
     }
@@ -1117,7 +1117,7 @@ mod test {
                 FeeRate::from_sat_per_vb_unchecked(1),
                 target_amount,
                 &drain_script,
-                &mut thread_rng(),
+                &mut rng(),
             )
             .unwrap();
 
@@ -1139,7 +1139,7 @@ mod test {
                 FeeRate::from_sat_per_vb_unchecked(1),
                 target_amount,
                 &drain_script,
-                &mut thread_rng(),
+                &mut rng(),
             )
             .unwrap();
 
@@ -1163,7 +1163,7 @@ mod test {
                 fee_rate,
                 target_amount,
                 &drain_script,
-                &mut thread_rng(),
+                &mut rng(),
             )
             .unwrap();
 
@@ -1187,7 +1187,7 @@ mod test {
             fee_rate,
             target_amount,
             &drain_script,
-            &mut thread_rng(),
+            &mut rng,
         );
 
         assert!(
@@ -1258,7 +1258,7 @@ mod test {
                 fee_rate,
                 target_amount,
                 &drain_script,
-                &mut thread_rng(),
+                &mut rng(),
             )
             .unwrap();
 
@@ -1279,7 +1279,7 @@ mod test {
             FeeRate::from_sat_per_vb_unchecked(1),
             target_amount,
             &drain_script,
-            &mut thread_rng(),
+            &mut rng(),
         );
 
         assert!(matches!(result, Err(InsufficientFunds { .. })));
@@ -1297,7 +1297,7 @@ mod test {
             FeeRate::from_sat_per_vb_unchecked(1000),
             target_amount,
             &drain_script,
-            &mut thread_rng(),
+            &mut rng(),
         );
         assert!(matches!(result, Err(InsufficientFunds { .. })));
     }
@@ -1317,7 +1317,7 @@ mod test {
                 fee_rate,
                 target_amount,
                 &drain_script,
-                &mut thread_rng(),
+                &mut rng(),
             )
             .unwrap();
 
@@ -1346,7 +1346,7 @@ mod test {
                     FeeRate::ZERO,
                     target_amount,
                     &drain_script,
-                    &mut thread_rng(),
+                    &mut rng,
                 )
                 .unwrap();
             assert_eq!(result.selected_amount(), target_amount);
@@ -1515,7 +1515,7 @@ mod test {
             FeeRate::from_sat_per_vb_unchecked(10),
             Amount::from_sat(500_000),
             &drain_script,
-            &mut thread_rng(),
+            &mut rng(),
         );
 
         assert_matches!(
@@ -1542,7 +1542,7 @@ mod test {
             FeeRate::from_sat_per_vb_unchecked(10),
             Amount::from_sat(500_000),
             &drain_script,
-            &mut thread_rng(),
+            &mut rng(),
         );
 
         assert_matches!(
@@ -1565,7 +1565,7 @@ mod test {
             FeeRate::from_sat_per_vb_unchecked(10_000),
             Amount::from_sat(500_000),
             &drain_script,
-            &mut thread_rng(),
+            &mut rng(),
         );
 
         assert_matches!(
@@ -1595,7 +1595,7 @@ mod test {
                 feerate,
                 target_amount,
                 &drain_script,
-                &mut thread_rng(),
+                &mut rng(),
             )
             .unwrap();
         assert_eq!(res.selected_amount(), Amount::from_sat(200_000));
@@ -1652,7 +1652,7 @@ mod test {
                         fee_rate,
                         target_amount,
                         &drain_script,
-                        &mut thread_rng(),
+                        &mut rng(),
                     )
                 }
                 CoinSelectionAlgo::OldestFirst => OldestFirstCoinSelection.coin_select(
@@ -1661,7 +1661,7 @@ mod test {
                     fee_rate,
                     target_amount,
                     &drain_script,
-                    &mut thread_rng(),
+                    &mut rng(),
                 ),
                 CoinSelectionAlgo::LargestFirst => LargestFirstCoinSelection.coin_select(
                     vec![],
@@ -1669,7 +1669,7 @@ mod test {
                     fee_rate,
                     target_amount,
                     &drain_script,
-                    &mut thread_rng(),
+                    &mut rng(),
                 ),
             };
 

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -47,7 +47,7 @@ use miniscript::{
     descriptor::KeyMap,
     psbt::{PsbtExt, PsbtInputExt, PsbtInputSatisfier},
 };
-use rand_core::RngCore;
+use rand::RngCore;
 
 mod changeset;
 pub mod coin_selection;

--- a/wallet/src/wallet/tx_builder.rs
+++ b/wallet/src/wallet/tx_builder.rs
@@ -47,7 +47,7 @@ use bitcoin::{
     absolute, transaction::Version, Amount, FeeRate, OutPoint, ScriptBuf, Sequence, Transaction,
     TxIn, TxOut, Txid, Weight,
 };
-use rand_core::RngCore;
+use rand::RngCore;
 
 use super::coin_selection::CoinSelectionAlgorithm;
 use super::utils::shuffle_slice;
@@ -689,7 +689,7 @@ impl<Cs: CoinSelectionAlgorithm> TxBuilder<'_, Cs> {
     /// or more calls to this method before closing the wallet. See [`Wallet::reveal_next_address`].
     #[cfg(feature = "std")]
     pub fn finish(self) -> Result<Psbt, CreateTxError> {
-        self.finish_with_aux_rand(&mut bitcoin::key::rand::thread_rng())
+        self.finish_with_aux_rand(&mut rand::rng())
     }
 
     /// Finish building the transaction.
@@ -804,7 +804,7 @@ impl TxOrdering {
     /// Uses the thread-local random number generator (rng).
     #[cfg(feature = "std")]
     pub fn sort_tx(&self, tx: &mut Transaction) {
-        self.sort_tx_with_aux_rand(tx, &mut bitcoin::key::rand::thread_rng())
+        self.sort_tx_with_aux_rand(tx, &mut rand::rng())
     }
 
     /// Sort transaction inputs and outputs by [`TxOrdering`] variant.

--- a/wallet/src/wallet/utils.rs
+++ b/wallet/src/wallet/utils.rs
@@ -14,7 +14,7 @@ use bitcoin::{absolute, relative, Amount, Script, Sequence};
 
 use miniscript::{MiniscriptKey, Satisfier, ToPublicKey};
 
-use rand_core::RngCore;
+use rand::RngCore;
 
 /// Trait to check if a value is below the dust limit.
 /// We are performing dust value calculation for a given script public key using rust-bitcoin to
@@ -143,7 +143,7 @@ mod test {
     use crate::bitcoin::{Address, Network, Sequence};
     use alloc::vec::Vec;
     use core::str::FromStr;
-    use rand::{rngs::StdRng, thread_rng, SeedableRng};
+    use rand::{rng, rngs::StdRng, SeedableRng};
 
     #[test]
     fn test_is_dust() {
@@ -210,14 +210,14 @@ mod test {
     #[cfg(feature = "std")]
     fn test_shuffle_slice_empty_vec() {
         let mut test: Vec<u8> = vec![];
-        shuffle_slice(&mut test, &mut thread_rng());
+        shuffle_slice(&mut test, &mut rng());
     }
 
     #[test]
     #[cfg(feature = "std")]
     fn test_shuffle_slice_single_vec() {
         let mut test: Vec<u8> = vec![0];
-        shuffle_slice(&mut test, &mut thread_rng());
+        shuffle_slice(&mut test, &mut rng());
     }
 
     #[test]


### PR DESCRIPTION
Closes #32 (or do we want to keep that open until a new release?)

### Changelog

- Bump `rand` to `0.9.1` and move it out of `dev-dependencies`.
- Remove `rand_core`: only `rand_core` was imported, but then we would use `bitcoin::key::rand`.
- Remove `bitcoin::key::rand::thread_rng()` in favor of `rand::rng()`.
- Rename `thread_rng()` to `rng()`, `gen_range` to `random_range`.
- Import `getrandom` when the target is `wasm32`: it was necessary to create `.cargo/config.toml` as well (for context, see https://github.com/rust-random/rand/issues/886).

### Checklists

#### All Submissions:

* [X] I've signed all my commits
* [X] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [X] I ran `cargo +nightly fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [X] I'm linking the issue being fixed by this PR
