### PR TITLE
feat(signer): merge internal and external signer containers

### DIFF
--- a/wallet/src/wallet/export.rs
+++ b/wallet/src/wallet/export.rs
@@ -119,11 +119,7 @@ impl FullyNodedExport {
     ) -> Result<Self, &'static str> {
         let descriptor = wallet
             .public_descriptor(KeychainKind::External)
-            .to_string_with_secret(
-                &wallet
-                    .get_signers(KeychainKind::External)
-                    .as_key_map(wallet.secp_ctx()),
-            );
+            .to_string_with_secret(&wallet.get_signers().as_key_map(wallet.secp_ctx()));
         let descriptor = remove_checksum(descriptor);
         Self::is_compatible_with_core(&descriptor)?;
 
@@ -147,11 +143,7 @@ impl FullyNodedExport {
         let change_descriptor = {
             let descriptor = wallet
                 .public_descriptor(KeychainKind::Internal)
-                .to_string_with_secret(
-                    &wallet
-                        .get_signers(KeychainKind::Internal)
-                        .as_key_map(wallet.secp_ctx()),
-                );
+                .to_string_with_secret(&wallet.get_signers().as_key_map(wallet.secp_ctx()));
             Some(remove_checksum(descriptor))
         };
 

--- a/wallet/src/wallet/signer.rs
+++ b/wallet/src/wallet/signer.rs
@@ -689,6 +689,15 @@ impl SignersContainer {
 
         container
     }
+
+    /// Extends this container with all signers from another container.
+    /// If a signer with the same key (id and ordering) exists in both containers,
+    /// the one from the other container will overwrite the existing one.
+    pub fn extend(&mut self, other: &SignersContainer) {
+        for (key, signer) in other.0.iter() {
+            self.0.insert(key.clone(), signer.clone());
+        }
+    }
 }
 
 impl SignersContainer {

--- a/wallet/tests/psbt.rs
+++ b/wallet/tests/psbt.rs
@@ -182,7 +182,6 @@ fn test_psbt_multiple_internalkey_signers() {
 
     // Adds a signer for the wrong internal key, bdk should not use this key to sign
     wallet.add_signer(
-        KeychainKind::External,
         // A signerordering lower than 100, bdk will use this signer first
         SignerOrdering(0),
         Arc::new(SignerWrapper::new(

--- a/wallet/tests/wallet.rs
+++ b/wallet/tests/wallet.rs
@@ -259,7 +259,7 @@ fn wallet_load_checks() -> anyhow::Result<()> {
             .expect("db should not fail")
             .expect("wallet was persisted");
         for keychain in [KeychainKind::External, KeychainKind::Internal] {
-            let keymap = wallet.get_signers(keychain).as_key_map(wallet.secp_ctx());
+            let keymap = wallet.get_signers().as_key_map(wallet.secp_ctx());
             assert!(
                 !keymap.is_empty(),
                 "load should populate keymap for keychain {keychain:?}"
@@ -368,10 +368,7 @@ fn single_descriptor_wallet_persist_and_recover() {
         .expect("must have loaded changeset");
     assert_eq!(wallet.derivation_index(KeychainKind::External), Some(2));
     // should have private key
-    assert_eq!(
-        wallet.get_signers(KeychainKind::External).as_key_map(secp),
-        keymap,
-    );
+    assert_eq!(wallet.get_signers().as_key_map(secp), keymap,);
 
     // should error on wrong internal params
     let desc = get_test_wpkh();


### PR DESCRIPTION
Currently BDK stores signers in two separate SignersContainer instances - one for internal keychain and one for external. This separation is unnecessary since:
1. Most signers can sign for both keychains
2. Both containers are always called during signing
3. The separation adds complexity without benefits

This change:
- Adds an `extend` method to SignersContainer to support merging containers
- Keeps a single signer container in Wallet

Closes #186

### Notes to the reviewers

- Looking for a concept ACK to validate that my approach is okay. 
- 3 tests fail with `Incompatible change descriptor`, from the export module. On further investigation, I see that the export node returns the change descriptor as a public key while the derived change descriptor is a private key. I am not sure why this is case and a second review would be great:
```rust
change_descriptor: Some("tr([73c5da0a/86'/0'/0']tprv8fMn4hSKPRC1oaCPqxDb1JWtgkpeiQvZhsr8W2xuy3GEMkzoArcAWTfJxYb6Wj8XNNDWEjfYKK4wGQXh3ZUXhDF2NcnsALpWTeSwarJt7Vc/1/*)")

export.change_descriptor(): Some("tr([73c5da0a/86'/0'/0']tpubDC3pD7UZXnsgh3EBjbtBQiB1FnLask7UHBSunZ1DPK4dCFFZoFRkgxHB8gt42FvLzx1DpxfHWxAsYaY6b643RVcGjDxXxns7wKKYnnfEcbB/1/*)")
```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo +nightly fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
