### PR TITLE
Add wallet birthday to `CreateParams`

### DIFF
--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -447,7 +447,12 @@ impl Wallet {
         let genesis_hash = params
             .genesis_hash
             .unwrap_or(genesis_block(network).block_hash());
-        let (chain, chain_changeset) = LocalChain::from_genesis_hash(genesis_hash);
+        let (mut chain, chain_changeset) = LocalChain::from_genesis_hash(genesis_hash);
+        if let Some(birthday) = params.birthday {
+            chain
+                .apply_update(CheckPoint::new(birthday))
+                .expect("wallet birthday overrides genesis hash.");
+        }
 
         let (descriptor, mut descriptor_keymap) = (params.descriptor)(&secp, network_kind)?;
         check_wallet_descriptor(&descriptor)?;

--- a/src/wallet/params.rs
+++ b/src/wallet/params.rs
@@ -1,6 +1,6 @@
 use alloc::boxed::Box;
 
-use bdk_chain::keychain_txout::DEFAULT_LOOKAHEAD;
+use bdk_chain::{keychain_txout::DEFAULT_LOOKAHEAD, BlockId};
 use bitcoin::{BlockHash, Network, NetworkKind};
 use miniscript::descriptor::KeyMap;
 
@@ -65,6 +65,7 @@ pub struct CreateParams {
     pub(crate) change_descriptor_keymap: KeyMap,
     pub(crate) network: Network,
     pub(crate) genesis_hash: Option<BlockHash>,
+    pub(crate) birthday: Option<BlockId>,
     pub(crate) lookahead: u32,
     pub(crate) use_spk_cache: bool,
 }
@@ -88,6 +89,7 @@ impl CreateParams {
             change_descriptor_keymap: KeyMap::default(),
             network: Network::Bitcoin,
             genesis_hash: None,
+            birthday: None,
             lookahead: DEFAULT_LOOKAHEAD,
             use_spk_cache: false,
         }
@@ -110,6 +112,7 @@ impl CreateParams {
             change_descriptor_keymap: KeyMap::default(),
             network: Network::Bitcoin,
             genesis_hash: None,
+            birthday: None,
             lookahead: DEFAULT_LOOKAHEAD,
             use_spk_cache: false,
         }
@@ -135,6 +138,7 @@ impl CreateParams {
             change_descriptor_keymap: KeyMap::default(),
             network: Network::Bitcoin,
             genesis_hash: None,
+            birthday: None,
             lookahead: DEFAULT_LOOKAHEAD,
             use_spk_cache: false,
         }
@@ -159,6 +163,13 @@ impl CreateParams {
     /// Use a custom `genesis_hash`.
     pub fn genesis_hash(mut self, genesis_hash: BlockHash) -> Self {
         self.genesis_hash = Some(genesis_hash);
+        self
+    }
+
+    /// Begin wallet scanning from the specified birthday. Particularly useful for block-based
+    /// scanning sources.
+    pub fn birthday(mut self, birthday: BlockId) -> Self {
+        self.birthday = Some(birthday);
         self
     }
 


### PR DESCRIPTION
There has been discussion offline on how to improve the experience for recovering wallets using block-by-block scanning methods. A birthday has come up multiple times, so I introduce one here in `CreateParams`.

I believe the `expect` may only be hit when attempting to over-write the genesis block. If we want to return the error, it would require a break in the error type. IMO this seems unnecessary, as a birthday should not attempt to replace genesis.

This may be used immediately in `Wallet::latest_checkpoint` or similar.

### Changelog notice

- Added `birthday` parameter to `CreateParams`

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `just p` before pushing

#### New Features:

* [ ] I've added tests for the new feature
* [x] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
