### PR TITLE
Bump `bitcoin` dependency requirement to v0.32.6 to reflect used API

### DIFF
--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -18,7 +18,7 @@ workspace = true
 [dependencies]
 rand_core = { version = "0.6.0" }
 miniscript = { version = "12.3.1", features = [ "serde" ], default-features = false }
-bitcoin = { version = "0.32.4", features = [ "serde", "base64" ], default-features = false }
+bitcoin = { version = "0.32.6", features = [ "serde", "base64" ], default-features = false }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
 bdk_chain = { version = "0.23.0", features = [ "miniscript", "serde" ], default-features = false }


### PR DESCRIPTION
### Description

Starting with commit `f6fd9853e`, `bdk_wallet` makes use of `bitcoin::key::TweakedKeyPair::to_keypair` which was introduced with v0.32.6. Here, we adjust the minimum API requirement in `Cargo.toml`, as BDK 2.0.0 builds could otherwise fail with:

```
error[E0599]: no method named `to_keypair` found for struct `TweakedKeypair` in the current scope
   --> /home/tnull/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bdk_wallet-2.0.0/src/wallet/signer.rs:580:14
    |
578 |           None => keypair
    |  _________________-
579 | |             .tap_tweak(secp, psbt_input.tap_merkle_root)
580 | |             .to_keypair(),
    | |             -^^^^^^^^^^ method not found in `TweakedKeypair`
    | |_____________|
    |

For more information about this error, try `rustc --explain E0599`.
```