### PR TITLE
Preserve insertion order of manually selected utxos if `TxOrdering::Untouched`

### DIFF
--- a/wallet/src/wallet/tx_builder.rs
+++ b/wallet/src/wallet/tx_builder.rs
@@ -276,6 +276,8 @@ impl<'a, Cs> TxBuilder<'a, Cs> {
     ///
     /// These have priority over the "unspendable" UTXOs, meaning that if a UTXO is present both in
     /// the "UTXOs" and the "unspendable" list, it will be spent.
+    ///
+    /// If a UTXO is inserted multiple times, only the final insertion will take effect.
     pub fn add_utxos(&mut self, outpoints: &[OutPoint]) -> Result<&mut Self, AddUtxoError> {
         // Canonicalize once, instead of once for every call to `get_utxo`.
         let unspent: HashMap<OutPoint, LocalOutput> = self
@@ -326,6 +328,10 @@ impl<'a, Cs> TxBuilder<'a, Cs> {
     }
 
     /// Add a foreign UTXO i.e. a UTXO not known by this wallet.
+    ///
+    /// Foreign UTXOs are not prioritized over local UTXOs. If a local UTXO is added to the
+    /// manually selected list, it will replace any conflicting foreign UTXOs. However, a foreign
+    /// UTXO cannot replace a conflicting local UTXO.
     ///
     /// There might be cases where the UTXO belongs to the wallet but it doesn't have knowledge of
     /// it. This is possible if the wallet is not synced or its not being use to track


### PR DESCRIPTION
### Description

On my attempt to fix bitcoindevkit/bdk#1794 in bitcoindevkit/bdk#1798, I broke the assumption that insertion order is preserved when `TxBuilder::ordering` is `TxOrdering::Untouched`. Some users are relying in this assumption, so here I'm trying to restore it back, without adding a new dependency for this single use case like #252, or creating a new struct just to track this.

In this fourth alternative solution I'm going back to use `Vec` to store the manually selected UTxOs.

I was reluctant to do it in this way because `HashMap` seems a better solution giving its property of avoiding duplicates, but as we also want to keep the secuential nature of the insertion of UTxOs in `TxBuilder`, here is an alternative aligned with that principle. 

May replace #252 
May replace #261 .
Fixes #244

### Notes to the reviewers

Also, as I was working on this, I came back to the following tests:
- `test_prexisting_foreign_utxo_have_no_precedence_over_local_utxo_with_same_outpoint`
- `test_prexisting_local_utxo_have_precedence_over_foreign_utxo_with_same_outpoint`

Motivated during the implementation and review of bitcoindevkit/bdk#1798.

Which required the underlying structure to also hold the properties of no duplication for manually selected UTxOs, as the structures were accessed directly for these cases.

The test tries to cover the case when there are two wallets using the same descriptor, one tracks transactions and the other does not. The first passes UTxOs belonging to the second one and this one creates transactions using the `add_foreign_utxo` interface.
In this case it was expected for any `LocalUtxo` of the offline wallet to supersede any conflicting foreign UTxO. But, the simulation of this case went against the borrowing constraints of rust.
By how costly was to reproduce this behavior for me in the tests, I would like to have second opinions in the feasibility of the test case.

### Changelog notice

No public APIs are changed by these commits.

### Checklists

> [!IMPORTANT]
> This pull request **DOES NOT** break the existing API
* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo +nightly fmt` and `cargo clippy` before committing
* [x] I've added tests for the new code
* [x] I've expanded docs addressing new code
* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR