### PR TITLE
feat(persist_test_utils)!: Add async suite to test AsyncWalletPersister

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,10 +28,8 @@ serde_json = { version = "1" }
 serde = { version = "1", features = ["derive"] }
 
 # Optional dependencies
-anyhow = { version = "1", optional = true }
 bdk_file_store = { version = "0.22.0", optional = true }
 bip39 = { version = "2.2.2", optional = true }
-tempfile = { version = "3.26.0", optional = true }
 
 [features]
 default = ["std"]
@@ -41,7 +39,7 @@ all-keys = ["keys-bip39"]
 keys-bip39 = ["bip39"]
 rusqlite = ["bdk_chain/rusqlite"]
 file_store = ["bdk_file_store"]
-test-utils = ["std", "anyhow", "tempfile"]
+test-utils = ["std"]
 
 [dev-dependencies]
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,10 +29,8 @@ serde_json = { version = "1" }
 serde = { version = "1", features = ["derive"] }
 
 # Optional dependencies
-anyhow = { version = "1", optional = true }
 bdk_file_store = { version = "0.22.0", optional = true }
 bip39 = { version = "2.2.2", optional = true }
-tempfile = { version = "3.26.0", optional = true }
 
 
 [features]
@@ -44,7 +42,7 @@ keys-bip39 = ["bip39"]
 rusqlite = ["bdk_chain/rusqlite"]
 file_store = ["bdk_file_store"]
 bdk-tx = ["dep:bdk_tx"]
-test-utils = ["std", "anyhow", "tempfile"]
+test-utils = ["std"]
 
 [dev-dependencies]
 anyhow = "1"

--- a/src/persist_test_utils.rs
+++ b/src/persist_test_utils.rs
@@ -14,7 +14,7 @@ use bitcoin::{
 };
 use miniscript::{Descriptor, DescriptorPublicKey};
 
-use crate::{locked_outpoints, ChangeSet, WalletPersister};
+use crate::{locked_outpoints, AsyncWalletPersister, ChangeSet, WalletPersister};
 
 macro_rules! block_id {
     ($height:expr, $hash:literal) => {{
@@ -458,4 +458,124 @@ impl PersistError {
     {
         Self::Persister(Box::new(e))
     }
+}
+
+/// Tests the functionality of an [`AsyncWalletPersister`].
+///
+/// # Errors
+///
+/// If any of the following occurs:
+///
+/// - A newly initialized [`AsyncWalletPersister`] isn't empty
+/// - The [`AsyncWalletPersister`] fails to persist a wallet [`ChangeSet`]
+/// - A mismatch of [`ChangeSet`] between what is read and persisted
+pub async fn persist_wallet_changeset_async<F, P>(create_store: F) -> Result<(), PersistError>
+where
+    F: AsyncFnOnce() -> Result<P, P::Error>,
+    P: AsyncWalletPersister,
+    P::Error: core::error::Error + 'static,
+{
+    let mut persister = init_async_wallet_persister(create_store).await?;
+    let tx1 = create_one_inp_one_out_tx(hash!("We_are_all_Satoshi"), 30_000);
+    let tx2 = create_one_inp_one_out_tx(tx1.compute_txid(), 20_000);
+    let changeset1 = get_changeset(tx1);
+    persist_changeset_verify_async(&mut persister, &changeset1, &changeset1).await?;
+    let changeset2 = get_changeset_two(tx2);
+    let mut expected = changeset1;
+    Merge::merge(&mut expected, changeset2.clone());
+    persist_changeset_verify_async(&mut persister, &changeset2, &expected).await
+}
+
+/// Tests if descriptors are being persisted correctly by an [`AsyncWalletPersister`].
+///
+/// First persists only the external descriptor (covering the single-keychain case), then persists
+/// the change descriptor and verifies the backend returns both merged.
+pub async fn persist_keychains_async<F, P>(create_store: F) -> Result<(), PersistError>
+where
+    F: AsyncFnOnce() -> Result<P, P::Error>,
+    P: AsyncWalletPersister,
+    P::Error: core::error::Error + 'static,
+{
+    let mut persister = init_async_wallet_persister(create_store).await?;
+    // Round 1: single keychain (external descriptor only)
+    let changeset1 = descriptor_changeset();
+    persist_changeset_verify_async(&mut persister, &changeset1, &changeset1).await?;
+    // Round 2: add the change descriptor, verify both are returned
+    let changeset2 = change_descriptor_changeset();
+    let mut expected = changeset1;
+    Merge::merge(&mut expected, changeset2.clone());
+    persist_changeset_verify_async(&mut persister, &changeset2, &expected).await
+}
+
+/// Tests network persistence.
+///
+/// Persists a [`ChangeSet`] with only the network field set and verifies it round-trips correctly.
+pub async fn persist_network_async<F, P>(create_store: F) -> Result<(), PersistError>
+where
+    F: AsyncFnOnce() -> Result<P, P::Error>,
+    P: AsyncWalletPersister,
+    P::Error: core::error::Error + 'static,
+{
+    let mut persister = init_async_wallet_persister(create_store).await?;
+    let changeset = network_changeset();
+    let expected = &changeset;
+    persist_changeset_verify_async(&mut persister, &changeset, expected).await
+}
+
+/// Initializes a new [`AsyncWalletPersister`] and checks that the persistence backend is empty.
+///
+/// # Errors
+///
+/// - If the persister's [`initialize`] function returns a non-empty [`ChangeSet`], then
+///   [`PersistError::ChangeSetMismatch`] error occurs.
+///
+/// [`initialize`]: AsyncWalletPersister::initialize
+async fn init_async_wallet_persister<F, P>(create_store: F) -> Result<P, PersistError>
+where
+    F: AsyncFnOnce() -> Result<P, P::Error>,
+    P: AsyncWalletPersister,
+    P::Error: core::error::Error + 'static,
+{
+    let mut persister = create_store().await.map_err(PersistError::persister)?;
+    let changeset = AsyncWalletPersister::initialize(&mut persister)
+        .await
+        .map_err(PersistError::persister)?;
+    if changeset != ChangeSet::default() {
+        return Err(PersistError::ChangeSetMismatch {
+            got: Box::new(changeset),
+            expected: Box::new(ChangeSet::default()),
+        });
+    }
+    Ok(persister)
+}
+
+/// Persists the `changeset`, and verifies the persister returns the `expected` upon
+/// initializing the backend.
+///
+/// # Errors
+///
+/// - If the [`AsyncWalletPersister`] implementation fails
+/// - If the newly initialized [`ChangeSet`] doesn't match `expected`
+async fn persist_changeset_verify_async<P>(
+    persister: &mut P,
+    changeset: &ChangeSet,
+    expected: &ChangeSet,
+) -> Result<(), PersistError>
+where
+    P: AsyncWalletPersister,
+    P::Error: core::error::Error + 'static,
+{
+    AsyncWalletPersister::persist(persister, changeset)
+        .await
+        .map_err(PersistError::persister)?;
+    let changeset = AsyncWalletPersister::initialize(persister)
+        .await
+        .map_err(PersistError::persister)?;
+    if &changeset != expected {
+        return Err(PersistError::ChangeSetMismatch {
+            got: Box::new(changeset),
+            expected: Box::new(expected.clone()),
+        });
+    }
+    Ok(())
 }

--- a/src/persist_test_utils.rs
+++ b/src/persist_test_utils.rs
@@ -1,18 +1,20 @@
 //! Utilities for testing custom persistence backends for `bdk_wallet`
 
-use crate::{
-    bitcoin::{
-        absolute, key::Secp256k1, transaction, Address, Amount, Network, OutPoint, ScriptBuf,
-        Transaction, TxIn, TxOut, Txid,
-    },
-    chain::{
-        keychain_txout::{self},
-        local_chain, tx_graph, ConfirmationBlockTime, DescriptorExt, Merge, SpkIterator,
-    },
-    locked_outpoints,
-    miniscript::descriptor::{Descriptor, DescriptorPublicKey},
-    ChangeSet, WalletPersister,
+use alloc::boxed::Box;
+use alloc::sync::Arc;
+use core::fmt;
+use core::str::FromStr;
+
+use bdk_chain::{
+    keychain_txout, local_chain, tx_graph, ConfirmationBlockTime, DescriptorExt, Merge, SpkIterator,
 };
+use bitcoin::{
+    absolute, secp256k1::Secp256k1, transaction, Address, Amount, Network, OutPoint, ScriptBuf,
+    Transaction, TxIn, TxOut, Txid,
+};
+use miniscript::{Descriptor, DescriptorPublicKey};
+
+use crate::{locked_outpoints, ChangeSet, WalletPersister};
 
 macro_rules! block_id {
     ($height:expr, $hash:literal) => {{
@@ -28,11 +30,6 @@ macro_rules! hash {
         bitcoin::hashes::Hash::hash($index.as_bytes())
     }};
 }
-
-use std::fmt::Debug;
-use std::path::Path;
-use std::str::FromStr;
-use std::sync::Arc;
 
 const DESCRIPTORS: [&str; 4] = [
     "tr([5940b9b9/86'/0'/0']tpubDDVNqmq75GNPWQ9UNKfP43UwjaHU4GYfoPavojQbfpyfZp2KetWgjGBRRAy4tYCrAA6SB11mhQAkqxjh1VtQHyKwT4oYxpwLaGHvoKmtxZf/0/*)#44aqnlam",
@@ -66,31 +63,226 @@ fn spk_at_index(descriptor: &Descriptor<DescriptorPublicKey>, index: u32) -> Scr
         .script_pubkey()
 }
 
-/// tests if [`Wallet`] is being persisted correctly
+/// Tests if [`Wallet`](crate::Wallet) is being persisted correctly.
 ///
-/// [`Wallet`]: <https://docs.rs/bdk_wallet/latest/bdk_wallet/struct.Wallet.html>
-/// [`ChangeSet`]: <https://docs.rs/bdk_wallet/latest/bdk_wallet/struct.ChangeSet.html>
-///
-/// We create a dummy [`ChangeSet`], persist it and check if loaded [`ChangeSet`] matches
-/// the persisted one. We then create another such dummy [`ChangeSet`], persist it and load it to
-/// check if merged [`ChangeSet`] is returned.
-pub fn persist_wallet_changeset<Store, CreateStore>(filename: &str, create_store: CreateStore)
+/// Persists a full [`ChangeSet`] and verifies it round-trips correctly. Then persists a second
+/// [`ChangeSet`] and verifies the backend returns the merged result.
+pub fn persist_wallet_changeset<F, P>(create_store: F) -> Result<(), PersistError>
 where
-    CreateStore: Fn(&Path) -> anyhow::Result<Store>,
-    Store: WalletPersister,
-    Store::Error: Debug,
+    F: FnOnce() -> Result<P, P::Error>,
+    P: WalletPersister,
+    P::Error: core::error::Error + 'static,
 {
-    // create store
-    let temp_dir = tempfile::tempdir().expect("must create tempdir");
-    let file_path = temp_dir.path().join(filename);
-    let mut store = create_store(&file_path).expect("store should get created");
+    let mut persister = init_wallet_persister(create_store)?;
+    let tx1 = create_one_inp_one_out_tx(hash!("We_are_all_Satoshi"), 30_000);
+    let tx2 = create_one_inp_one_out_tx(tx1.compute_txid(), 20_000);
+    let changeset1 = get_changeset(tx1);
+    persist_changeset_verify(&mut persister, &changeset1, &changeset1)?;
+    let changeset2 = get_changeset_two(tx2);
+    let mut expected = changeset1;
+    Merge::merge(&mut expected, changeset2.clone());
+    persist_changeset_verify(&mut persister, &changeset2, &expected)
+}
 
-    // initialize store
-    let changeset =
-        WalletPersister::initialize(&mut store).expect("empty changeset should get loaded");
-    assert_eq!(changeset, ChangeSet::default());
+/// tests if multiple [`Wallet`](crate::Wallet)s can be persisted in a single file correctly
+///
+/// We create a dummy [`ChangeSet`] for first wallet and persist it then we create a dummy
+/// [`ChangeSet`] for second wallet and persist that. Finally we load these two [`ChangeSet`]s and
+/// check if they were persisted correctly.
+pub fn persist_multiple_wallet_changesets<F, P>(create_stores: F) -> Result<(), PersistError>
+where
+    F: Fn() -> Result<(P, P), P::Error>,
+    P: WalletPersister,
+    P::Error: core::error::Error + 'static,
+{
+    use PersistError as E;
 
-    // create changeset
+    // create stores
+    let (mut store_first, mut store_sec) = create_stores().map_err(E::persister)?;
+
+    // initialize first store
+    let changeset = WalletPersister::initialize(&mut store_first).map_err(E::persister)?;
+
+    if changeset != ChangeSet::default() {
+        return Err(PersistError::ChangeSetMismatch {
+            got: Box::new(changeset),
+            expected: Box::new(ChangeSet::default()),
+        });
+    }
+
+    // create first changeset
+    let descriptor: Descriptor<DescriptorPublicKey> = DESCRIPTORS[0].parse().unwrap();
+    let change_descriptor: Descriptor<DescriptorPublicKey> = DESCRIPTORS[1].parse().unwrap();
+
+    let changeset1 = ChangeSet {
+        descriptor: Some(descriptor.clone()),
+        change_descriptor: Some(change_descriptor.clone()),
+        network: Some(Network::Testnet),
+        ..ChangeSet::default()
+    };
+
+    // persist first changeset
+    WalletPersister::persist(&mut store_first, &changeset1).map_err(E::persister)?;
+
+    // initialize second store
+    let changeset = WalletPersister::initialize(&mut store_sec).map_err(E::persister)?;
+
+    if changeset != ChangeSet::default() {
+        return Err(PersistError::ChangeSetMismatch {
+            got: Box::new(changeset),
+            expected: Box::new(ChangeSet::default()),
+        });
+    }
+
+    // create second changeset
+    let descriptor: Descriptor<DescriptorPublicKey> = DESCRIPTORS[2].parse().unwrap();
+    let change_descriptor: Descriptor<DescriptorPublicKey> = DESCRIPTORS[3].parse().unwrap();
+
+    let changeset2 = ChangeSet {
+        descriptor: Some(descriptor.clone()),
+        change_descriptor: Some(change_descriptor.clone()),
+        network: Some(Network::Testnet),
+        ..ChangeSet::default()
+    };
+
+    // persist second changeset
+    WalletPersister::persist(&mut store_sec, &changeset2).map_err(E::persister)?;
+
+    // load first changeset
+    let changeset_read = WalletPersister::initialize(&mut store_first).map_err(E::persister)?;
+
+    if changeset_read != changeset1 {
+        return Err(PersistError::ChangeSetMismatch {
+            got: Box::new(changeset_read),
+            expected: Box::new(changeset1),
+        });
+    }
+
+    // load second changeset
+    let changeset_read = WalletPersister::initialize(&mut store_sec).map_err(E::persister)?;
+
+    if changeset_read != changeset2 {
+        return Err(PersistError::ChangeSetMismatch {
+            got: Box::new(changeset_read),
+            expected: Box::new(changeset2),
+        });
+    }
+
+    Ok(())
+}
+
+/// Tests if [`Network`] is being persisted correctly.
+///
+/// Persists a [`ChangeSet`] with only the network field set and verifies it round-trips correctly.
+pub fn persist_network<F, P>(create_store: F) -> Result<(), PersistError>
+where
+    F: FnOnce() -> Result<P, P::Error>,
+    P: WalletPersister,
+    P::Error: core::error::Error + 'static,
+{
+    let mut persister = init_wallet_persister(create_store)?;
+    let changeset = network_changeset();
+    persist_changeset_verify(&mut persister, &changeset, &changeset)
+}
+
+/// Tests if descriptors are being persisted correctly.
+///
+/// First persists only the external descriptor (covering the single-keychain case), then persists
+/// the change descriptor and verifies the backend returns both merged.
+pub fn persist_keychains<F, P>(create_store: F) -> Result<(), PersistError>
+where
+    F: FnOnce() -> Result<P, P::Error>,
+    P: WalletPersister,
+    P::Error: core::error::Error + 'static,
+{
+    let mut persister = init_wallet_persister(create_store)?;
+    // Round 1: single keychain (external descriptor only)
+    let changeset1 = descriptor_changeset();
+    persist_changeset_verify(&mut persister, &changeset1, &changeset1)?;
+    // Round 2: add the change descriptor, verify both are returned
+    let changeset2 = change_descriptor_changeset();
+    let mut expected = changeset1;
+    Merge::merge(&mut expected, changeset2.clone());
+    persist_changeset_verify(&mut persister, &changeset2, &expected)
+}
+
+/// Initializes a new [`WalletPersister`] and checks that the persistence backend is empty.
+///
+/// # Errors
+///
+/// - If the persister's [`initialize`] function returns a non-empty [`ChangeSet`], then
+///   [`PersistError::ChangeSetMismatch`] error occurs.
+///
+/// [`initialize`]: WalletPersister::initialize
+fn init_wallet_persister<F, P>(create_store: F) -> Result<P, PersistError>
+where
+    F: FnOnce() -> Result<P, P::Error>,
+    P: WalletPersister,
+    P::Error: core::error::Error + 'static,
+{
+    let mut persister = create_store().map_err(PersistError::persister)?;
+    let changeset = WalletPersister::initialize(&mut persister).map_err(PersistError::persister)?;
+    if changeset != ChangeSet::default() {
+        return Err(PersistError::ChangeSetMismatch {
+            got: Box::new(changeset),
+            expected: Box::new(ChangeSet::default()),
+        });
+    }
+    Ok(persister)
+}
+
+/// Persists the `changeset`, and verifies the persister returns the `expected` upon
+/// initializing the backend.
+///
+/// # Errors
+///
+/// - If the [`WalletPersister`] implementation fails
+/// - If the newly initialized [`ChangeSet`] doesn't match `expected`
+fn persist_changeset_verify<P>(
+    persister: &mut P,
+    changeset: &ChangeSet,
+    expected: &ChangeSet,
+) -> Result<(), PersistError>
+where
+    P: WalletPersister,
+    P::Error: core::error::Error + 'static,
+{
+    WalletPersister::persist(persister, changeset).map_err(PersistError::persister)?;
+    let changeset = WalletPersister::initialize(persister).map_err(PersistError::persister)?;
+    if &changeset != expected {
+        return Err(PersistError::ChangeSetMismatch {
+            got: Box::new(changeset),
+            expected: Box::new(expected.clone()),
+        });
+    }
+    Ok(())
+}
+
+fn network_changeset() -> ChangeSet {
+    ChangeSet {
+        network: Some(Network::Bitcoin),
+        ..Default::default()
+    }
+}
+
+fn descriptor_changeset() -> ChangeSet {
+    let descriptor: Descriptor<DescriptorPublicKey> = DESCRIPTORS[0].parse().unwrap();
+    ChangeSet {
+        descriptor: Some(descriptor),
+        ..Default::default()
+    }
+}
+
+fn change_descriptor_changeset() -> ChangeSet {
+    let change_descriptor: Descriptor<DescriptorPublicKey> = DESCRIPTORS[1].parse().unwrap();
+    ChangeSet {
+        change_descriptor: Some(change_descriptor),
+        ..Default::default()
+    }
+}
+
+/// Creates a [`ChangeSet`].
+fn get_changeset(tx1: Transaction) -> ChangeSet {
     let descriptor: Descriptor<DescriptorPublicKey> = DESCRIPTORS[0].parse().unwrap();
     let change_descriptor: Descriptor<DescriptorPublicKey> = DESCRIPTORS[1].parse().unwrap();
 
@@ -103,11 +295,7 @@ where
         .into(),
     };
 
-    let tx1 = Arc::new(create_one_inp_one_out_tx(
-        hash!("We_are_all_Satoshi"),
-        30_000,
-    ));
-    let tx2 = Arc::new(create_one_inp_one_out_tx(tx1.compute_txid(), 20_000));
+    let txid1 = tx1.compute_txid();
 
     let conf_anchor: ConfirmationBlockTime = ConfirmationBlockTime {
         block_id: block_id!(910234, "B"),
@@ -117,7 +305,7 @@ where
     let outpoint = OutPoint::new(hash!("Rust"), 0);
 
     let tx_graph_changeset = tx_graph::ChangeSet::<ConfirmationBlockTime> {
-        txs: [tx1.clone()].into(),
+        txs: [Arc::new(tx1)].into(),
         txouts: [
             (
                 outpoint,
@@ -135,10 +323,10 @@ where
             ),
         ]
         .into(),
-        anchors: [(conf_anchor, tx1.compute_txid())].into(),
-        last_seen: [(tx1.compute_txid(), 1755317760)].into(),
-        first_seen: [(tx1.compute_txid(), 1755317750)].into(),
-        last_evicted: [(tx1.compute_txid(), 1755317760)].into(),
+        anchors: [(conf_anchor, txid1)].into(),
+        last_seen: [(txid1, 1755317760)].into(),
+        first_seen: [(txid1, 1755317750)].into(),
+        last_evicted: [(txid1, 1755317760)].into(),
     };
 
     let keychain_txout_changeset = keychain_txout::ChangeSet {
@@ -164,7 +352,7 @@ where
         outpoints: [(outpoint, true)].into(),
     };
 
-    let mut changeset = ChangeSet {
+    ChangeSet {
         descriptor: Some(descriptor.clone()),
         change_descriptor: Some(change_descriptor.clone()),
         network: Some(Network::Testnet),
@@ -172,17 +360,16 @@ where
         tx_graph: tx_graph_changeset,
         indexer: keychain_txout_changeset,
         locked_outpoints: locked_outpoints_changeset,
-    };
+    }
+}
 
-    // persist and load
-    WalletPersister::persist(&mut store, &changeset).expect("changeset should get persisted");
+/// Creates a second [`ChangeSet`].
+///
+/// To correctly test a wallet persister this should return a different
+/// [`ChangeSet`] than the one returned by [`get_changeset`].
+fn get_changeset_two(tx2: Transaction) -> ChangeSet {
+    let descriptor: Descriptor<DescriptorPublicKey> = DESCRIPTORS[0].parse().unwrap();
 
-    let changeset_read =
-        WalletPersister::initialize(&mut store).expect("changeset should get loaded");
-
-    assert_eq!(changeset, changeset_read);
-
-    // create another changeset
     let local_chain_changeset = local_chain::ChangeSet {
         blocks: [(910236, Some(hash!("BDK")))].into(),
     };
@@ -192,10 +379,12 @@ where
         confirmation_time: 1755317760,
     };
 
-    let outpoint = OutPoint::new(hash!("Bitcoin_fixes_things"), 1);
+    let txid2 = tx2.compute_txid();
+
+    let outpoint = OutPoint::new(hash!("Bitcoin_fixes_things"), 0);
 
     let tx_graph_changeset = tx_graph::ChangeSet::<ConfirmationBlockTime> {
-        txs: [tx2.clone()].into(),
+        txs: [Arc::new(tx2)].into(),
         txouts: [(
             outpoint,
             TxOut {
@@ -204,10 +393,10 @@ where
             },
         )]
         .into(),
-        anchors: [(conf_anchor, tx2.compute_txid())].into(),
-        last_seen: [(tx2.compute_txid(), 1755317700)].into(),
-        first_seen: [(tx2.compute_txid(), 1755317700)].into(),
-        last_evicted: [(tx2.compute_txid(), 1755317760)].into(),
+        anchors: [(conf_anchor, txid2)].into(),
+        last_seen: [(txid2, 1755317700)].into(),
+        first_seen: [(txid2, 1755317700)].into(),
+        last_evicted: [(txid2, 1755317760)].into(),
     };
 
     let keychain_txout_changeset = keychain_txout::ChangeSet {
@@ -223,7 +412,7 @@ where
         outpoints: [(outpoint, true)].into(),
     };
 
-    let changeset_new = ChangeSet {
+    ChangeSet {
         descriptor: None,
         change_descriptor: None,
         network: None,
@@ -231,204 +420,42 @@ where
         tx_graph: tx_graph_changeset,
         indexer: keychain_txout_changeset,
         locked_outpoints: locked_outpoints_changeset,
-    };
-
-    // persist, load and check if same as merged
-    WalletPersister::persist(&mut store, &changeset_new).expect("changeset should get persisted");
-    let changeset_read_new = WalletPersister::initialize(&mut store).unwrap();
-
-    changeset.merge(changeset_new);
-
-    assert_eq!(changeset, changeset_read_new);
+    }
 }
 
-/// tests if multiple [`Wallet`]s can be persisted in a single file correctly
-///
-/// [`Wallet`]: <https://docs.rs/bdk_wallet/latest/bdk_wallet/struct.Wallet.html>
-/// [`ChangeSet`]: <https://docs.rs/bdk_wallet/latest/bdk_wallet/struct.ChangeSet.html>
-///
-/// We create a dummy [`ChangeSet`] for first wallet and persist it then we create a dummy
-/// [`ChangeSet`] for second wallet and persist that. Finally we load these two [`ChangeSet`]s and
-/// check if they were persisted correctly.
-pub fn persist_multiple_wallet_changesets<Store, CreateStores>(
-    filename: &str,
-    create_dbs: CreateStores,
-) where
-    CreateStores: Fn(&Path) -> anyhow::Result<(Store, Store)>,
-    Store: WalletPersister,
-    Store::Error: Debug,
-{
-    // create stores
-    let temp_dir = tempfile::tempdir().expect("must create tempdir");
-    let file_path = temp_dir.path().join(filename);
-
-    let (mut store_first, mut store_sec) =
-        create_dbs(&file_path).expect("store should get created");
-
-    // initialize first store
-    let changeset =
-        WalletPersister::initialize(&mut store_first).expect("should load empty changeset");
-    assert_eq!(changeset, ChangeSet::default());
-
-    // create first changeset
-    let descriptor: Descriptor<DescriptorPublicKey> = DESCRIPTORS[0].parse().unwrap();
-    let change_descriptor: Descriptor<DescriptorPublicKey> = DESCRIPTORS[1].parse().unwrap();
-
-    let changeset1 = ChangeSet {
-        descriptor: Some(descriptor.clone()),
-        change_descriptor: Some(change_descriptor.clone()),
-        network: Some(Network::Testnet),
-        ..ChangeSet::default()
-    };
-
-    // persist first changeset
-    WalletPersister::persist(&mut store_first, &changeset1).expect("should persist changeset");
-
-    // initialize second store
-    let changeset =
-        WalletPersister::initialize(&mut store_sec).expect("should load empty changeset");
-    assert_eq!(changeset, ChangeSet::default());
-
-    // create second changeset
-    let descriptor: Descriptor<DescriptorPublicKey> = DESCRIPTORS[2].parse().unwrap();
-    let change_descriptor: Descriptor<DescriptorPublicKey> = DESCRIPTORS[3].parse().unwrap();
-
-    let changeset2 = ChangeSet {
-        descriptor: Some(descriptor.clone()),
-        change_descriptor: Some(change_descriptor.clone()),
-        network: Some(Network::Testnet),
-        ..ChangeSet::default()
-    };
-
-    // persist second changeset
-    WalletPersister::persist(&mut store_sec, &changeset2).expect("should persist changeset");
-
-    // load first changeset
-    let changeset_read =
-        WalletPersister::initialize(&mut store_first).expect("should load persisted changeset1");
-    assert_eq!(changeset_read, changeset1);
-
-    // load second changeset
-    let changeset_read =
-        WalletPersister::initialize(&mut store_sec).expect("should load persisted changeset2");
-    assert_eq!(changeset_read, changeset2);
+/// Errors caused by a failed wallet persister test.
+#[derive(Debug)]
+pub enum PersistError {
+    /// Change set mismatch
+    ChangeSetMismatch {
+        /// the resulting changeset
+        got: Box<ChangeSet>,
+        /// the expected changeset
+        expected: Box<ChangeSet>,
+    },
+    /// The wallet persister implementation failed
+    Persister(Box<dyn core::error::Error + 'static>),
 }
 
-/// tests if [`Network`] is being persisted correctly
-///
-/// [`Network`]: <https://docs.rs/bitcoin/latest/bitcoin/enum.Network.html>
-/// [`ChangeSet`]: <https://docs.rs/bdk_wallet/latest/bdk_wallet/struct.ChangeSet.html>
-///
-/// We create a dummy [`ChangeSet`] with only network field populated, persist it and check if
-/// loaded [`ChangeSet`] has the same [`Network`] as what we persisted.
-pub fn persist_network<Store, CreateStore>(filename: &str, create_store: CreateStore)
-where
-    CreateStore: Fn(&Path) -> anyhow::Result<Store>,
-    Store: WalletPersister,
-    Store::Error: Debug,
-{
-    // create store
-    let temp_dir = tempfile::tempdir().expect("must create tempdir");
-    let file_path = temp_dir.path().join(filename);
-    let mut store = create_store(&file_path).expect("store should get created");
-
-    // initialize store
-    let changeset = WalletPersister::initialize(&mut store)
-        .expect("should initialize and load empty changeset");
-    assert_eq!(changeset, ChangeSet::default());
-
-    // persist the network
-    let changeset = ChangeSet {
-        network: Some(Network::Bitcoin),
-        ..ChangeSet::default()
-    };
-    WalletPersister::persist(&mut store, &changeset).expect("should persist changeset");
-
-    // read the persisted network
-    let changeset_read =
-        WalletPersister::initialize(&mut store).expect("should load persisted changeset");
-
-    assert_eq!(changeset_read.network, Some(Network::Bitcoin));
+impl fmt::Display for PersistError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Persister(e) => write!(f, "{e}"),
+            Self::ChangeSetMismatch { got, expected } => {
+                write!(f, "expected: {expected:?}, got: {got:?}")
+            }
+        }
+    }
 }
 
-/// tests if descriptors are being persisted correctly
-///
-/// [`ChangeSet`]: <https://docs.rs/bdk_wallet/latest/bdk_wallet/struct.ChangeSet.html>
-///
-/// We create a dummy [`ChangeSet`] with only descriptor fields populated, persist it and check if
-/// loaded [`ChangeSet`] has the same descriptors as what we persisted.
-pub fn persist_keychains<Store, CreateStore>(filename: &str, create_store: CreateStore)
-where
-    CreateStore: Fn(&Path) -> anyhow::Result<Store>,
-    Store: WalletPersister,
-    Store::Error: Debug,
-{
-    // create store
-    let temp_dir = tempfile::tempdir().expect("must create tempdir");
-    let file_path = temp_dir.path().join(filename);
-    let mut store = create_store(&file_path).expect("store should get created");
+impl core::error::Error for PersistError {}
 
-    // initialize store
-    let changeset = WalletPersister::initialize(&mut store)
-        .expect("should initialize and load empty changeset");
-    assert_eq!(changeset, ChangeSet::default());
-
-    // persist the descriptors
-    let descriptor: Descriptor<DescriptorPublicKey> = DESCRIPTORS[1].parse().unwrap();
-    let change_descriptor: Descriptor<DescriptorPublicKey> = DESCRIPTORS[0].parse().unwrap();
-
-    let changeset = ChangeSet {
-        descriptor: Some(descriptor.clone()),
-        change_descriptor: Some(change_descriptor.clone()),
-        ..ChangeSet::default()
-    };
-
-    WalletPersister::persist(&mut store, &changeset).expect("should persist descriptors");
-
-    // load the descriptors
-    let changeset_read =
-        WalletPersister::initialize(&mut store).expect("should read persisted changeset");
-
-    assert_eq!(changeset_read.descriptor.unwrap(), descriptor);
-    assert_eq!(changeset_read.change_descriptor.unwrap(), change_descriptor);
-}
-
-/// tests if descriptor(in a single keychain wallet) is being persisted correctly
-///
-/// [`ChangeSet`]: <https://docs.rs/bdk_wallet/latest/bdk_wallet/struct.ChangeSet.html>
-///
-/// We create a dummy [`ChangeSet`] with only descriptor field populated, persist it and check if
-/// loaded [`ChangeSet`] has the same descriptor as what we persisted.
-pub fn persist_single_keychain<Store, CreateStore>(filename: &str, create_store: CreateStore)
-where
-    CreateStore: Fn(&Path) -> anyhow::Result<Store>,
-    Store: WalletPersister,
-    Store::Error: Debug,
-{
-    // create store
-    let temp_dir = tempfile::tempdir().expect("must create tempdir");
-    let file_path = temp_dir.path().join(filename);
-    let mut store = create_store(&file_path).expect("store should get created");
-
-    // initialize store
-    let changeset = WalletPersister::initialize(&mut store)
-        .expect("should initialize and load empty changeset");
-    assert_eq!(changeset, ChangeSet::default());
-
-    // persist descriptor
-    let descriptor: Descriptor<DescriptorPublicKey> = DESCRIPTORS[0].parse().unwrap();
-
-    let changeset = ChangeSet {
-        descriptor: Some(descriptor.clone()),
-        ..ChangeSet::default()
-    };
-
-    WalletPersister::persist(&mut store, &changeset).expect("should persist descriptors");
-
-    // load the descriptor
-    let changeset_read =
-        WalletPersister::initialize(&mut store).expect("should read persisted changeset");
-
-    assert_eq!(changeset_read.descriptor.unwrap(), descriptor);
-    assert_eq!(changeset_read.change_descriptor, None);
+impl PersistError {
+    /// Converts `e` to a [`PersistError::Persister`].
+    fn persister<E>(e: E) -> Self
+    where
+        E: core::error::Error + 'static,
+    {
+        Self::Persister(Box::new(e))
+    }
 }

--- a/tests/persisted_wallet.rs
+++ b/tests/persisted_wallet.rs
@@ -24,7 +24,7 @@ use bitcoin::{
 use miniscript::{Descriptor, DescriptorPublicKey};
 
 use bdk_wallet::persist_test_utils::{
-    persist_keychains, persist_network, persist_single_keychain, persist_wallet_changeset,
+    persist_keychains, persist_network, persist_wallet_changeset,
 };
 
 mod common;
@@ -454,42 +454,55 @@ fn two_path_descriptor_wallet_persist_and_recover() {
 
 #[test]
 fn wallet_changeset_is_persisted() {
-    persist_wallet_changeset("store.db", |path| {
-        Ok(bdk_file_store::Store::create(DB_MAGIC, path)?)
-    });
-    persist_wallet_changeset::<bdk_chain::rusqlite::Connection, _>("store.sqlite", |path| {
-        Ok(bdk_chain::rusqlite::Connection::open(path)?)
-    });
+    let tmpdir = tempfile::tempdir().unwrap();
+
+    // Test file_store
+    persist_wallet_changeset(|| {
+        bdk_file_store::Store::load_or_create(DB_MAGIC, tmpdir.path().join("store.db"))
+            .map(|(store, _)| store)
+            .map_err(bdk_wallet::FileStoreError::Load)
+    })
+    .expect("failed to persist wallet changeset");
+
+    // Test rusqlite Connection
+    persist_wallet_changeset(|| {
+        bdk_chain::rusqlite::Connection::open(tmpdir.path().join("store.sqlite"))
+    })
+    .expect("failed to persist wallet changeset");
 }
 
 #[test]
 fn keychains_are_persisted() {
-    persist_keychains("store.db", |path| {
-        Ok(bdk_file_store::Store::create(DB_MAGIC, path)?)
-    });
-    persist_keychains::<bdk_chain::rusqlite::Connection, _>("store.sqlite", |path| {
-        Ok(bdk_chain::rusqlite::Connection::open(path)?)
-    });
-}
+    let tmpdir = tempfile::tempdir().unwrap();
 
-#[test]
-fn single_keychain_is_persisted() {
-    persist_single_keychain("store.db", |path| {
-        Ok(bdk_file_store::Store::create(DB_MAGIC, path)?)
-    });
-    persist_single_keychain::<bdk_chain::rusqlite::Connection, _>("store.sqlite", |path| {
-        Ok(bdk_chain::rusqlite::Connection::open(path)?)
-    });
+    // Test file_store
+    persist_keychains(|| {
+        bdk_file_store::Store::load_or_create(DB_MAGIC, tmpdir.path().join("store.db"))
+            .map(|(store, _)| store)
+            .map_err(bdk_wallet::FileStoreError::Load)
+    })
+    .expect("failed to persist keychains");
+
+    // Test rusqlite Connection
+    persist_keychains(|| bdk_chain::rusqlite::Connection::open(tmpdir.path().join("store.sqlite")))
+        .expect("failed to persist keychains");
 }
 
 #[test]
 fn network_is_persisted() {
-    persist_network("store.db", |path| {
-        Ok(bdk_file_store::Store::create(DB_MAGIC, path)?)
-    });
-    persist_network::<bdk_chain::rusqlite::Connection, _>("store.sqlite", |path| {
-        Ok(bdk_chain::rusqlite::Connection::open(path)?)
-    });
+    let tmpdir = tempfile::tempdir().unwrap();
+
+    // Test file_store
+    persist_network(|| {
+        bdk_file_store::Store::load_or_create(DB_MAGIC, tmpdir.path().join("store.db"))
+            .map(|(store, _)| store)
+            .map_err(bdk_wallet::FileStoreError::Load)
+    })
+    .expect("failed to persist network");
+
+    // Test rusqlite Connection
+    persist_network(|| bdk_chain::rusqlite::Connection::open(tmpdir.path().join("store.sqlite")))
+        .expect("failed to persist network");
 }
 
 #[test]


### PR DESCRIPTION
### Description

Refactors the `persist_test_utils` module and extends it with an async test suite for `AsyncWalletPersister`.

903bd848be3f157747c3f690ae7bd020064012ed: Refactor WalletPersister suite + update deps

The public test functions previously took a `filename: &str` and a path-based closure, managed `tempfile::tempdir()` internally, and panicked on failure. This redesigns the API so callers supply a `FnOnce() -> Result<P, P::Error>` closure that owns the store directly, and all functions return `Result<(), PersistError>` instead of panicking. A new `PersistError` enum exposes failures as structured values with `ChangeSetMismatch { got, expected }` and `Persister(Box<dyn core::error::Error>)` variants. `persist_single_keychain` is removed, and its coverage is absorbed into `persist_keychains`, which now runs two rounds: external descriptor only (the single-keychain case), then external plus change descriptor with merge verification. `anyhow` and `tempfile` are removed from the `test-utils` feature's optional dependencies and kept only as `dev-dependencies`.

6dc8fe5580f3d2dda670f30aca108b419d96280e: Add async suite to test AsyncWalletPersister

Adds async counterparts to every public function in the `WalletPersister` test suite so implementors of `AsyncWalletPersister` can exercise the same scenarios: `persist_wallet_changeset_async`, `persist_keychains_async`, and `persist_network_async`. Two private helpers, `init_async_wallet_persister` and `persist_changeset_verify_async`, mirror the sync suite API. All entry points use the `F: AsyncFnOnce() -> Result<P, P::Error>` bound, consistent with the sync API pattern.

Potential follow-ups:

- [ ] Add async counterpart for `persist_multiple_wallet_changesets`

### Changelog notice

**Added**
- `persist_wallet_changeset_async`, `persist_keychains_async`, `persist_network_async` to `persist_test_utils` for testing `AsyncWalletPersister` implementations

**Changed**
- Refactored `persist_test_utils` public API: callers own store construction; functions now return `Result<(), PersistError>` instead of panicking
- Added `PersistError` enum with `ChangeSetMismatch` and `Persister` variants
- `persist_keychains` now covers the single-keychain case; `persist_single_keychain` removed
- Removed optional `anyhow` and `tempfile` dependencies from the `test-utils` feature

### Checklists

#### All Submissions:

* [x] I ran `just p` before pushing

#### New Features:

* [x] This pull request breaks the existing API
* [x] I've added docs for the new feature