### PR TITLE
TxBuilder should not change order of insertion

### DIFF
--- a/wallet/src/wallet/tx_builder.rs
+++ b/wallet/src/wallet/tx_builder.rs
@@ -276,6 +276,8 @@ impl<'a, Cs> TxBuilder<'a, Cs> {
     ///
     /// These have priority over the "unspendable" utxos, meaning that if a utxo is present both in
     /// the "utxos" and the "unspendable" list, it will be spent.
+    ///
+    /// If a UTxO is inserted multiple times, only the final insertion will take effect.
     pub fn add_utxos(&mut self, outpoints: &[OutPoint]) -> Result<&mut Self, AddUtxoError> {
         let order_max = self
             .params
@@ -323,6 +325,10 @@ impl<'a, Cs> TxBuilder<'a, Cs> {
     }
 
     /// Add a foreign UTXO i.e. a UTXO not known by this wallet.
+    ///
+    /// Foreign UTxOs do not take priority over local UTxOs. If a local UTxO is added to the
+    /// manually selected list, it will replace any conflicting foreign UTxOs. However, a foreign
+    /// UTxO cannot replace a conflicting local UTxO.
     ///
     /// There might be cases where the UTxO belongs to the wallet but it doesn't have knowledge of
     /// it. This is possible if the wallet is not synced or its not being use to track

--- a/wallet/tests/wallet.rs
+++ b/wallet/tests/wallet.rs
@@ -4699,3 +4699,73 @@ fn test_tx_details_method() {
     let tx_details_2_option = test_wallet.tx_details(txid_2);
     assert!(tx_details_2_option.is_none());
 }
+
+#[test]
+fn test_tx_ordering_untouched_preserves_insertion_ordering() {
+    let (mut wallet, txid) = get_funded_wallet_wpkh();
+    let script_pubkey = wallet
+        .next_unused_address(KeychainKind::External)
+        .address
+        .script_pubkey();
+    let tx1 = Transaction {
+        input: vec![TxIn {
+            previous_output: OutPoint { txid, vout: 0 },
+            ..Default::default()
+        }],
+        output: vec![
+            TxOut {
+                value: Amount::from_sat(500),
+                script_pubkey: script_pubkey.clone(),
+            };
+            4
+        ],
+        ..new_tx(0)
+    };
+
+    let txid1 = tx1.compute_txid();
+    insert_tx(&mut wallet, tx1);
+    insert_anchor(
+        &mut wallet,
+        txid1,
+        ConfirmationBlockTime {
+            block_id: BlockId {
+                height: 2_100,
+                hash: BlockHash::all_zeros(),
+            },
+            confirmation_time: 300,
+        },
+    );
+    let utxos = wallet
+        .list_unspent()
+        .map(|o| o.outpoint)
+        .take(2)
+        .collect::<Vec<_>>();
+
+    let mut builder = wallet.build_tx();
+    builder
+        .ordering(bdk_wallet::TxOrdering::Untouched)
+        .add_utxos(&utxos)
+        .unwrap()
+        .add_recipient(script_pubkey.clone(), Amount::from_sat(400))
+        .add_recipient(script_pubkey.clone(), Amount::from_sat(300))
+        .add_recipient(script_pubkey.clone(), Amount::from_sat(500));
+    let tx = builder.finish().unwrap().unsigned_tx;
+    let txins = tx
+        .input
+        .iter()
+        .take(2) // First two UTxOs should be manually selected and sorted by insertion
+        .map(|txin| txin.previous_output)
+        .collect::<Vec<_>>();
+
+    assert!(txins == utxos);
+
+    let txouts = tx
+        .output
+        .iter()
+        .take(3) // Exclude possible change output
+        .map(|txout| txout.value.to_sat())
+        .collect::<Vec<_>>();
+
+    // Check vout is sorted by recipient insertion order
+    assert!(txouts == vec![400, 300, 500]);
+}


### PR DESCRIPTION
### Description

On my attempt to fix bitcoindevkit/bdk#1794 in bitcoindevkit/bdk#1798, I broke the assumption that insertion order is preserved when `TxBuilder::ordering` is `TxOrdering::Untouched`. Some users are relying in this assumption so here I'm trying to restore it back, without adding a new dependency for this single use case like #252 , and trying to not redesign the `TxBuilder::utxos` interface again.

However, I'm open to do that if there are strong reasons for it. Opening as Draft to gather opinions.

Fixes #244

cc: @eauxxs

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

No public APIs are changed by these commits.

### Checklists

> [!IMPORTANT]
> This pull request **DOES NOT** break the existing API
* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo +nightly fmt` and `cargo clippy` before committing
* [x] I've added tests for the new code
* [x] I've expanded docs addressing new code
* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR