### PR TITLE
chore(just): add a `_default` recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -4,6 +4,9 @@ alias f := fmt
 alias t := test
 alias p := pre-push
 
+_default:
+   @just --list
+
 # Build the project
 build:
    cargo build


### PR DESCRIPTION
This PR adds a `_default` recipe at the top of the `justfile` so that running `just` will list the recipes instead of running the `build` recipe.
