### PR TITLE
Add utilities to test persistence

### DIFF
--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -22,6 +22,9 @@ bitcoin = { version = "0.32.6", features = [ "serde", "base64" ], default-featur
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
 bdk_chain = { version = "0.23.1", features = [ "miniscript", "serde" ], default-features = false }
+anyhow = { version = "1.0.98", optional = true }
+tempfile = { version = "3.20.0", optional = true }
+bdk_testenv = { version = "0.13.0", optional = true}
 
 # Optional dependencies
 bip39 = { version = "2.0", optional = true }
@@ -35,7 +38,7 @@ all-keys = ["keys-bip39"]
 keys-bip39 = ["bip39"]
 rusqlite = ["bdk_chain/rusqlite"]
 file_store = ["bdk_file_store"]
-test-utils = ["std"]
+test-utils = ["std", "anyhow", "tempfile", "bdk_testenv"]
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -24,7 +24,6 @@ serde_json = { version = "^1.0" }
 bdk_chain = { version = "0.23.1", features = [ "miniscript", "serde" ], default-features = false }
 anyhow = { version = "1.0.98", optional = true }
 tempfile = { version = "3.20.0", optional = true }
-bdk_testenv = { version = "0.13.0", optional = true}
 
 # Optional dependencies
 bip39 = { version = "2.0", optional = true }
@@ -38,7 +37,7 @@ all-keys = ["keys-bip39"]
 keys-bip39 = ["bip39"]
 rusqlite = ["bdk_chain/rusqlite"]
 file_store = ["bdk_file_store"]
-test-utils = ["std", "anyhow", "tempfile", "bdk_testenv"]
+test-utils = ["std", "anyhow", "tempfile"]
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -31,6 +31,10 @@ pub mod keys;
 pub mod psbt;
 #[cfg(feature = "test-utils")]
 pub mod test_utils;
+
+#[cfg(feature = "test-utils")]
+pub mod persist_test_utils;
+
 mod types;
 mod wallet;
 

--- a/wallet/src/persist_test_utils.rs
+++ b/wallet/src/persist_test_utils.rs
@@ -1,0 +1,367 @@
+use crate::{
+    bitcoin::{
+        absolute, key::Secp256k1, transaction, Address, Amount, Network, OutPoint, ScriptBuf,
+        Transaction, TxIn, TxOut, Txid,
+    },
+    chain::{
+        keychain_txout::{self},
+        local_chain, tx_graph, ConfirmationBlockTime, DescriptorExt, Merge, SpkIterator,
+    },
+    miniscript::descriptor::{Descriptor, DescriptorPublicKey},
+    ChangeSet, WalletPersister,
+};
+use bdk_testenv::{block_id, hash};
+use std::fmt::Debug;
+use std::path::Path;
+use std::str::FromStr;
+use std::sync::Arc;
+
+const DESCRIPTORS: [&str; 4] = [
+    "tr([5940b9b9/86'/0'/0']tpubDDVNqmq75GNPWQ9UNKfP43UwjaHU4GYfoPavojQbfpyfZp2KetWgjGBRRAy4tYCrAA6SB11mhQAkqxjh1VtQHyKwT4oYxpwLaGHvoKmtxZf/0/*)#44aqnlam",
+    "tr([5940b9b9/86'/0'/0']tpubDDVNqmq75GNPWQ9UNKfP43UwjaHU4GYfoPavojQbfpyfZp2KetWgjGBRRAy4tYCrAA6SB11mhQAkqxjh1VtQHyKwT4oYxpwLaGHvoKmtxZf/1/*)#ypcpw2dr",
+    "wpkh([41f2aed0/84h/1h/0h]tpubDDFSdQWw75hk1ewbwnNpPp5DvXFRKt68ioPoyJDY752cNHKkFxPWqkqCyCf4hxrEfpuxh46QisehL3m8Bi6MsAv394QVLopwbtfvryFQNUH/0/*)#g0w0ymmw",
+    "wpkh([41f2aed0/84h/1h/0h]tpubDDFSdQWw75hk1ewbwnNpPp5DvXFRKt68ioPoyJDY752cNHKkFxPWqkqCyCf4hxrEfpuxh46QisehL3m8Bi6MsAv394QVLopwbtfvryFQNUH/1/*)#emtwewtk",
+];
+
+fn create_one_inp_one_out_tx(txid: Txid, amount: u64) -> Transaction {
+    Transaction {
+        version: transaction::Version::ONE,
+        lock_time: absolute::LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: OutPoint::new(txid, 0),
+            ..TxIn::default()
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(amount),
+            script_pubkey: Address::from_str("bcrt1q3qtze4ys45tgdvguj66zrk4fu6hq3a3v9pfly5")
+                .unwrap()
+                .assume_checked()
+                .script_pubkey(),
+        }],
+    }
+}
+
+fn spk_at_index(descriptor: &Descriptor<DescriptorPublicKey>, index: u32) -> ScriptBuf {
+    descriptor
+        .derived_descriptor(&Secp256k1::verification_only(), index)
+        .expect("must derive")
+        .script_pubkey()
+}
+
+pub fn persist_wallet_changeset<Store, CreateStore>(filename: &str, create_store: CreateStore)
+where
+    CreateStore: Fn(&Path) -> anyhow::Result<Store>,
+    Store: WalletPersister,
+    Store::Error: Debug,
+{
+    // create store
+    let temp_dir = tempfile::tempdir().expect("must create tempdir");
+    let file_path = temp_dir.path().join(filename);
+    let mut store = create_store(&file_path).expect("store should get created");
+
+    // initialize store
+    let changeset =
+        WalletPersister::initialize(&mut store).expect("empty changeset should get loaded");
+    assert_eq!(changeset, ChangeSet::default());
+
+    // create changeset
+    let descriptor: Descriptor<DescriptorPublicKey> = DESCRIPTORS[0].parse().unwrap();
+    let change_descriptor: Descriptor<DescriptorPublicKey> = DESCRIPTORS[1].parse().unwrap();
+
+    let local_chain_changeset = local_chain::ChangeSet {
+        blocks: [
+            (910234, Some(hash!("B"))),
+            (910233, Some(hash!("T"))),
+            (910235, Some(hash!("C"))),
+        ]
+        .into(),
+    };
+
+    let tx1 = Arc::new(create_one_inp_one_out_tx(
+        hash!("We_are_all_Satoshi"),
+        30_000,
+    ));
+    let tx2 = Arc::new(create_one_inp_one_out_tx(tx1.compute_txid(), 20_000));
+
+    let conf_anchor: ConfirmationBlockTime = ConfirmationBlockTime {
+        block_id: block_id!(910234, "B"),
+        confirmation_time: 1755317160,
+    };
+
+    let tx_graph_changeset = tx_graph::ChangeSet::<ConfirmationBlockTime> {
+        txs: [tx1.clone()].into(),
+        txouts: [
+            (
+                OutPoint::new(hash!("Rust"), 0),
+                TxOut {
+                    value: Amount::from_sat(1300),
+                    script_pubkey: spk_at_index(&descriptor, 4),
+                },
+            ),
+            (
+                OutPoint::new(hash!("REDB"), 0),
+                TxOut {
+                    value: Amount::from_sat(1400),
+                    script_pubkey: spk_at_index(&descriptor, 10),
+                },
+            ),
+        ]
+        .into(),
+        anchors: [(conf_anchor, tx1.compute_txid())].into(),
+        last_seen: [(tx1.compute_txid(), 1755317760)].into(),
+        first_seen: [(tx1.compute_txid(), 1755317750)].into(),
+        last_evicted: [(tx1.compute_txid(), 1755317760)].into(),
+    };
+
+    let keychain_txout_changeset = keychain_txout::ChangeSet {
+        last_revealed: [
+            (descriptor.descriptor_id(), 12),
+            (change_descriptor.descriptor_id(), 10),
+        ]
+        .into(),
+        spk_cache: [
+            (
+                descriptor.descriptor_id(),
+                SpkIterator::new_with_range(&descriptor, 0..=37).collect(),
+            ),
+            (
+                change_descriptor.descriptor_id(),
+                SpkIterator::new_with_range(&change_descriptor, 0..=35).collect(),
+            ),
+        ]
+        .into(),
+    };
+
+    let mut changeset = ChangeSet {
+        descriptor: Some(descriptor.clone()),
+        change_descriptor: Some(change_descriptor.clone()),
+        network: Some(Network::Testnet),
+        local_chain: local_chain_changeset,
+        tx_graph: tx_graph_changeset,
+        indexer: keychain_txout_changeset,
+    };
+
+    // persist and load
+    WalletPersister::persist(&mut store, &changeset).expect("changeset should get persisted");
+
+    let changeset_read =
+        WalletPersister::initialize(&mut store).expect("changeset should get loaded");
+
+    assert_eq!(changeset, changeset_read);
+
+    // create another changeset
+    let local_chain_changeset = local_chain::ChangeSet {
+        blocks: [(910236, Some(hash!("BDK")))].into(),
+    };
+
+    let conf_anchor: ConfirmationBlockTime = ConfirmationBlockTime {
+        block_id: block_id!(910236, "BDK"),
+        confirmation_time: 1755317760,
+    };
+
+    let tx_graph_changeset = tx_graph::ChangeSet::<ConfirmationBlockTime> {
+        txs: [tx2.clone()].into(),
+        txouts: [(
+            OutPoint::new(hash!("Bitcoin_fixes_things"), 0),
+            TxOut {
+                value: Amount::from_sat(10000),
+                script_pubkey: spk_at_index(&descriptor, 21),
+            },
+        )]
+        .into(),
+        anchors: [(conf_anchor, tx2.compute_txid())].into(),
+        last_seen: [(tx2.compute_txid(), 1755317700)].into(),
+        first_seen: [(tx2.compute_txid(), 1755317700)].into(),
+        last_evicted: [(tx2.compute_txid(), 1755317760)].into(),
+    };
+
+    let keychain_txout_changeset = keychain_txout::ChangeSet {
+        last_revealed: [(descriptor.descriptor_id(), 14)].into(),
+        spk_cache: [(
+            descriptor.descriptor_id(),
+            SpkIterator::new_with_range(&descriptor, 37..=39).collect(),
+        )]
+        .into(),
+    };
+
+    let changeset_new = ChangeSet {
+        descriptor: None,
+        change_descriptor: None,
+        network: None,
+        local_chain: local_chain_changeset,
+        tx_graph: tx_graph_changeset,
+        indexer: keychain_txout_changeset,
+    };
+
+    // persist, load and check if same as merged
+    WalletPersister::persist(&mut store, &changeset_new).expect("changeset should get persisted");
+    let changeset_read_new = WalletPersister::initialize(&mut store).unwrap();
+
+    changeset.merge(changeset_new);
+
+    assert_eq!(changeset, changeset_read_new);
+}
+
+pub fn persist_multiple_wallet_changesets<Store, CreateStores>(
+    filename: &str,
+    create_dbs: CreateStores,
+) where
+    CreateStores: Fn(&Path) -> anyhow::Result<(Store, Store)>,
+    Store: WalletPersister,
+    Store::Error: Debug,
+{
+    // create stores
+    let temp_dir = tempfile::tempdir().expect("must create tempdir");
+    let file_path = temp_dir.path().join(filename);
+
+    let (mut store_first, mut store_sec) =
+        create_dbs(&file_path).expect("store should get created");
+
+    // initialize first store
+    let changeset =
+        WalletPersister::initialize(&mut store_first).expect("should load empty changeset");
+    assert_eq!(changeset, ChangeSet::default());
+
+    // create first changeset
+    let descriptor: Descriptor<DescriptorPublicKey> = DESCRIPTORS[0].parse().unwrap();
+    let change_descriptor: Descriptor<DescriptorPublicKey> = DESCRIPTORS[1].parse().unwrap();
+
+    let changeset1 = ChangeSet {
+        descriptor: Some(descriptor.clone()),
+        change_descriptor: Some(change_descriptor.clone()),
+        network: Some(Network::Testnet),
+        ..ChangeSet::default()
+    };
+
+    // persist first changeset
+    WalletPersister::persist(&mut store_first, &changeset1).expect("should persist changeset");
+
+    // initialize second store
+    let changeset =
+        WalletPersister::initialize(&mut store_sec).expect("should load empty changeset");
+    assert_eq!(changeset, ChangeSet::default());
+
+    // create second changeset
+    let descriptor: Descriptor<DescriptorPublicKey> = DESCRIPTORS[2].parse().unwrap();
+    let change_descriptor: Descriptor<DescriptorPublicKey> = DESCRIPTORS[3].parse().unwrap();
+
+    let changeset2 = ChangeSet {
+        descriptor: Some(descriptor.clone()),
+        change_descriptor: Some(change_descriptor.clone()),
+        network: Some(Network::Testnet),
+        ..ChangeSet::default()
+    };
+
+    // persist second changeset
+    WalletPersister::persist(&mut store_sec, &changeset2).expect("should persist changeset");
+
+    // load first changeset
+    let changeset_read =
+        WalletPersister::initialize(&mut store_first).expect("should load persisted changeset1");
+    assert_eq!(changeset_read, changeset1);
+
+    // load second changeset
+    let changeset_read =
+        WalletPersister::initialize(&mut store_sec).expect("should load persisted changeset2");
+    assert_eq!(changeset_read, changeset2);
+}
+
+pub fn persist_network<Store, CreateStore>(filename: &str, create_store: CreateStore)
+where
+    CreateStore: Fn(&Path) -> anyhow::Result<Store>,
+    Store: WalletPersister,
+    Store::Error: Debug,
+{
+    // create store
+    let temp_dir = tempfile::tempdir().expect("must create tempdir");
+    let file_path = temp_dir.path().join(filename);
+    let mut store = create_store(&file_path).expect("store should get created");
+
+    // initialize store
+    let changeset = WalletPersister::initialize(&mut store)
+        .expect("should initialize and load empty changeset");
+    assert_eq!(changeset, ChangeSet::default());
+
+    // persist the network
+    let changeset = ChangeSet {
+        network: Some(Network::Bitcoin),
+        ..ChangeSet::default()
+    };
+    WalletPersister::persist(&mut store, &changeset).expect("should persist changeset");
+
+    // read the persisted network
+    let changeset_read =
+        WalletPersister::initialize(&mut store).expect("should load persisted changeset");
+
+    assert_eq!(changeset_read.network, Some(Network::Bitcoin));
+}
+
+pub fn persist_keychains<Store, CreateStore>(filename: &str, create_store: CreateStore)
+where
+    CreateStore: Fn(&Path) -> anyhow::Result<Store>,
+    Store: WalletPersister,
+    Store::Error: Debug,
+{
+    // create store
+    let temp_dir = tempfile::tempdir().expect("must create tempdir");
+    let file_path = temp_dir.path().join(filename);
+    let mut store = create_store(&file_path).expect("store should get created");
+
+    // initialize store
+    let changeset = WalletPersister::initialize(&mut store)
+        .expect("should initialize and load empty changeset");
+    assert_eq!(changeset, ChangeSet::default());
+
+    // persist the descriptors
+    let descriptor: Descriptor<DescriptorPublicKey> = DESCRIPTORS[1].parse().unwrap();
+    let change_descriptor: Descriptor<DescriptorPublicKey> = DESCRIPTORS[0].parse().unwrap();
+
+    let changeset = ChangeSet {
+        descriptor: Some(descriptor.clone()),
+        change_descriptor: Some(change_descriptor.clone()),
+        ..ChangeSet::default()
+    };
+
+    WalletPersister::persist(&mut store, &changeset).expect("should persist descriptors");
+
+    // load the descriptors
+    let changeset_read =
+        WalletPersister::initialize(&mut store).expect("should read persisted changeset");
+
+    assert_eq!(changeset_read.descriptor.unwrap(), descriptor);
+    assert_eq!(changeset_read.change_descriptor.unwrap(), change_descriptor);
+}
+
+pub fn persist_single_keychain<Store, CreateStore>(filename: &str, create_store: CreateStore)
+where
+    CreateStore: Fn(&Path) -> anyhow::Result<Store>,
+    Store: WalletPersister,
+    Store::Error: Debug,
+{
+    // create store
+    let temp_dir = tempfile::tempdir().expect("must create tempdir");
+    let file_path = temp_dir.path().join(filename);
+    let mut store = create_store(&file_path).expect("store should get created");
+
+    // initialize store
+    let changeset = WalletPersister::initialize(&mut store)
+        .expect("should initialize and load empty changeset");
+    assert_eq!(changeset, ChangeSet::default());
+
+    // persist descriptor
+    let descriptor: Descriptor<DescriptorPublicKey> = DESCRIPTORS[0].parse().unwrap();
+
+    let changeset = ChangeSet {
+        descriptor: Some(descriptor.clone()),
+        ..ChangeSet::default()
+    };
+
+    WalletPersister::persist(&mut store, &changeset).expect("should persist descriptors");
+
+    // load the descriptor
+    let changeset_read =
+        WalletPersister::initialize(&mut store).expect("should read persisted changeset");
+
+    assert_eq!(changeset_read.descriptor.unwrap(), descriptor);
+    assert_eq!(changeset_read.change_descriptor, None);
+}

--- a/wallet/src/persist_test_utils.rs
+++ b/wallet/src/persist_test_utils.rs
@@ -12,7 +12,22 @@ use crate::{
     miniscript::descriptor::{Descriptor, DescriptorPublicKey},
     ChangeSet, WalletPersister,
 };
-use bdk_testenv::{block_id, hash};
+
+macro_rules! block_id {
+    ($height:expr, $hash:literal) => {{
+        bdk_chain::BlockId {
+            height: $height,
+            hash: bitcoin::hashes::Hash::hash($hash.as_bytes()),
+        }
+    }};
+}
+
+macro_rules! hash {
+    ($index:literal) => {{
+        bitcoin::hashes::Hash::hash($index.as_bytes())
+    }};
+}
+
 use std::fmt::Debug;
 use std::path::Path;
 use std::str::FromStr;

--- a/wallet/src/persist_test_utils.rs
+++ b/wallet/src/persist_test_utils.rs
@@ -1,3 +1,5 @@
+//! Utilities for testing custom persistence backends for `bdk_wallet`
+
 use crate::{
     bitcoin::{
         absolute, key::Secp256k1, transaction, Address, Amount, Network, OutPoint, ScriptBuf,
@@ -48,6 +50,14 @@ fn spk_at_index(descriptor: &Descriptor<DescriptorPublicKey>, index: u32) -> Scr
         .script_pubkey()
 }
 
+/// tests if [`Wallet`] is being persisted correctly
+///
+/// [`Wallet`]: <https://docs.rs/bdk_wallet/latest/bdk_wallet/struct.Wallet.html>
+/// [`ChangeSet`]: <https://docs.rs/bdk_wallet/latest/bdk_wallet/struct.ChangeSet.html>
+///
+/// We create a dummy [`ChangeSet`], persist it and check if loaded [`ChangeSet`] matches
+/// the persisted one. We then create another such dummy [`ChangeSet`], persist it and load it to
+/// check if merged [`ChangeSet`] is returned.
 pub fn persist_wallet_changeset<Store, CreateStore>(filename: &str, create_store: CreateStore)
 where
     CreateStore: Fn(&Path) -> anyhow::Result<Store>,
@@ -202,6 +212,14 @@ where
     assert_eq!(changeset, changeset_read_new);
 }
 
+/// tests if multiple [`Wallet`]s can be persisted in a single file correctly
+///
+/// [`Wallet`]: <https://docs.rs/bdk_wallet/latest/bdk_wallet/struct.Wallet.html>
+/// [`ChangeSet`]: <https://docs.rs/bdk_wallet/latest/bdk_wallet/struct.ChangeSet.html>
+///
+/// We create a dummy [`ChangeSet`] for first wallet and persist it then we create a dummy
+/// [`ChangeSet`] for second wallet and persist that. Finally we load these two [`ChangeSet`]s and
+/// check if they were persisted correctly.
 pub fn persist_multiple_wallet_changesets<Store, CreateStores>(
     filename: &str,
     create_dbs: CreateStores,
@@ -266,6 +284,13 @@ pub fn persist_multiple_wallet_changesets<Store, CreateStores>(
     assert_eq!(changeset_read, changeset2);
 }
 
+/// tests if [`Network`] is being persisted correctly
+///
+/// [`Network`]: <https://docs.rs/bitcoin/latest/bitcoin/enum.Network.html>
+/// [`ChangeSet`]: <https://docs.rs/bdk_wallet/latest/bdk_wallet/struct.ChangeSet.html>
+///
+/// We create a dummy [`ChangeSet`] with only network field populated, persist it and check if
+/// loaded [`ChangeSet`] has the same [`Network`] as what we persisted.
 pub fn persist_network<Store, CreateStore>(filename: &str, create_store: CreateStore)
 where
     CreateStore: Fn(&Path) -> anyhow::Result<Store>,
@@ -296,6 +321,12 @@ where
     assert_eq!(changeset_read.network, Some(Network::Bitcoin));
 }
 
+/// tests if descriptors are being persisted correctly
+///
+/// [`ChangeSet`]: <https://docs.rs/bdk_wallet/latest/bdk_wallet/struct.ChangeSet.html>
+///
+/// We create a dummy [`ChangeSet`] with only descriptor fields populated, persist it and check if
+/// loaded [`ChangeSet`] has the same descriptors as what we persisted.
 pub fn persist_keychains<Store, CreateStore>(filename: &str, create_store: CreateStore)
 where
     CreateStore: Fn(&Path) -> anyhow::Result<Store>,
@@ -332,6 +363,12 @@ where
     assert_eq!(changeset_read.change_descriptor.unwrap(), change_descriptor);
 }
 
+/// tests if descriptor(in a single keychain wallet) is being persisted correctly
+///
+/// [`ChangeSet`]: <https://docs.rs/bdk_wallet/latest/bdk_wallet/struct.ChangeSet.html>
+///
+/// We create a dummy [`ChangeSet`] with only descriptor field populated, persist it and check if
+/// loaded [`ChangeSet`] has the same descriptor as what we persisted.
 pub fn persist_single_keychain<Store, CreateStore>(filename: &str, create_store: CreateStore)
 where
     CreateStore: Fn(&Path) -> anyhow::Result<Store>,

--- a/wallet/tests/persisted_wallet.rs
+++ b/wallet/tests/persisted_wallet.rs
@@ -20,6 +20,10 @@ use bitcoin::{
 };
 use miniscript::{Descriptor, DescriptorPublicKey};
 
+use bdk_wallet::persist_test_utils::{
+    persist_keychains, persist_network, persist_single_keychain, persist_wallet_changeset,
+};
+
 mod common;
 use common::*;
 
@@ -418,4 +422,44 @@ fn single_descriptor_wallet_persist_and_recover() {
         if keychain == KeychainKind::Internal && loaded.is_none() && expected == Some(exp_desc),
         "single descriptor wallet should refuse change descriptor param"
     );
+}
+
+#[test]
+fn wallet_changeset_is_persisted() {
+    persist_wallet_changeset("store.db", |path| {
+        Ok(bdk_file_store::Store::create(DB_MAGIC, path)?)
+    });
+    persist_wallet_changeset::<bdk_chain::rusqlite::Connection, _>("store.sqlite", |path| {
+        Ok(bdk_chain::rusqlite::Connection::open(path)?)
+    });
+}
+
+#[test]
+fn keychains_are_persisted() {
+    persist_keychains("store.db", |path| {
+        Ok(bdk_file_store::Store::create(DB_MAGIC, path)?)
+    });
+    persist_keychains::<bdk_chain::rusqlite::Connection, _>("store.sqlite", |path| {
+        Ok(bdk_chain::rusqlite::Connection::open(path)?)
+    });
+}
+
+#[test]
+fn single_keychain_is_persisted() {
+    persist_single_keychain("store.db", |path| {
+        Ok(bdk_file_store::Store::create(DB_MAGIC, path)?)
+    });
+    persist_single_keychain::<bdk_chain::rusqlite::Connection, _>("store.sqlite", |path| {
+        Ok(bdk_chain::rusqlite::Connection::open(path)?)
+    });
+}
+
+#[test]
+fn network_is_persisted() {
+    persist_network("store.db", |path| {
+        Ok(bdk_file_store::Store::create(DB_MAGIC, path)?)
+    });
+    persist_network::<bdk_chain::rusqlite::Connection, _>("store.sqlite", |path| {
+        Ok(bdk_chain::rusqlite::Connection::open(path)?)
+    });
 }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Added some basic functions to test `WalletPersister` impl. Fixes #14 and might help with #234 .

### Changelog notice

```
Added
    - functions to test `WalletPersister` impl of custom persistence backends.
    - tests for file_store and rusqlite based on persistence testing functions added
```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `just p` before pushing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
