### PR TITLE
Bump Rust compiler version to stable (1.91.1)

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.90.0"
+channel = "1.91.1"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
This is just a straight bump of the default compiler version specified in `rust-toolchain.toml` to [1.91.1, the latest stable](https://releases.rs/).