### PR TITLE
feat: add `justfile`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,7 +20,7 @@ of the PR were done in a specific way -->
 
 * [ ] I've signed all my commits
 * [ ] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
-* [ ] I ran `cargo +nightly fmt` and `cargo clippy` before committing
+* [ ] I ran `just p` before pushing
 
 #### New Features:
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ It is built upon the excellent [`rust-bitcoin`] and [`rust-miniscript`] crates.
 There is currently only one published crate in this repository:
 
 - [`wallet`](./wallet): Contains the central high level `Wallet` type that is built from the low-level mechanisms provided by the other components.
-  
+
 Crates that `bdk_wallet` depends on are found in the [`bdk`] repository.
 
 Fully working examples of how to use these components are in `/examples`:
@@ -54,6 +54,12 @@ Fully working examples of how to use these components are in `/examples`:
 The libraries in this repository maintain a MSRV of 1.63.0.
 
 To build with the MSRV of 1.63.0 you will need to pin dependencies by running the [`pin-msrv.sh`](./ci/pin-msrv.sh) script.
+
+## Just
+
+This project has a [`justfile`](/justfile) for easy command running. You must have [`just`](https://github.com/casey/just) installed.
+
+To see a list of available recipes: `just -l`
 
 ## License
 

--- a/justfile
+++ b/justfile
@@ -1,0 +1,29 @@
+alias b := build
+alias c := check
+alias f := fmt
+alias t := test
+alias p := pre-push
+
+# Build the project
+build:
+   cargo build
+
+# Check code: formatting, compilation, linting, and commit signature
+check:
+   cargo +nightly fmt --all -- --check
+   cargo check --workspace --exclude 'example_*' --all-features
+   cargo clippy --all-features --all-targets -- -D warnings
+   @[ "$(git log --pretty='format:%G?' -1 HEAD)" = "N" ] && \
+       echo "\n⚠️  Unsigned commit: BDK requires that commits be signed." || \
+       true
+
+# Format all code
+fmt:
+   cargo +nightly fmt
+
+# Run all tests on the workspace with all features
+test:
+   cargo test --workspace --exclude 'example_*' --all-features
+
+# Run pre-push suite: format, check, and test
+pre-push: fmt check test


### PR DESCRIPTION
### Description

Closes #240.

This PR adds a `justfile`, updates the PR template to use it, and adds a section on the `README.md` to show available recipes.

These are the implemented recipes:
```justfile
alias b := build
alias c := check
alias f := fmt
alias t := test
alias p := pre-push

build:
    cargo build

check:
    cargo +nightly fmt --all -- --check
    cargo check --workspace --exclude 'example_*' --all-features
    cargo clippy --all-features --all-targets -- -D warnings
    @[ "$(git log --pretty='format:%G?' -1 HEAD)" = "N" ] && \
        echo "\n⚠️  Unsigned commit: BDK requires that commits be signed." || \
        true

fmt:
    cargo +nightly fmt

test:
    cargo test --workspace --exclude 'example_*' --all-features

pre-push: fmt check test
```

`check` will verify if `HEAD` was signed and echo that warning if not. It does not check all commits, but I think that checking only the last is a pretty good heuristic (who only signs the last commit?).

Before pushing, one only needs to run `just p`.

### Checklists

#### All Submissions:

* [X] I've signed all my commits
* [X] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [X] I ran `just p` before pushing