### PR TITLE
chore(deps): bump `bdk-chain` to `0.23.1`

### DIFF
--- a/examples/example_wallet_electrum/Cargo.toml
+++ b/examples/example_wallet_electrum/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 
 [dependencies]
 bdk_wallet = { path = "../../wallet", features = ["rusqlite"] }
-bdk_electrum = { version = "0.23.0" }
+bdk_electrum = { version = "0.23.1" }
 anyhow = "1"

--- a/examples/example_wallet_esplora_async/Cargo.toml
+++ b/examples/example_wallet_esplora_async/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 
 [dependencies]
 bdk_wallet = { path = "../../wallet", features = ["rusqlite"] }
-bdk_esplora = { version = "0.22.0", features = ["async-https", "tokio"] }
+bdk_esplora = { version = "0.22.1", features = ["async-https", "tokio"] }
 tokio = { version = "1.38.1", features = ["rt", "rt-multi-thread", "macros"] }
 anyhow = "1"

--- a/examples/example_wallet_esplora_blocking/Cargo.toml
+++ b/examples/example_wallet_esplora_blocking/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 
 [dependencies]
 bdk_wallet = { path = "../../wallet", features = ["rusqlite"] }
-bdk_esplora = { version = "0.22.0", features = ["blocking"] }
+bdk_esplora = { version = "0.22.1", features = ["blocking"] }
 anyhow = "1"

--- a/examples/example_wallet_rpc/Cargo.toml
+++ b/examples/example_wallet_rpc/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 bdk_wallet = { path = "../../wallet", features = ["rusqlite"] }
-bdk_bitcoind_rpc = { version = "0.20.0" }
+bdk_bitcoind_rpc = { version = "0.21.0" }
 
 anyhow = "1"
 clap = { version = "4.5.17", features = ["derive", "env"] }

--- a/examples/example_wallet_rpc/src/main.rs
+++ b/examples/example_wallet_rpc/src/main.rs
@@ -174,8 +174,8 @@ fn main() -> anyhow::Result<()> {
             }
             Emission::Mempool(event) => {
                 let start_apply_mempool = Instant::now();
-                wallet.apply_evicted_txs(event.evicted_ats());
-                wallet.apply_unconfirmed_txs(event.new_txs);
+                wallet.apply_evicted_txs(event.evicted);
+                wallet.apply_unconfirmed_txs(event.update);
                 wallet.persist(&mut db)?;
                 println!(
                     "Applied unconfirmed transactions in {}s",

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -21,11 +21,11 @@ miniscript = { version = "12.3.1", features = [ "serde" ], default-features = fa
 bitcoin = { version = "0.32.6", features = [ "serde", "base64" ], default-features = false }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
-bdk_chain = { version = "0.23.0", features = [ "miniscript", "serde" ], default-features = false }
+bdk_chain = { version = "0.23.1", features = [ "miniscript", "serde" ], default-features = false }
 
 # Optional dependencies
 bip39 = { version = "2.0", optional = true }
-bdk_file_store = { version = "0.21.0", optional = true }
+bdk_file_store = { version = "0.21.1", optional = true }
 
 [features]
 default = ["std"]
@@ -40,7 +40,7 @@ test-utils = ["std"]
 [dev-dependencies]
 assert_matches = "1.5.0"
 tempfile = "3"
-bdk_chain = { version = "0.23.0", features = ["rusqlite"] }
+bdk_chain = { version = "0.23.1", features = ["rusqlite"] }
 bdk_wallet = { path = ".", features = ["rusqlite", "file_store", "test-utils"] }
 anyhow = "1"
 rand = "^0.8"


### PR DESCRIPTION
### Description

- updates the `bdk-chain` to `0.23.1` in `bdk_wallet`.
- updates the `esplora`, `electrum` and `bitcoind_rpc` to latest version.

### Notes to the reviewers

I had to update the `insert_tx` in `test_utils` and the `wallet_rpc` example in order to work with bumped versions, let me know if all sounds good.

### Changelog notice

```md
### Changes

- deps: bump `bdk-chain` to `0.23.1`

```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `just p` before pushing
