### PR TITLE
Make `FutureResult` non-`Send` when no-`std`

### DIFF
--- a/src/wallet/persisted.rs
+++ b/src/wallet/persisted.rs
@@ -55,7 +55,10 @@ pub trait WalletPersister {
     fn persist(persister: &mut Self, changeset: &ChangeSet) -> Result<(), Self::Error>;
 }
 
+#[cfg(feature = "std")]
 type FutureResult<'a, T, E> = Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'a>>;
+#[cfg(not(feature = "std"))]
+type FutureResult<'a, T, E> = Pin<Box<dyn Future<Output = Result<T, E>> + 'a>>;
 
 /// Async trait that persists [`PersistedWallet`].
 ///


### PR DESCRIPTION
### Description

This PR updates the `FutureResult` type alias in the async persister implementation to support **non-`Send` futures** when the `std` feature is disabled.

Previously, the `FutureResult` type always required the `Send` bound, which prevented `no_std` environments from using non-`Send` futures. With this change, the bound is applied only when the `std` feature is enabled.

This improves compatibility for embedded or `no_std` targets while keeping full `Send` safety for standard environments.

### Notes to the reviewers

The change is minimal and fully backwards compatible.
It only affects compilation under `no_std` builds and does not modify any runtime behavior or APIs under the `std` feature.

Please confirm that this approach aligns with the intended async API design and does not conflict with downstream usage expectations.

### Changelog notice

#### Changed

* Relaxed the `FutureResult` type alias to allow non-`Send` futures in `no_std` builds.