### PR TITLE
ci: add `cargo mutants` weekly job

### DIFF
--- a/.github/workflows/cron_cargo_mutants.yml
+++ b/.github/workflows/cron_cargo_mutants.yml
@@ -1,0 +1,49 @@
+name: Weekly cargo-mutants
+
+permissions: {}
+
+on:
+  schedule:
+    - cron: "0 0 * * 0" # runs weekly on Sunday at 00:00
+  workflow_dispatch: # allows manual triggering
+
+jobs:
+  cargo-mutants:
+    name: Cargo Mutants
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: taiki-e/install-action@2383334cf567d78771fc7d89b6b3802ef1412cf6
+        with:
+          tool: cargo-mutants
+      - run: cargo mutants --in-place --no-shuffle
+      - uses: actions/upload-artifact@v4
+        with:
+          name: mutants.out
+          path: mutants.out
+      - name: Check for new mutants
+        if: always()
+        run: |
+          if [ -s mutants.out/missed.txt ]; then
+            echo "New missed mutants found"
+            MUTANTS_VERSION=$(cargo mutants --version)
+            gh issue create \
+            --title "cargo-mutants: new mutants found" \
+            --body "$(cat <<EOF
+          Displaying up to the first 10 mutants:
+          \`\`\`
+          $(head -n 10 mutants.out/missed.txt)
+          \`\`\`
+          Running cargo mutants version: ${MUTANTS_VERSION}
+          For the complete list, please check the [mutants.out artifact](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+          EOF
+          )"
+            echo "create_issue=true" >> $GITHUB_ENV
+          else
+            echo "No new mutants found"
+            echo "create_issue=false" >> $GITHUB_ENV
+          fi
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/justfile
+++ b/justfile
@@ -3,6 +3,7 @@ alias c := check
 alias f := fmt
 alias t := test
 alias p := pre-push
+alias m := mutants
 
 # Build the project
 build:
@@ -27,3 +28,7 @@ test:
 
 # Run pre-push suite: format, check, and test
 pre-push: fmt check test
+
+# Run `cargo-mutants` for mutation testing
+mutants:
+   cargo mutants --in-place --no-shuffle


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

I think it's also a good idea to adopt mutation testing to `bdk_wallet` and other crates in our ecosystem. It can be achieved through the usage of [`cargo mutants`](https://github.com/sourcefrog/cargo-mutants). It's already adopted by Bitcoin Core and Rust Bitcoin, and you can find more about the rational [here](https://mutants.rs/how-it-works.html).

This PR adds a new CI job following the rust-bitcoin's weekly job, and opens an issue reporting the mutants found, if any.

It can be run on a PR basis, but as it can be slow to run, I don't think we should adopt that now, but fine-tuning to only mutate within each PR changes can be done in the future.

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

As it's the first time running `cargo mutants` on the crate, it's quite slow and time-consuming to run. Since no custom `re` exclusion is being used yet, you'll notice this if you try to run it locally.

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `just p` before pushing

#### New Features:

* [x] I've added tests for the new feature
* [ ] I've added docs for the new feature
