### PR TITLE
ci(msrv):  pin syn crate to 2.0.106

### DIFF
--- a/ci/pin-msrv.sh
+++ b/ci/pin-msrv.sh
@@ -11,3 +11,4 @@ set -euo pipefail
 # rustup override set 1.63.0
 
 cargo update -p once_cell --precise "1.20.3"
+cargo update -p syn --precise "2.0.106"


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Pinning to `syn` 2.0.106 which has MSRV 1.61.0.

### Notes to the reviewers

The latest `syn` 2.0.107 and 2.0.108 have MSRV 1.68.0, which breaks our MSRV tests.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `just p` before pushing

