### PR TITLE
Multipath descriptor support (BIP 389)

### DIFF
--- a/wallet/src/descriptor/error.rs
+++ b/wallet/src/descriptor/error.rs
@@ -21,7 +21,8 @@ pub enum Error {
     InvalidDescriptorChecksum,
     /// The descriptor contains hardened derivation steps on public extended keys
     HardenedDerivationXpub,
-    /// The descriptor contains multipath keys
+    /// The descriptor contains multipath keys with an invalid number of paths (must have exactly 2
+    /// paths for receive and change)
     MultiPath,
     /// Error thrown while working with [`keys`](crate::keys)
     Key(crate::keys::KeyError),
@@ -68,7 +69,7 @@ impl fmt::Display for Error {
             ),
             Self::MultiPath => write!(
                 f,
-                "The descriptor contains multipath keys, which are not supported yet"
+                "The descriptor contains multipath keys with invalid number of paths (must have exactly 2 paths for receive and change)"
             ),
             Self::Key(err) => write!(f, "Key error: {}", err),
             Self::Policy(err) => write!(f, "Policy error: {}", err),

--- a/wallet/src/wallet/params.rs
+++ b/wallet/src/wallet/params.rs
@@ -28,7 +28,7 @@ where
 
         let descriptors = desc
             .into_single_descriptors()
-            .map_err(|_| DescriptorError::MultiPath)?;
+            .map_err(DescriptorError::Miniscript)?;
 
         if descriptors.len() != 2 {
             return Err(DescriptorError::MultiPath);


### PR DESCRIPTION
### Description

#### Key Features:
  - New API: `Wallet::create_multipath(descriptor)` following the same pattern as `create()` and `create_single()`
  - [BIP 389](https://github.com/bitcoin/bips/blob/master/bip-0389.mediawiki) compliance with exactly 2-path validation (receive and change)
  - Robust validation with clear error messages
  - Pattern consistency with existing wallet creation methods

 #### Usage Example:
  
```rust
let multipath_desc = "wpkh([9a6a2580/84'/1'/0']tpub.../‹0;1›/*)";
let wallet = Wallet::create_multipath(multipath_desc)
      .network(Network::Testnet)
      .create_wallet_no_persist()?;

// Automatically creates separate receive and change descriptors
let receive_addr = wallet.peek_address(KeychainKind::External, 0);  // Uses path /0/*
let change_addr = wallet.peek_address(KeychainKind::Internal, 0);   // Uses path /1/*
```

### Notes to the reviewers

#### Design Decisions:
  1. Pattern Consistency: Uses `make_multipath_descriptor_to_extract()` helper following the same pattern as existing `make_descriptor_to_extract()` function
  2. Lazy Evaluation: Descriptor parsing only happens when needed during wallet creation, not during parameter setup - this maintains performance and follows Rust's lazy evaluation patterns
  3. Strict Validation: Only allows exactly 2-path multipath descriptors to ensure proper receive/change separation
  4. API Consistency: The `create_multipath()` method returns `CreateParams` just like `create()` and `create_single()`, maintaining the fluent builder pattern

#### Implementation Notes:
  - The function calls `make_multipath_descriptor_to_extract()` twice (once for receive, once for change) which is intentional and follows the established pattern of lazy evaluation
  - Validation occurs in the descriptor extraction closures, providing clear error messages when descriptors are actually processed
  - All existing functionality remains unchanged - this is a purely additive feature

### Changelog notice

Added:
  - `Wallet::create_multipath()` method for creating wallets from BIP 389 multipath descriptors
  - `CreateParams::new_multipath()` for multipath descriptor parameter creation
  - Support for 2-path multipath descriptors with automatic receive/change separation
  - Enhanced validation for multipath descriptors with descriptive error messages
  
### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `just p` before pushing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR

Closes #11