### PR TITLE
clippy!: `Box` large enum variants

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,4 +1,1 @@
-# TODO fix, see: https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant
-enum-variant-size-threshold = 1032
-# TODO fix, see: https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err
-large-error-threshold = 993
+msrv = "1.63.0"

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -227,9 +227,9 @@ pub enum LoadMismatch {
         /// Keychain identifying the descriptor.
         keychain: KeychainKind,
         /// The loaded descriptor.
-        loaded: Option<ExtendedDescriptor>,
+        loaded: Option<Box<ExtendedDescriptor>>,
         /// The expected descriptor.
-        expected: Option<ExtendedDescriptor>,
+        expected: Option<Box<ExtendedDescriptor>>,
     },
 }
 
@@ -565,8 +565,8 @@ impl Wallet {
                 if descriptor.descriptor_id() != exp_desc.descriptor_id() {
                     return Err(LoadError::Mismatch(LoadMismatch::Descriptor {
                         keychain: KeychainKind::External,
-                        loaded: Some(descriptor),
-                        expected: Some(exp_desc),
+                        loaded: Some(Box::new(descriptor)),
+                        expected: Some(Box::new(exp_desc)),
                     }));
                 }
                 if params.extract_keys {
@@ -575,7 +575,7 @@ impl Wallet {
             } else {
                 return Err(LoadError::Mismatch(LoadMismatch::Descriptor {
                     keychain: KeychainKind::External,
-                    loaded: Some(descriptor),
+                    loaded: Some(Box::new(descriptor)),
                     expected: None,
                 }));
             }
@@ -595,7 +595,7 @@ impl Wallet {
                     return Err(LoadError::Mismatch(LoadMismatch::Descriptor {
                         keychain: KeychainKind::Internal,
                         loaded: None,
-                        expected: Some(exp_desc),
+                        expected: Some(Box::new(exp_desc)),
                     }));
                 }
             }
@@ -609,7 +609,7 @@ impl Wallet {
                 None => {
                     return Err(LoadError::Mismatch(LoadMismatch::Descriptor {
                         keychain: KeychainKind::Internal,
-                        loaded: Some(desc),
+                        loaded: Some(Box::new(desc)),
                         expected: None,
                     }))
                 }
@@ -621,8 +621,8 @@ impl Wallet {
                     if desc.descriptor_id() != exp_desc.descriptor_id() {
                         return Err(LoadError::Mismatch(LoadMismatch::Descriptor {
                             keychain: KeychainKind::Internal,
-                            loaded: Some(desc),
-                            expected: Some(exp_desc),
+                            loaded: Some(Box::new(desc)),
+                            expected: Some(Box::new(exp_desc)),
                         }));
                     }
                     if params.extract_keys {

--- a/wallet/tests/persisted_wallet.rs
+++ b/wallet/tests/persisted_wallet.rs
@@ -346,6 +346,7 @@ fn single_descriptor_wallet_persist_and_recover() {
     // should error on wrong internal params
     let desc = get_test_wpkh();
     let (exp_desc, _) = <Descriptor<DescriptorPublicKey>>::parse_descriptor(secp, desc).unwrap();
+    let exp_desc = Box::new(exp_desc);
     let err = Wallet::load()
         .descriptor(KeychainKind::Internal, Some(desc))
         .extract_keys()


### PR DESCRIPTION
### Description

This is a fix to address clippy lints

- `clippy::large_enum_variant`
- `clippy::result_large_error`

BREAKING: The types `LoadMismatch`, and `CreateWithPersistError` are changed as a result of the now boxed variants.

fixes #245 

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

#### Bugfixes:

* [x] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
