### PR TITLE
Release v2.2.0

### DIFF
--- a/examples/example_wallet_electrum/src/main.rs
+++ b/examples/example_wallet_electrum/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use bdk_electrum::electrum_client;
 use bdk_electrum::BdkElectrumClient;
 use bdk_wallet::bitcoin::Amount;

--- a/examples/example_wallet_esplora_async/src/main.rs
+++ b/examples/example_wallet_esplora_async/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use anyhow::Ok;
 use bdk_esplora::{esplora_client, EsploraAsyncExt};
 use bdk_wallet::{

--- a/examples/example_wallet_esplora_blocking/src/main.rs
+++ b/examples/example_wallet_esplora_blocking/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use bdk_esplora::{esplora_client, EsploraExt};
 use bdk_wallet::rusqlite::Connection;
 use bdk_wallet::{

--- a/wallet/CHANGELOG.md
+++ b/wallet/CHANGELOG.md
@@ -7,6 +7,21 @@ Contributors do not need to change this file but do need to add changelog detail
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [wallet-2.2.0]
+
+### Added
+
+- feat: Return wallet events when applying updates #310
+- feat: (Backport #300) - Add utilities to test persistence #311
+- docs: (Backport #306) - docs: add wording on required use of xpub for multipath constructor #309
+- docs: add metadata fields to issue templates for triage #296
+
+### Changed 
+
+- ci: automated update to rustc 1.89.0 #298
+
+\***Note that the `signer` module has been deprecated and is planned to be removed in a future release.**\*
+
 ## [wallet-2.1.0]
 
 ### Added
@@ -1330,3 +1345,4 @@ final transaction is created by calling `finish` on the builder.
 [wallet-2.0.0-beta.0]: https://github.com/bitcoindevkit/bdk/releases/tag/wallet-2.0.0-beta.0
 [wallet-2.0.0]: https://github.com/bitcoindevkit/bdk/releases/tag/wallet-2.0.0
 [wallet-2.1.0]: https://github.com/bitcoindevkit/bdk/releases/tag/wallet-2.1.0
+[wallet-2.2.0]: https://github.com/bitcoindevkit/bdk/releases/tag/wallet-2.2.0

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bdk_wallet"
 homepage = "https://bitcoindevkit.org"
-version = "2.2.0-alpha.0"
+version = "2.2.0"
 repository = "https://github.com/bitcoindevkit/bdk_wallet"
 documentation = "https://docs.rs/bdk_wallet"
 description = "A modern, lightweight, descriptor-based wallet library"

--- a/wallet/examples/policy.rs
+++ b/wallet/examples/policy.rs
@@ -9,6 +9,7 @@
 // You may not use this file except in accordance with one or both of these
 // licenses.
 
+#![allow(deprecated)]
 extern crate bdk_wallet;
 use std::error::Error;
 

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -6,6 +6,7 @@
     doc(html_logo_url = "https://github.com/bitcoindevkit/bdk/raw/master/static/bdk.png")
 )]
 #![no_std]
+#![allow(deprecated)] // Signers are being removed.
 #![warn(missing_docs)]
 #![allow(clippy::uninlined_format_args)]
 

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -56,6 +56,10 @@ pub mod event;
 pub mod export;
 mod params;
 mod persisted;
+#[deprecated(
+    since = "2.2.0",
+    note = "PSBT signing was moved to `bitcoin::psbt` module"
+)]
 pub mod signer;
 pub mod tx_builder;
 pub(crate) mod utils;

--- a/wallet/tests/add_foreign_utxo.rs
+++ b/wallet/tests/add_foreign_utxo.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use std::str::FromStr;
 
 use bdk_wallet::psbt::PsbtUtils;

--- a/wallet/tests/persisted_wallet.rs
+++ b/wallet/tests/persisted_wallet.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 

--- a/wallet/tests/psbt.rs
+++ b/wallet/tests/psbt.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use bdk_wallet::bitcoin::{Amount, FeeRate, Psbt, TxIn};
 use bdk_wallet::test_utils::*;
 use bdk_wallet::{psbt, KeychainKind, SignOptions};

--- a/wallet/tests/wallet.rs
+++ b/wallet/tests/wallet.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use std::str::FromStr;
 use std::sync::Arc;
 

--- a/wallet/tests/wallet_event.rs
+++ b/wallet/tests/wallet_event.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use bdk_chain::{BlockId, CheckPoint, ConfirmationBlockTime};
 use bdk_wallet::event::WalletEvent;
 use bdk_wallet::test_utils::{get_test_wpkh_and_change_desc, new_wallet_and_funding_update};


### PR DESCRIPTION
Bump `bdk_wallet` to 2.2.0 and update `CHANGELOG.md`. Note that `signer` module is now deprecated and planned to be removed in an upcoming release. Current PSBT signing logic now lives in [`bitcoin::psbt`](https://docs.rs/bitcoin/latest/bitcoin/psbt/index.html) module.

fix #307 

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
