### PR TITLE
ci: bump rust-cache to 2.8.0

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -28,7 +28,7 @@ jobs:
             profile: minimal
             components: llvm-tools-preview
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2.7.8
+        uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0
       - name: Install grcov
         run: if [[ ! -e ~/.cargo/bin/grcov ]]; then cargo install grcov; fi
       - name: Test

--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -47,7 +47,7 @@ jobs:
             override: true
             profile: minimal
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2.7.8
+        uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0
       - name: Pin dependencies for MSRV
         if: matrix.rust.version == '1.63.0'
         run: ./ci/pin-msrv.sh
@@ -75,7 +75,7 @@ jobs:
           profile: minimal
           # target: "thumbv6m-none-eabi"
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2.7.8
+        uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0
       - name: Check bdk wallet
         working-directory: ./wallet
         # TODO "--target thumbv6m-none-eabi" should work but currently does not
@@ -105,7 +105,7 @@ jobs:
             profile: minimal
             target: "wasm32-unknown-unknown"
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2.7.8
+        uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0
       - name: Check bdk wallet
         working-directory: ./wallet
         run: cargo check --target wasm32-unknown-unknown --no-default-features --features miniscript/no-std,bdk_chain/hashbrown
@@ -144,7 +144,7 @@ jobs:
             components: clippy
             override: true
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2.7.8
+        uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -174,7 +174,7 @@ jobs:
           override: true
           profile: minimal
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2.7.8
+        uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0
       - name: Build
         working-directory: examples/${{ matrix.example-dir }}
         run: cargo build


### PR DESCRIPTION
Bump Swatinem/rust-cache to v2.8.0.

### Notes to the reviewers

`Swatinem/rust-cache` is now pinned to a commit at [98c8021b550208e191a6a3145459bfc9fb29c4c0](https://github.com/Swatinem/rust-cache/commit/98c8021b550208e191a6a3145459bfc9fb29c4c0).

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

    ci: bump rust-cache to 2.8.0

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

