### PR TITLE
feat!: Persist utxo lock status

### DIFF
--- a/wallet/src/wallet/changeset.rs
+++ b/wallet/src/wallet/changeset.rs
@@ -1,11 +1,16 @@
+use alloc::collections::BTreeMap;
+
 use bdk_chain::{
     indexed_tx_graph, keychain_txout, local_chain, tx_graph, ConfirmationBlockTime, Merge,
 };
+use bitcoin::{OutPoint, Txid};
 use miniscript::{Descriptor, DescriptorPublicKey};
 use serde::{Deserialize, Serialize};
 
 type IndexedTxGraphChangeSet =
     indexed_tx_graph::ChangeSet<ConfirmationBlockTime, keychain_txout::ChangeSet>;
+
+use crate::UtxoInfo;
 
 /// A change set for [`Wallet`]
 ///
@@ -114,6 +119,8 @@ pub struct ChangeSet {
     pub tx_graph: tx_graph::ChangeSet<ConfirmationBlockTime>,
     /// Changes to [`KeychainTxOutIndex`](keychain_txout::KeychainTxOutIndex).
     pub indexer: keychain_txout::ChangeSet,
+    /// Changes to utxo info.
+    pub utxo_info: BTreeMap<OutPoint, UtxoInfo>,
 }
 
 impl Merge for ChangeSet {
@@ -142,6 +149,11 @@ impl Merge for ChangeSet {
             self.network = other.network;
         }
 
+        // To merge utxo_info we just extend the existing collection. If there's
+        // an existing entry for a given outpoint, then it is overwritten by the
+        // new utxo info.
+        self.utxo_info.extend(other.utxo_info);
+
         Merge::merge(&mut self.local_chain, other.local_chain);
         Merge::merge(&mut self.tx_graph, other.tx_graph);
         Merge::merge(&mut self.indexer, other.indexer);
@@ -154,6 +166,7 @@ impl Merge for ChangeSet {
             && self.local_chain.is_empty()
             && self.tx_graph.is_empty()
             && self.indexer.is_empty()
+            && self.utxo_info.is_empty()
     }
 }
 
@@ -163,6 +176,8 @@ impl ChangeSet {
     pub const WALLET_SCHEMA_NAME: &'static str = "bdk_wallet";
     /// Name of table to store wallet descriptors and network.
     pub const WALLET_TABLE_NAME: &'static str = "bdk_wallet";
+    /// Name of table to store wallet utxo info.
+    pub const WALLET_UTXO_TABLE_NAME: &'static str = "bdk_wallet_utxo_info";
 
     /// Get v0 sqlite [ChangeSet] schema
     pub fn schema_v0() -> alloc::string::String {
@@ -177,12 +192,25 @@ impl ChangeSet {
         )
     }
 
+    /// Get v1 sqlite [ChangeSet] schema. Schema v1 adds a table for wallet UTXO info.
+    pub fn schema_v1() -> alloc::string::String {
+        format!(
+            "CREATE TABLE {} ( \
+                txid TEXT NOT NULL, \
+                vout INTEGER NOT NULL, \
+                is_locked INTEGER, \
+                PRIMARY KEY(txid, vout) \
+                ) STRICT;",
+            Self::WALLET_UTXO_TABLE_NAME,
+        )
+    }
+
     /// Initialize sqlite tables for wallet tables.
     pub fn init_sqlite_tables(db_tx: &chain::rusqlite::Transaction) -> chain::rusqlite::Result<()> {
         crate::rusqlite_impl::migrate_schema(
             db_tx,
             Self::WALLET_SCHEMA_NAME,
-            &[&Self::schema_v0()],
+            &[&Self::schema_v0(), &Self::schema_v1()],
         )?;
 
         bdk_chain::local_chain::ChangeSet::init_sqlite_tables(db_tx)?;
@@ -218,6 +246,27 @@ impl ChangeSet {
             changeset.descriptor = desc.map(Impl::into_inner);
             changeset.change_descriptor = change_desc.map(Impl::into_inner);
             changeset.network = network.map(Impl::into_inner);
+        }
+
+        // Load utxo info.
+        let mut stmt = db_tx.prepare(&format!(
+            "SELECT txid, vout, is_locked FROM {}",
+            Self::WALLET_UTXO_TABLE_NAME,
+        ))?;
+        let rows = stmt.query_map([], |row| {
+            Ok((
+                row.get::<_, Impl<Txid>>("txid")?,
+                row.get::<_, u32>("vout")?,
+                row.get::<_, bool>("is_locked")?,
+            ))
+        })?;
+        for row in rows {
+            let (Impl(txid), vout, is_locked) = row?;
+            let utxo_info = UtxoInfo {
+                outpoint: OutPoint::new(txid, vout),
+                is_locked,
+            };
+            changeset.utxo_info.insert(utxo_info.outpoint, utxo_info);
         }
 
         changeset.local_chain = local_chain::ChangeSet::from_sqlite(db_tx)?;
@@ -265,6 +314,20 @@ impl ChangeSet {
             network_statement.execute(named_params! {
                 ":id": 0,
                 ":network": Impl(network),
+            })?;
+        }
+
+        // Persist utxo info.
+        let mut stmt = db_tx.prepare_cached(&format!(
+            "INSERT INTO {}(txid, vout, is_locked) VALUES(:txid, :vout, :is_locked) ON CONFLICT DO UPDATE SET is_locked = :is_locked",
+            Self::WALLET_UTXO_TABLE_NAME,
+        ))?;
+        for (&outpoint, utxo_info) in &self.utxo_info {
+            let OutPoint { txid, vout } = outpoint;
+            stmt.execute(named_params! {
+                ":txid": Impl(txid),
+                ":vout": vout,
+                ":is_locked": utxo_info.is_locked,
             })?;
         }
 

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -109,6 +109,7 @@ pub struct Wallet {
     stage: ChangeSet,
     network: Network,
     secp: SecpCtx,
+    utxo_info: BTreeMap<OutPoint, UtxoInfo>,
 }
 
 /// An update to [`Wallet`].
@@ -449,6 +450,7 @@ impl Wallet {
         let change_descriptor = index.get_descriptor(KeychainKind::Internal).cloned();
         let indexed_graph = IndexedTxGraph::new(index);
         let indexed_graph_changeset = indexed_graph.initial_changeset();
+        let utxo_info = BTreeMap::new();
 
         let stage = ChangeSet {
             descriptor,
@@ -457,6 +459,7 @@ impl Wallet {
             tx_graph: indexed_graph_changeset.tx_graph,
             indexer: indexed_graph_changeset.indexer,
             network: Some(network),
+            ..Default::default()
         };
 
         Ok(Wallet {
@@ -467,6 +470,7 @@ impl Wallet {
             indexed_graph,
             stage,
             secp,
+            utxo_info,
         })
     }
 
@@ -653,10 +657,11 @@ impl Wallet {
         let mut indexed_graph = IndexedTxGraph::new(index);
         indexed_graph.apply_changeset(changeset.indexer.into());
         indexed_graph.apply_changeset(changeset.tx_graph.into());
+        let utxo_info = BTreeMap::new();
 
         let stage = ChangeSet::default();
 
-        Ok(Some(Wallet {
+        let mut wallet = Wallet {
             signers,
             change_signers,
             chain,
@@ -664,7 +669,27 @@ impl Wallet {
             stage,
             network,
             secp,
-        }))
+            utxo_info,
+        };
+
+        // Apply lock status to wallet utxos.
+        wallet.utxo_info = wallet
+            .list_unspent()
+            .map(|output| {
+                (
+                    output.outpoint,
+                    UtxoInfo {
+                        outpoint: output.outpoint,
+                        is_locked: false,
+                    },
+                )
+            })
+            .collect();
+        for (outpoint, utxo_info) in changeset.utxo_info {
+            wallet.utxo_info.insert(outpoint, utxo_info);
+        }
+
+        Ok(Some(wallet))
     }
 
     /// Get the Bitcoin network the wallet is using.
@@ -2110,6 +2135,8 @@ impl Wallet {
                     CanonicalizationParams::default(),
                     self.indexed_graph.index.outpoints().iter().cloned(),
                 )
+                // Filter out locked utxos
+                .filter(|(_, txo)| self.is_utxo_locked(txo.outpoint) != Some(true))
                 // only create LocalOutput if UTxO is mature
                 .filter_map(move |((k, i), full_txo)| {
                     full_txo
@@ -2377,6 +2404,84 @@ impl Wallet {
         &self.chain
     }
 
+    /// Is UTXO locked. `None` if the outpoint isn't found in `self.utxo_info`.
+    pub fn is_utxo_locked(&self, outpoint: OutPoint) -> Option<bool> {
+        Some(self.utxo_info.get(&outpoint)?.is_locked)
+    }
+
+    /// Lock an unspent output by `outpoint`.
+    ///
+    /// Locked utxos are automatically filtered out during coin selection. You need to persist
+    /// the wallet in order for the lock status to persist across restarts. To unlock a previously
+    /// locked outpoint, see [`Wallet::unlock_unspent`].
+    pub fn lock_unspent(&mut self, outpoint: OutPoint) {
+        use alloc::collections::btree_map;
+        let lock_value = true;
+
+        // If the utxo is not currently locked, update the lock value
+        // and stage the change.
+        let is_changed = match self.utxo_info.entry(outpoint) {
+            btree_map::Entry::Occupied(mut e) => {
+                let mut is_changed = false;
+
+                let utxo = e.get_mut();
+
+                if !utxo.is_locked {
+                    utxo.is_locked = lock_value;
+                    is_changed = true;
+                }
+
+                is_changed
+            }
+            btree_map::Entry::Vacant(e) => {
+                e.insert(UtxoInfo {
+                    outpoint,
+                    is_locked: lock_value,
+                });
+                true
+            }
+        };
+
+        if is_changed {
+            let utxo_info = UtxoInfo {
+                outpoint,
+                is_locked: lock_value,
+            };
+            self.stage.merge(ChangeSet {
+                utxo_info: [(outpoint, utxo_info)].into(),
+                ..Default::default()
+            });
+        }
+    }
+
+    /// Unlock unspent.
+    pub fn unlock_unspent(&mut self, outpoint: OutPoint) {
+        use alloc::collections::btree_map;
+        let lock_value = false;
+
+        match self.utxo_info.entry(outpoint) {
+            btree_map::Entry::Occupied(mut e) => {
+                let utxo = e.get_mut();
+
+                // If the utxo is currently locked, update the lock value and stage
+                // the change.
+                if utxo.is_locked {
+                    utxo.is_locked = lock_value;
+                    let utxo_info = UtxoInfo {
+                        outpoint,
+                        is_locked: lock_value,
+                    };
+                    self.stage.merge(ChangeSet {
+                        utxo_info: [(outpoint, utxo_info)].into(),
+                        ..Default::default()
+                    });
+                }
+            }
+            // If there is no entry, we're done because the utxo can't be locked.
+            btree_map::Entry::Vacant(..) => {}
+        }
+    }
+
     /// Introduces a `block` of `height` to the wallet, and tries to connect it to the
     /// `prev_blockhash` of the block's header.
     ///
@@ -2578,6 +2683,16 @@ impl AsRef<bdk_chain::tx_graph::TxGraph<ConfirmationBlockTime>> for Wallet {
     fn as_ref(&self) -> &bdk_chain::tx_graph::TxGraph<ConfirmationBlockTime> {
         self.indexed_graph.graph()
     }
+}
+
+/// Information about a wallet UTXO.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
+pub struct UtxoInfo {
+    /// Outpoint.
+    pub outpoint: bitcoin::OutPoint,
+    /// Whether the outpoint is locked by the user. This doesn't take into account
+    /// any timelocks that may be part of the actual scriptPubKey.
+    pub is_locked: bool,
 }
 
 /// Deterministically generate a unique name given the descriptors defining the wallet

--- a/wallet/tests/wallet.rs
+++ b/wallet/tests/wallet.rs
@@ -9,6 +9,7 @@ use bdk_chain::{
     keychain_txout::DEFAULT_LOOKAHEAD, BlockId, CanonicalizationParams, ChainPosition,
     ConfirmationBlockTime, DescriptorExt,
 };
+use bdk_wallet::coin_selection::InsufficientFunds;
 use bdk_wallet::coin_selection::{self, LargestFirstCoinSelection};
 use bdk_wallet::descriptor::{calc_checksum, DescriptorError, IntoWalletDescriptor};
 use bdk_wallet::error::CreateTxError;
@@ -51,6 +52,90 @@ const P2WPKH_FAKE_SIG_SIZE: usize = 72;
 const P2PKH_FAKE_SCRIPT_SIG_SIZE: usize = 107;
 
 const DB_MAGIC: &[u8] = &[0x21, 0x24, 0x48];
+
+#[test]
+fn test_lock_unspent_persist() -> anyhow::Result<()> {
+    use bdk_chain::rusqlite;
+    let mut conn = rusqlite::Connection::open_in_memory()?;
+
+    let (desc, change_desc) = get_test_tr_single_sig_xprv_and_change_desc();
+    let mut wallet = Wallet::create(desc, change_desc)
+        .network(Network::Signet)
+        .create_wallet(&mut conn)?;
+
+    // Receive coins.
+    for i in 0..3 {
+        let _ = receive_output(&mut wallet, Amount::from_sat(10_000), ReceiveTo::Mempool(i));
+    }
+
+    // Test 1: lock utxos
+    let unspent = wallet.list_unspent().collect::<Vec<_>>();
+    assert!(!unspent.is_empty());
+    for utxo in unspent {
+        wallet.lock_unspent(utxo.outpoint);
+        assert!(
+            wallet
+                .is_utxo_locked(utxo.outpoint)
+                .expect("should have utxo info"),
+            "Expect lock value = true"
+        );
+    }
+    wallet.persist(&mut conn)?;
+
+    // Test 2: The lock value is persistent
+    {
+        wallet = Wallet::load()
+            .load_wallet(&mut conn)?
+            .expect("wallet is persisted");
+
+        let unspent = wallet.list_unspent().collect::<Vec<_>>();
+        assert!(!unspent.is_empty());
+        for utxo in unspent {
+            assert!(
+                wallet
+                    .is_utxo_locked(utxo.outpoint)
+                    .expect("should have utxo info"),
+                "Expect recover lock value"
+            );
+        }
+
+        // Test 3: Locked utxos are excluded from coin selection
+        let addr = wallet.next_unused_address(KeychainKind::External).address;
+        let mut tx_builder = wallet.build_tx();
+        tx_builder.add_recipient(addr, Amount::from_sat(10_000));
+        let res = tx_builder.finish();
+        assert!(
+            matches!(
+                res,
+                Err(CreateTxError::CoinSelection(InsufficientFunds {
+                    available: Amount::ZERO,
+                    ..
+                })),
+            ),
+            "Locked utxos should not be selected",
+        );
+    }
+
+    // Test 4: Unlock utxos
+    {
+        wallet = Wallet::load()
+            .load_wallet(&mut conn)?
+            .expect("wallet is persisted");
+
+        let unspent = wallet.list_unspent().collect::<Vec<_>>();
+        for utxo in unspent {
+            wallet.unlock_unspent(utxo.outpoint);
+            assert!(
+                !wallet
+                    .is_utxo_locked(utxo.outpoint)
+                    .expect("should have utxo info"),
+                "Expect lock value = false"
+            );
+        }
+    }
+
+    Ok(())
+}
 
 #[test]
 fn wallet_is_persisted() -> anyhow::Result<()> {


### PR DESCRIPTION
### Description

Added `Wallet::lock_unspent`, `unlock_unspent`, and updated the wallet `ChangeSet` to persist information about wallet UTXOs including the lock status of an outpoint.

may resolve #166.


### Notes to the reviewers


### Changelog notice


### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo +nightly fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature

#### Bugfixes:

* [x] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
