### PR TITLE
Revert "clippy!: `Box` large enum variants"

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,4 @@
-msrv = "1.63.0"
+# TODO fix, see: https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant
+enum-variant-size-threshold = 1032
+# TODO fix, see: https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err
+large-error-threshold = 993

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -227,9 +227,9 @@ pub enum LoadMismatch {
         /// Keychain identifying the descriptor.
         keychain: KeychainKind,
         /// The loaded descriptor.
-        loaded: Option<Box<ExtendedDescriptor>>,
+        loaded: Option<ExtendedDescriptor>,
         /// The expected descriptor.
-        expected: Option<Box<ExtendedDescriptor>>,
+        expected: Option<ExtendedDescriptor>,
     },
 }
 
@@ -565,8 +565,8 @@ impl Wallet {
                 if descriptor.descriptor_id() != exp_desc.descriptor_id() {
                     return Err(LoadError::Mismatch(LoadMismatch::Descriptor {
                         keychain: KeychainKind::External,
-                        loaded: Some(Box::new(descriptor)),
-                        expected: Some(Box::new(exp_desc)),
+                        loaded: Some(descriptor),
+                        expected: Some(exp_desc),
                     }));
                 }
                 if params.extract_keys {
@@ -575,7 +575,7 @@ impl Wallet {
             } else {
                 return Err(LoadError::Mismatch(LoadMismatch::Descriptor {
                     keychain: KeychainKind::External,
-                    loaded: Some(Box::new(descriptor)),
+                    loaded: Some(descriptor),
                     expected: None,
                 }));
             }
@@ -595,7 +595,7 @@ impl Wallet {
                     return Err(LoadError::Mismatch(LoadMismatch::Descriptor {
                         keychain: KeychainKind::Internal,
                         loaded: None,
-                        expected: Some(Box::new(exp_desc)),
+                        expected: Some(exp_desc),
                     }));
                 }
             }
@@ -609,7 +609,7 @@ impl Wallet {
                 None => {
                     return Err(LoadError::Mismatch(LoadMismatch::Descriptor {
                         keychain: KeychainKind::Internal,
-                        loaded: Some(Box::new(desc)),
+                        loaded: Some(desc),
                         expected: None,
                     }))
                 }
@@ -621,8 +621,8 @@ impl Wallet {
                     if desc.descriptor_id() != exp_desc.descriptor_id() {
                         return Err(LoadError::Mismatch(LoadMismatch::Descriptor {
                             keychain: KeychainKind::Internal,
-                            loaded: Some(Box::new(desc)),
-                            expected: Some(Box::new(exp_desc)),
+                            loaded: Some(desc),
+                            expected: Some(exp_desc),
                         }));
                     }
                     if params.extract_keys {

--- a/wallet/src/wallet/persisted.rs
+++ b/wallet/src/wallet/persisted.rs
@@ -150,9 +150,7 @@ impl<P: WalletPersister> PersistedWallet<P> {
     ) -> Result<Self, CreateWithPersistError<P::Error>> {
         let existing = P::initialize(persister).map_err(CreateWithPersistError::Persist)?;
         if !existing.is_empty() {
-            return Err(CreateWithPersistError::DataAlreadyExists(Box::new(
-                existing,
-            )));
+            return Err(CreateWithPersistError::DataAlreadyExists(existing));
         }
         let mut inner =
             Wallet::create_with_params(params).map_err(CreateWithPersistError::Descriptor)?;
@@ -209,9 +207,7 @@ impl<P: AsyncWalletPersister> PersistedWallet<P> {
             .await
             .map_err(CreateWithPersistError::Persist)?;
         if !existing.is_empty() {
-            return Err(CreateWithPersistError::DataAlreadyExists(Box::new(
-                existing,
-            )));
+            return Err(CreateWithPersistError::DataAlreadyExists(existing));
         }
         let mut inner =
             Wallet::create_with_params(params).map_err(CreateWithPersistError::Descriptor)?;
@@ -296,7 +292,6 @@ impl WalletPersister for bdk_chain::rusqlite::Connection {
 
 /// Error for [`bdk_file_store`]'s implementation of [`WalletPersister`].
 #[cfg(feature = "file_store")]
-#[allow(clippy::large_enum_variant)] // Can be fixed in `bdk_file_store` by boxing the dump.
 #[derive(Debug)]
 pub enum FileStoreError {
     /// Error when loading from the store.
@@ -362,7 +357,7 @@ pub enum CreateWithPersistError<E> {
     /// Error from persistence.
     Persist(E),
     /// Persister already has wallet data.
-    DataAlreadyExists(Box<ChangeSet>),
+    DataAlreadyExists(ChangeSet),
     /// Occurs when the loaded changeset cannot construct [`Wallet`].
     Descriptor(DescriptorError),
 }

--- a/wallet/tests/persisted_wallet.rs
+++ b/wallet/tests/persisted_wallet.rs
@@ -346,7 +346,6 @@ fn single_descriptor_wallet_persist_and_recover() {
     // should error on wrong internal params
     let desc = get_test_wpkh();
     let (exp_desc, _) = <Descriptor<DescriptorPublicKey>>::parse_descriptor(secp, desc).unwrap();
-    let exp_desc = Box::new(exp_desc);
     let err = Wallet::load()
         .descriptor(KeychainKind::Internal, Some(desc))
         .extract_keys()


### PR DESCRIPTION
Reverts bitcoindevkit/bdk_wallet#277

Per discussion on team chat yesterday we need to revert this since it's a breaking change and wasn't meant to be merged until the 3.0 milestone. ValuedMammal will have to re-submit a replacement PR. 