### PR TITLE
deps: Update `bdk_chain` to 0.23.0

### DIFF
--- a/examples/example_wallet_electrum/Cargo.toml
+++ b/examples/example_wallet_electrum/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 
 [dependencies]
 bdk_wallet = { path = "../../wallet", features = ["file_store"] }
-bdk_electrum = { version = "0.22.0" }
+bdk_electrum = { version = "0.23.0" }
 anyhow = "1"

--- a/examples/example_wallet_esplora_async/Cargo.toml
+++ b/examples/example_wallet_esplora_async/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 
 [dependencies]
 bdk_wallet = { path = "../../wallet", features = ["rusqlite"] }
-bdk_esplora = { version = "0.21.0", features = ["async-https", "tokio"] }
+bdk_esplora = { version = "0.22.0", features = ["async-https", "tokio"] }
 tokio = { version = "1.38.1", features = ["rt", "rt-multi-thread", "macros"] }
 anyhow = "1"

--- a/examples/example_wallet_esplora_blocking/Cargo.toml
+++ b/examples/example_wallet_esplora_blocking/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 
 [dependencies]
 bdk_wallet = { path = "../../wallet", features = ["file_store"] }
-bdk_esplora = { version = "0.21.0", features = ["blocking"] }
+bdk_esplora = { version = "0.22.0", features = ["blocking"] }
 anyhow = "1"

--- a/examples/example_wallet_rpc/Cargo.toml
+++ b/examples/example_wallet_rpc/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 bdk_wallet = { path = "../../wallet", features = ["file_store"] }
-bdk_bitcoind_rpc = { version = "0.19.0" }
+bdk_bitcoind_rpc = { version = "0.20.0" }
 
 anyhow = "1"
 clap = { version = "4.5.17", features = ["derive", "env"] }

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -21,11 +21,11 @@ miniscript = { version = "12.3.1", features = [ "serde" ], default-features = fa
 bitcoin = { version = "0.32.4", features = [ "serde", "base64" ], default-features = false }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
-bdk_chain = { version = "0.22.0", features = [ "miniscript", "serde" ], default-features = false }
+bdk_chain = { version = "0.23.0", features = [ "miniscript", "serde" ], default-features = false }
 
 # Optional dependencies
 bip39 = { version = "2.0", optional = true }
-bdk_file_store = { version = "0.20.0", optional = true }
+bdk_file_store = { version = "0.21.0", optional = true }
 
 [features]
 default = ["std"]
@@ -40,7 +40,7 @@ test-utils = ["std"]
 [dev-dependencies]
 assert_matches = "1.5.0"
 tempfile = "3"
-bdk_chain = { version = "0.22.0", features = ["rusqlite"] }
+bdk_chain = { version = "0.23.0", features = ["rusqlite"] }
 bdk_wallet = { path = ".", features = ["rusqlite", "file_store", "test-utils"] }
 anyhow = "1"
 rand = "^0.8"

--- a/wallet/src/wallet/coin_selection.rs
+++ b/wallet/src/wallet/coin_selection.rs
@@ -750,6 +750,7 @@ mod test {
             value,
             index,
             ChainPosition::Unconfirmed {
+                first_seen: Some(last_seen),
                 last_seen: Some(last_seen),
             },
         )
@@ -850,7 +851,10 @@ mod test {
                             transitively: None,
                         }
                     } else {
-                        ChainPosition::Unconfirmed { last_seen: Some(0) }
+                        ChainPosition::Unconfirmed {
+                            first_seen: Some(1),
+                            last_seen: Some(1),
+                        }
                     },
                 }),
             });
@@ -875,7 +879,10 @@ mod test {
                     keychain: KeychainKind::External,
                     is_spent: false,
                     derivation_index: 42,
-                    chain_position: ChainPosition::Unconfirmed { last_seen: Some(0) },
+                    chain_position: ChainPosition::Unconfirmed {
+                        first_seen: Some(1),
+                        last_seen: Some(1),
+                    },
                 }),
             })
             .collect()
@@ -1231,7 +1238,10 @@ mod test {
         optional.push(utxo(
             Amount::from_sat(500_000),
             3,
-            ChainPosition::<ConfirmationBlockTime>::Unconfirmed { last_seen: Some(0) },
+            ChainPosition::<ConfirmationBlockTime>::Unconfirmed {
+                first_seen: Some(1),
+                last_seen: Some(1),
+            },
         ));
 
         // Defensive assertions, for sanity and in case someone changes the test utxos vector.

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -1593,13 +1593,12 @@ impl Wallet {
 
         // recording changes to the change keychain
         if let (Excess::Change { .. }, Some((keychain, index))) = (excess, drain_index) {
-            let (_, index_changeset) = self
-                .indexed_graph
-                .index
-                .reveal_to_target(keychain, index)
-                .expect("must not be None");
-            self.stage.merge(index_changeset.into());
-            self.mark_used(keychain, index);
+            if let Some((_, index_changeset)) =
+                self.indexed_graph.index.reveal_to_target(keychain, index)
+            {
+                self.stage.merge(index_changeset.into());
+                self.mark_used(keychain, index);
+            }
         }
 
         Ok(psbt)

--- a/wallet/src/wallet/params.rs
+++ b/wallet/src/wallet/params.rs
@@ -39,6 +39,7 @@ pub struct CreateParams {
     pub(crate) network: Network,
     pub(crate) genesis_hash: Option<BlockHash>,
     pub(crate) lookahead: u32,
+    pub(crate) use_spk_cache: bool,
 }
 
 impl CreateParams {
@@ -61,6 +62,7 @@ impl CreateParams {
             network: Network::Bitcoin,
             genesis_hash: None,
             lookahead: DEFAULT_LOOKAHEAD,
+            use_spk_cache: false,
         }
     }
 
@@ -82,6 +84,7 @@ impl CreateParams {
             network: Network::Bitcoin,
             genesis_hash: None,
             lookahead: DEFAULT_LOOKAHEAD,
+            use_spk_cache: false,
         }
     }
 
@@ -115,6 +118,15 @@ impl CreateParams {
     /// the default value [`DEFAULT_LOOKAHEAD`] is sufficient.
     pub fn lookahead(mut self, lookahead: u32) -> Self {
         self.lookahead = lookahead;
+        self
+    }
+
+    /// Use a persistent cache of indexed script pubkeys (SPKs).
+    ///
+    /// **Note:** To persist across restarts, this option must also be set at load time with
+    /// [`LoadParams`](LoadParams::use_spk_cache).
+    pub fn use_spk_cache(mut self, use_spk_cache: bool) -> Self {
+        self.use_spk_cache = use_spk_cache;
         self
     }
 
@@ -157,6 +169,7 @@ pub struct LoadParams {
     pub(crate) check_descriptor: Option<Option<DescriptorToExtract>>,
     pub(crate) check_change_descriptor: Option<Option<DescriptorToExtract>>,
     pub(crate) extract_keys: bool,
+    pub(crate) use_spk_cache: bool,
 }
 
 impl LoadParams {
@@ -173,6 +186,7 @@ impl LoadParams {
             check_descriptor: None,
             check_change_descriptor: None,
             extract_keys: false,
+            use_spk_cache: false,
         }
     }
 
@@ -231,6 +245,15 @@ impl LoadParams {
     /// See also [`LoadParams::descriptor`].
     pub fn extract_keys(mut self) -> Self {
         self.extract_keys = true;
+        self
+    }
+
+    /// Use a persistent cache of indexed script pubkeys (SPKs).
+    ///
+    /// **Note:** This should only be used if you have previously persisted a cache of script
+    /// pubkeys using [`CreateParams::use_spk_cache`].
+    pub fn use_spk_cache(mut self, use_spk_cache: bool) -> Self {
+        self.use_spk_cache = use_spk_cache;
         self
     }
 

--- a/wallet/src/wallet/tx_builder.rs
+++ b/wallet/src/wallet/tx_builder.rs
@@ -1024,7 +1024,10 @@ mod test {
                 txout: TxOut::NULL,
                 keychain: KeychainKind::External,
                 is_spent: false,
-                chain_position: chain::ChainPosition::Unconfirmed { last_seen: Some(0) },
+                chain_position: chain::ChainPosition::Unconfirmed {
+                    first_seen: Some(1),
+                    last_seen: Some(1),
+                },
                 derivation_index: 0,
             },
             LocalOutput {


### PR DESCRIPTION
### Description

The PR updates bdk_chain to 0.23.0. Additionally we introduce the ability to persist derived SPKs indexed by descriptor ID and derivation index.

The `CreateParams::use_spk_cache` method enables or disables a persistent cache for script pubkeys (SPKs) derived by the wallet. When enabled, the wallet will store and reuse previously derived SPKs, avoiding redundant derivation on subsequent loads.

When a wallet has many revealed addresses (i.e., many derived SPKs), loading the wallet can become slow if every address must be re-derived from scratch.

By enabling the SPK cache:

- **On wallet creation:** The wallet will persistently store each derived SPK as addresses are revealed.
- **On wallet load:** If `use_spk_cache` is also set in the corresponding `LoadParams`, the wallet will load the cached SPKs directly from storage, skipping the need to re-derive them from the descriptor. This can dramatically reduce load times for wallets with hundreds or thousands of revealed addresses, as the expensive crypto operations are avoided.

**Caveat:**  
Both creation and loading must have `use_spk_cache(true)` set for the cache to be used. If not, the wallet will fall back to deriving SPKs as usual.

fixes #246 
fixes #237 


### Changelog notice

#### Added

- `CreateParams::use_spk_cache`
- `LoadParams::use_spk_cache`

#### Changed

- bump bdk_chain to 0.23.0
- **Note:** This change extends the wallet `ChangeSet` type by adding `first_seen` to the tx_graph member, and adding `spk_cache` to the indexer.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo +nightly fmt` and `cargo clippy` before committing
* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
* [x] This pull request breaks the existing API
* [x] I'm linking the issue being fixed by this PR
