### PR TITLE
feat(bdk_wallet): add get_keymap() helper method to get the KeyMap for Psbt.sign

### DIFF
--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -1305,34 +1305,22 @@ impl Wallet {
         }
     }
 
-    /// Get the combined KeyMap for all signers in the wallet.
+    /// Get KeyMap
     ///
-    /// This includes keys from both external and internal (change) signers.
-    /// The returned KeyMap can be used with `PsbtExt::sign` to sign PSBTs directly.
-    ///
-    /// # Example
+    /// ## Example
     ///
     /// ```rust,no_run
-    /// use bdk_wallet::{KeychainKind, Wallet};
-    /// use miniscript::psbt::PsbtExt;
-    /// use bdk_wallet::bitcoin::{Amount, Network};
+    /// # use bdk_wallet::{KeychainKind, Wallet};
+    /// # use bdk_wallet::bitcoin::Network;
     ///
     /// let descriptor = "wpkh(tprv8ZgxMBicQKsPe73PBRSmNbTfbcsZnwWhz5eVmhHpi31HW29Z7mc9B4cWGRQzopNUzZUT391DeDJxL2PefNunWyLgqCKRMDkU1s2s8bAfoSk/84'/1'/0'/0/*)";
     /// let change_descriptor = "wpkh(tprv8ZgxMBicQKsPe73PBRSmNbTfbcsZnwWhz5eVmhHpi31HW29Z7mc9B4cWGRQzopNUzZUT391DeDJxL2PefNunWyLgqCKRMDkU1s2s8bAfoSk/84'/1'/0'/1/*)";
     /// let wallet = Wallet::create(descriptor, change_descriptor)
-    ///    .network(Network::Testnet)
-    ///    .create_wallet_no_persist()?;
+    ///     .network(Network::Testnet)
+    ///     .create_wallet_no_persist()?;
     ///
-    /// let address = wallet.peek_address(KeychainKind::External, 0);
-    ///
-    /// // Build a PSBT using the wallet
-    /// let mut tx_builder = wallet.build_tx();
-    /// tx_builder.add_recipient(address.script_pubkey(), Amount::from_sat(50_000));
-    /// let mut psbt = tx_builder.finish().unwrap();
-    ///
-    /// // Sign the PSBT directly using PsbtExt::sign with the wallet's keymap
     /// let keymap = wallet.get_keymap();
-    /// psbt.sign(&keymap, &wallet.secp_ctx()).expect("Failed to sign PSBT");
+    /// // Use the keymap with miniscript's PSBT signing or other cryptographic operations
     ///
     /// Ok::<(), Box<dyn std::error::Error>>(())
     /// ```


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

This PR adds a new helper method get_keymap() to the Wallet struct that returns a combined KeyMap containing all signing keys from both external and internal (change) signers.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

Added Wallet::get_keymap() helper method to retrieve a combined KeyMap from all wallet signers for convenient PSBT signing

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `just p` before pushing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR

Closes #331
