### PR TITLE
Add CPFP Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 bdk_chain = { version = "0.23.1", features = ["miniscript", "serde"], default-features = false }
+bdk_coin_select = { version = "0.4.1" }
+bdk_tx = { version = "0.1.0" }
 bitcoin = { version = "0.32.7", features = ["serde", "base64"], default-features = false }
 miniscript = { version = "12.3.1", features = ["serde"], default-features = false }
 rand_core = { version = "0.6.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 bdk_chain = { version = "0.23.1", features = ["miniscript", "serde"], default-features = false }
 bdk_coin_select = { version = "0.4.1" }
-bdk_tx = { version = "0.1.0" }
 bitcoin = { version = "0.32.7", features = ["serde", "base64"], default-features = false }
 miniscript = { version = "12.3.1", features = ["serde"], default-features = false }
 rand_core = { version = "0.6.0" }
@@ -31,6 +30,11 @@ anyhow = { version = "1.0.98", optional = true }
 bdk_file_store = { version = "0.21.1", optional = true }
 bip39 = { version = "2.0", optional = true }
 tempfile = { version = "3.20.0", optional = true }
+
+[dependencies.bdk_tx]
+version = "0.2.0"
+git = "https://github.com/valuedmammal/bdk-tx"
+branch = "release/0_2_0"
 
 [features]
 default = ["std"]

--- a/examples/cpfp.rs
+++ b/examples/cpfp.rs
@@ -1,0 +1,112 @@
+use bdk_tx::Signer;
+use bdk_wallet::{KeychainKind, Wallet};
+use bitcoin::{
+    consensus::encode::deserialize_hex, secp256k1::Secp256k1, Amount, Network, OutPoint, ScriptBuf,
+    Transaction, TxOut,
+};
+use miniscript::Descriptor;
+use std::sync::Arc;
+
+const EXTERNAL: &str = "tr(tprv8ZgxMBicQKsPd3krDUsBAmtnRsK3rb8u5yi1zhQgMhF1tR8MW7xfE4rnrbbsrbPR52e7rKapu6ztw1jXveJSCGHEriUGZV7mCe88duLp5pj/86'/1'/0'/0/*)";
+const INTERNAL: &str = "tr(tprv8ZgxMBicQKsPd3krDUsBAmtnRsK3rb8u5yi1zhQgMhF1tR8MW7xfE4rnrbbsrbPR52e7rKapu6ztw1jXveJSCGHEriUGZV7mCe88duLp5pj/86'/1'/0'/1/*)";
+
+const FEERATE: f32 = 10.0;
+
+fn main() -> anyhow::Result<()> {
+    let secp = Secp256k1::new();
+    let (external_desc, mut keymap) = Descriptor::parse_descriptor(&secp, EXTERNAL)?;
+    let (internal_desc, internal_keymap) = Descriptor::parse_descriptor(&secp, INTERNAL)?;
+    keymap.extend(internal_keymap);
+
+    let mut wallet = Wallet::create(external_desc, internal_desc)
+        .network(Network::Regtest)
+        .create_wallet_no_persist()?;
+
+    // Track balances for sanity checking
+    let initial_balance = wallet.balance().total();
+    println!("Initial balance: {}", initial_balance);
+
+    let tx0: Transaction = deserialize_hex(
+        "02000000000101401087cb611c1173462be69d8abb501edaf0e89cf086d0c88e377043fc7f6bde0000000000fdffffff02db1285270100000022512049c3c5eac192a9ee551f1a3a45bbb47c68c7c01e8d007847a44cdca20080a55f80de80020000000022512005472086085253543288c12a67aa2975f1e8e698b1f026d625238ef84abbfe2b024730440220787949255eb0af8e9f69b6e4f112a3a157c02a4498b87f5dede45eafd46405390220435c5562e86d1a2ad3f752d90d1fb877d8a207b09b5688c5d3371c201c534f9e012102cb066247461fb43246467b94f72497be4f5fa863baeca191c431648559e7efd365000000",
+    )?;
+    let tx0 = Arc::new(tx0);
+    let outpoint = fund_wallet(&mut wallet, tx0.clone())?;
+
+    let funded_balance = wallet.balance().total();
+    println!("Balance after funding: {} sat", funded_balance);
+
+    let next_index = wallet.next_derivation_index(KeychainKind::External);
+    let definite_descriptor: Descriptor<miniscript::DefiniteDescriptorKey> = wallet
+        .public_descriptor(KeychainKind::External)
+        .at_derivation_index(next_index)?;
+
+    let target_feerate = bdk_coin_select::FeeRate::from_sat_per_vb(FEERATE);
+
+    let (mut psbt, finalizer) =
+        wallet.create_sweep(outpoint, definite_descriptor, target_feerate)?;
+
+    let _ = psbt.sign(&Signer(keymap), &secp).unwrap();
+    let res = finalizer.finalize(&mut psbt);
+    assert!(res.is_finalized());
+
+    let tx1 = psbt.extract_tx().expect("Must be finalized!");
+    assert_eq!(tx1.input.len(), 1, "Child should have 1 input");
+    assert_eq!(
+        tx1.input[0].previous_output, outpoint,
+        "Should spend from parent"
+    );
+
+    wallet.apply_unconfirmed_txs([(Arc::new(tx1.clone()), 110)]);
+    let tx1 = Arc::new(tx1);
+
+    compute_feerate(&wallet, &[tx0, tx1]);
+
+    let final_balance = wallet.balance().total();
+    println!("Final balance: {} sat", final_balance);
+
+    Ok(())
+}
+
+/// Compute the package feerate and print it to stdout.
+fn compute_feerate(wallet: &Wallet, txs: &[Arc<Transaction>]) {
+    let mut acc_fee = 0;
+    let mut acc_vsize = 0;
+
+    for tx in txs {
+        let fee = wallet.calculate_fee(tx).unwrap().to_sat();
+        let vsize = tx.vsize() as u64;
+        let feerate = fee as f32 / vsize as f32;
+        println!("Fee {fee} Vsize {vsize} FeeRate {}", feerate);
+        acc_fee += fee;
+        acc_vsize += vsize;
+    }
+
+    println!("Target feerate {}", FEERATE);
+    println!("Package feerate {}", acc_fee as f32 / acc_vsize as f32);
+}
+
+fn fund_wallet(wallet: &mut Wallet, tx0: Arc<Transaction>) -> anyhow::Result<OutPoint> {
+    let txid0 = tx0.compute_txid();
+
+    // Previous output of tx0. This is needed for fee calculation.
+    let prevout = OutPoint::new(
+        "de6b7ffc4370378ec8d086f09ce8f0da1e50bb8a9de62b4673111c61cb871040".parse()?,
+        0,
+    );
+    let txout = TxOut {
+        script_pubkey: ScriptBuf::from_hex("0014ca5688311d4d0637f1c66bfd495eee02c5fe1755")?,
+        value: Amount::from_btc(50.0)?,
+    };
+    wallet.insert_txout(prevout, txout);
+    wallet.apply_unconfirmed_txs([(tx0.clone(), 100)]);
+
+    let outpoint = tx0
+        .output
+        .iter()
+        .enumerate()
+        .find(|(_vout, txo)| txo.value == Amount::from_btc(0.42).unwrap())
+        .map(|(vout, _)| OutPoint::new(txid0, vout as u32))
+        .unwrap();
+
+    Ok(outpoint)
+}

--- a/examples/psbt.rs
+++ b/examples/psbt.rs
@@ -47,7 +47,7 @@ fn main() -> anyhow::Result<()> {
     let feerate = feerate_unchecked(FEERATE);
     params
         .add_recipients([(addr, AMOUNT)])
-        .feerate(feerate)
+        .fee(bdk_tx::FeeStrategy::FeeRate(feerate))
         .coin_selection(SingleRandomDraw);
 
     // Create PSBT (which also returns the Finalizer).

--- a/examples/psbt.rs
+++ b/examples/psbt.rs
@@ -1,0 +1,117 @@
+#![allow(clippy::print_stdout)]
+
+use std::collections::HashMap;
+use std::str::FromStr;
+
+use bdk_chain::BlockId;
+use bdk_chain::ConfirmationBlockTime;
+use bdk_wallet::psbt::{PsbtParams, SelectionStrategy::*};
+use bdk_wallet::test_utils::*;
+use bdk_wallet::{KeychainKind::External, Wallet};
+use bitcoin::{
+    bip32, consensus,
+    secp256k1::{self, rand},
+    Address, Amount, TxIn, TxOut,
+};
+use rand::Rng;
+
+// This example shows how to create a PSBT using BDK Wallet.
+
+const NETWORK: bitcoin::Network = bitcoin::Network::Signet;
+const SEND_TO: &str = "tb1pw3g5qvnkryghme7pyal228ekj6vq48zc5k983lqtlr2a96n4xw0q5ejknw";
+const AMOUNT: Amount = Amount::from_sat(42_000);
+const FEERATE: f64 = 2.0; // sat/vb
+
+fn main() -> anyhow::Result<()> {
+    let (desc, change_desc) = get_test_wpkh_and_change_desc();
+    let secp = secp256k1::Secp256k1::new();
+
+    // Xpriv to be used for signing the PSBT
+    let xprv = bip32::Xpriv::from_str("tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L")?;
+
+    // Create wallet and fund it.
+    let mut wallet = Wallet::create(desc, change_desc)
+        .network(NETWORK)
+        .create_wallet_no_persist()?;
+
+    fund_wallet(&mut wallet)?;
+
+    let utxos = wallet
+        .list_unspent()
+        .map(|output| (output.outpoint, output))
+        .collect::<HashMap<_, _>>();
+
+    // Build params.
+    let mut params = PsbtParams::default();
+    let addr = Address::from_str(SEND_TO)?.require_network(NETWORK)?;
+    let feerate = feerate_unchecked(FEERATE);
+    params
+        .add_recipients([(addr, AMOUNT)])
+        .feerate(feerate)
+        .coin_selection(SingleRandomDraw);
+
+    // Create PSBT (which also returns the Finalizer).
+    let (mut psbt, finalizer) = wallet.create_psbt(params)?;
+
+    dbg!(&psbt);
+
+    let tx = &psbt.unsigned_tx;
+    for txin in &tx.input {
+        let op = txin.previous_output;
+        let output = utxos.get(&op).unwrap();
+        println!("TxIn: {}", output.txout.value);
+    }
+    for txout in &tx.output {
+        println!("TxOut: {}", txout.value);
+    }
+
+    let _ = psbt.sign(&xprv, &secp);
+    println!("Signed: {}", !psbt.inputs[0].partial_sigs.is_empty());
+    let finalize_res = finalizer.finalize(&mut psbt);
+    println!("Finalized: {}", finalize_res.is_finalized());
+
+    let tx = psbt.extract_tx()?;
+    let feerate = wallet.calculate_fee_rate(&tx)?;
+    println!("Fee rate: {} sat/vb", bdk_wallet::floating_rate!(feerate));
+
+    println!("{}", consensus::encode::serialize_hex(&tx));
+
+    Ok(())
+}
+
+fn fund_wallet(wallet: &mut Wallet) -> anyhow::Result<()> {
+    let anchor = ConfirmationBlockTime {
+        block_id: BlockId {
+            height: 260071,
+            hash: "000000099f67ae6469d1ad0525d756e24d4b02fbf27d65b3f413d5feb367ec48".parse()?,
+        },
+        confirmation_time: 1752184658,
+    };
+    insert_checkpoint(wallet, anchor.block_id);
+
+    let mut rng = rand::thread_rng();
+
+    // Fund wallet with several random utxos
+    for i in 0..21 {
+        let addr = wallet.reveal_next_address(External).address;
+        let value = 10_000 * (i + 1) + (100 * rng.gen_range(0..10));
+        let tx = bitcoin::Transaction {
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            version: bitcoin::transaction::Version::TWO,
+            input: vec![TxIn::default()],
+            output: vec![TxOut {
+                script_pubkey: addr.script_pubkey(),
+                value: Amount::from_sat(value),
+            }],
+        };
+        insert_tx_anchor(wallet, tx, anchor.block_id);
+    }
+
+    let tip = BlockId {
+        height: 260171,
+        hash: "0000000b9efb77450e753ae9fd7be9f69219511c27b6e95c28f4126f3e1591c3".parse()?,
+    };
+    insert_checkpoint(wallet, tip);
+
+    Ok(())
+}

--- a/examples/rbf.rs
+++ b/examples/rbf.rs
@@ -1,0 +1,92 @@
+#![allow(clippy::print_stdout)]
+
+use std::str::FromStr;
+use std::sync::Arc;
+
+use bdk_chain::BlockId;
+use bdk_wallet::test_utils::*;
+use bdk_wallet::Wallet;
+use bitcoin::{bip32, consensus, secp256k1, Address, FeeRate, Transaction};
+
+// This example shows how to create a Replace-By-Fee (RBF) transaction using BDK Wallet.
+
+const NETWORK: bitcoin::Network = bitcoin::Network::Regtest;
+const SEND_TO: &str = "bcrt1q3yfqg2v9d605r45y5ddt5unz5n8v7jl5yk4a4f";
+
+fn main() -> anyhow::Result<()> {
+    let desc = "wpkh(tprv8ZgxMBicQKsPe5tkv8BYJRupCNULhJYDv6qrtVAK9fNVheU6TbscSedVi8KQk8vVZqXMnsGomtVkR4nprbgsxTS5mAQPV4dpPXNvsmYcgZU/84h/1h/0h/0/*)";
+    let change_desc = "wpkh(tprv8ZgxMBicQKsPe5tkv8BYJRupCNULhJYDv6qrtVAK9fNVheU6TbscSedVi8KQk8vVZqXMnsGomtVkR4nprbgsxTS5mAQPV4dpPXNvsmYcgZU/84h/1h/0h/1/*)";
+    let secp = secp256k1::Secp256k1::new();
+
+    // Xpriv to be used for signing the PSBT
+    let xprv = bip32::Xpriv::from_str("tprv8ZgxMBicQKsPe5tkv8BYJRupCNULhJYDv6qrtVAK9fNVheU6TbscSedVi8KQk8vVZqXMnsGomtVkR4nprbgsxTS5mAQPV4dpPXNvsmYcgZU")?;
+
+    // Create wallet and "fund" it.
+    let mut wallet = Wallet::create(desc, change_desc)
+        .network(NETWORK)
+        .create_wallet_no_persist()?;
+
+    // `tx_1` is the unconfirmed wallet tx that we want to replace.
+    let tx_1 = fund_wallet(&mut wallet)?;
+    wallet.apply_unconfirmed_txs([(tx_1.clone(), 1234567000)]);
+
+    // We'll need to fill in the original recipient details.
+    let addr = Address::from_str(SEND_TO)?.require_network(NETWORK)?;
+    let txo = tx_1
+        .output
+        .iter()
+        .find(|txo| txo.script_pubkey == addr.script_pubkey())
+        .expect("failed to find orginal recipient")
+        .clone();
+
+    // Now build fee bump.
+    let (mut psbt, finalizer) = wallet.replace_by_fee_and_recipients(
+        &[Arc::clone(&tx_1)],
+        FeeRate::from_sat_per_vb_unchecked(5),
+        vec![(txo.script_pubkey, txo.value)],
+    )?;
+
+    let _ = psbt.sign(&xprv, &secp);
+    println!("Signed: {}", !psbt.inputs[0].partial_sigs.is_empty());
+    let finalize_res = finalizer.finalize(&mut psbt);
+    println!("Finalized: {}", finalize_res.is_finalized());
+
+    let tx = psbt.extract_tx()?;
+    let feerate = wallet.calculate_fee_rate(&tx)?;
+    println!("Fee rate: {} sat/vb", bdk_wallet::floating_rate!(feerate));
+
+    println!("{}", consensus::encode::serialize_hex(&tx));
+
+    wallet.apply_unconfirmed_txs([(tx.clone(), 1234567001)]);
+
+    let txid_2 = tx.compute_txid();
+
+    assert!(
+        wallet
+            .tx_graph()
+            .direct_conflicts(&tx_1)
+            .any(|(_, txid)| txid == txid_2),
+        "ERROR: RBF tx does not replace `tx_1`",
+    );
+
+    Ok(())
+}
+
+fn fund_wallet(wallet: &mut Wallet) -> anyhow::Result<Arc<Transaction>> {
+    // The parent of `tx`. This is needed to compute the original fee.
+    let tx0: Transaction = consensus::encode::deserialize_hex(
+        "020000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff025100ffffffff0200f2052a010000001600144d34238b9c4c59b9e2781e2426a142a75b8901ab0000000000000000266a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf90120000000000000000000000000000000000000000000000000000000000000000000000000",
+    )?;
+
+    let anchor_block = BlockId {
+        height: 101,
+        hash: "3bcc1c447c6b3886f43e416b5c21cf5c139dc4829a71dc78609bc8f6235611c5".parse()?,
+    };
+    insert_tx_anchor(wallet, tx0, anchor_block);
+
+    let tx: Transaction = consensus::encode::deserialize_hex(
+        "020000000001014cb96536e94ba3f840cb5c2c965c8f9a306209de63fcd02060219aaf14f1d7b30000000000fdffffff0280de80020000000016001489120429856e9f41d684a35aba7262a4cecf4bf4f312852701000000160014757a57b3009c0e9b2b9aa548434dc295e21aeb05024730440220400c0a767ce42e0ea02b72faabb7f3433e607b475111285e0975bba1e6fd2e13022059453d83cbacb6652ba075f59ca0437036f3f94cae1959c7c5c0f96a8954707a012102c0851c2d2bddc1dd0b05caeac307703ec0c4b96ecad5a85af47f6420e2ef6c661b000000",
+    )?;
+
+    Ok(Arc::new(tx))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ pub use bdk_chain::rusqlite;
 pub use bdk_chain::rusqlite_impl;
 pub use descriptor::template;
 pub use descriptor::HdKeyPaths;
+pub use psbt::*;
 pub use signer;
 pub use signer::SignOptions;
 pub use tx_builder::*;

--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -17,7 +17,6 @@ use bitcoin::FeeRate;
 use bitcoin::Psbt;
 use bitcoin::TxOut;
 
-#[allow(unused)]
 mod params;
 
 pub use params::*;

--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -17,6 +17,11 @@ use bitcoin::FeeRate;
 use bitcoin::Psbt;
 use bitcoin::TxOut;
 
+#[allow(unused)]
+mod params;
+
+pub use params::*;
+
 // TODO upstream the functions here to `rust-bitcoin`?
 
 /// Trait to add functions to extract utxos and calculate fees.

--- a/src/psbt/params.rs
+++ b/src/psbt/params.rs
@@ -28,6 +28,7 @@ pub struct ReplaceTx;
 pub type Rbf = ReplaceTx;
 
 /// Parameters to create a PSBT.
+// TODO: Can we derive `Clone` for this?
 #[derive(Debug)]
 pub struct PsbtParams<C> {
     /// Set of selected UTXO outpoints.
@@ -465,6 +466,7 @@ pub enum SelectionStrategy {
 /// for coin selection. This has a default implementation that enables selection of all
 /// txouts passed to it.
 #[allow(clippy::type_complexity)]
+#[derive(Clone)]
 pub(crate) struct UtxoFilter(
     pub Arc<dyn Fn(&FullTxOut<ConfirmationBlockTime>) -> bool + Send + Sync>,
 );

--- a/src/psbt/params.rs
+++ b/src/psbt/params.rs
@@ -30,39 +30,53 @@ pub type Rbf = ReplaceTx;
 /// Parameters to create a PSBT.
 #[derive(Debug)]
 pub struct PsbtParams<C> {
-    // Inputs
+    /// Set of selected UTXO outpoints.
     pub(crate) set: HashSet<OutPoint>,
+    /// List of UTXO outpoints to spend.
     pub(crate) utxos: Vec<OutPoint>,
+    /// List of planned transaction [`Input`]s.
     pub(crate) inputs: Vec<Input>,
-
-    // Outputs
+    /// List of recipient script/amount pairs.
     pub(crate) recipients: Vec<(ScriptBuf, Amount)>,
+    /// Optional script or descriptor designated for change.
     pub(crate) change_script: Option<ScriptSource>,
-
-    // Coin Selection
+    /// Optional assets for creating a spend plan.
     pub(crate) assets: Option<Assets>,
+    /// Fee targeting strategy.
     pub(crate) fee_strategy: FeeStrategy,
+    /// Policy for creating change outputs.
     pub(crate) change_policy: ChangePolicy,
+    /// Whether to spend all available coins.
     pub(crate) drain_wallet: bool,
+    /// Coin selection strategy to use.
     pub(crate) coin_selection: SelectionStrategy,
+    /// Parameters for transaction canonicalization.
     pub(crate) canonical_params: CanonicalizationParams,
+    /// UTXO filtering function.
     pub(crate) utxo_filter: UtxoFilter,
+    /// Optional height for evaluating coinbase maturity.
     pub(crate) maturity_height: Option<u32>,
+    /// Only allow spending UTXOs which are selected manually.
     pub(crate) manually_selected_only: bool,
-
-    // PSBT
+    /// Optional transaction [`Version`].
     pub(crate) version: Option<Version>,
+    /// Optional transaction [`LockTime`](absolute::LockTime).
     pub(crate) locktime: Option<absolute::LockTime>,
+    /// Optional fallback [`Sequence`] for inputs.
     pub(crate) fallback_sequence: Option<Sequence>,
+    /// Ordering of the transaction's inputs and outputs.
     pub(crate) ordering: TxOrdering<Input, Output>,
+    /// Only set the [`witness_utxo`](bitcoin::psbt::Input::witness_utxo) in PSBT inputs. This
+    /// allows opting out of setting the
+    /// [`non_witness_utxo`](bitcoin::psbt::Input::non_witness_utxo).
     pub(crate) only_witness_utxo: bool,
+    /// Optional PSBT sighash type.
     pub(crate) sighash_type: Option<PsbtSighashType>,
+    /// Whether to try filling in the PSBT global xpubs from the wallet's descriptors.
     pub(crate) add_global_xpubs: bool,
-
-    // RBF
+    /// Set of txids being replaced if this is a RBF transaction.
     pub(crate) replace: HashSet<Txid>,
-
-    /// Context marker.
+    /// The context in which the params are used.
     pub(crate) marker: core::marker::PhantomData<C>,
 }
 

--- a/src/psbt/params.rs
+++ b/src/psbt/params.rs
@@ -1,0 +1,582 @@
+//! Parameters for creating a PSBT.
+
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::fmt;
+
+use bdk_chain::{BlockId, CanonicalizationParams, ConfirmationBlockTime, FullTxOut, TxGraph};
+use bdk_tx::{DefiniteDescriptor, Input, Output};
+use bitcoin::{
+    absolute, transaction::Version, Amount, FeeRate, OutPoint, ScriptBuf, Sequence, Transaction,
+    Txid,
+};
+use miniscript::plan::Assets;
+
+use crate::collections::HashSet;
+use crate::TxOrdering;
+
+/// Marker type representing the PSBT creation state.
+#[derive(Debug)]
+pub struct CreateTx;
+
+/// Marker type representing the Replace-By-Fee (RBF) state.
+#[derive(Debug)]
+pub struct ReplaceTx;
+
+/// Alias for [`ReplaceTx`] context marker.
+pub type Rbf = ReplaceTx;
+
+/// Parameters to create a PSBT.
+#[derive(Debug)]
+pub struct PsbtParams<C> {
+    // Inputs
+    pub(crate) set: HashSet<OutPoint>,
+    pub(crate) utxos: Vec<OutPoint>,
+    pub(crate) inputs: Vec<Input>,
+
+    // Outputs
+    pub(crate) recipients: Vec<(ScriptBuf, Amount)>,
+    pub(crate) change_descriptor: Option<DefiniteDescriptor>,
+
+    // Coin Selection
+    pub(crate) assets: Option<Assets>,
+    pub(crate) feerate: FeeRate,
+    pub(crate) longterm_feerate: FeeRate,
+    pub(crate) drain_wallet: bool,
+    pub(crate) coin_selection: SelectionStrategy,
+    pub(crate) canonical_params: CanonicalizationParams,
+    pub(crate) utxo_filter: UtxoFilter,
+    pub(crate) maturity_height: Option<u32>,
+    pub(crate) manually_selected_only: bool,
+
+    // PSBT
+    pub(crate) version: Option<Version>,
+    pub(crate) locktime: Option<absolute::LockTime>,
+    pub(crate) fallback_sequence: Option<Sequence>,
+    pub(crate) ordering: TxOrdering<Input, Output>,
+    pub(crate) only_witness_utxo: bool,
+    pub(crate) add_global_xpubs: bool,
+
+    // RBF
+    pub(crate) replace: HashSet<Txid>,
+
+    /// Context marker.
+    pub(crate) marker: core::marker::PhantomData<C>,
+}
+
+impl Default for PsbtParams<CreateTx> {
+    fn default() -> Self {
+        Self {
+            set: Default::default(),
+            utxos: Default::default(),
+            inputs: Default::default(),
+            assets: Default::default(),
+            recipients: Default::default(),
+            change_descriptor: Default::default(),
+            feerate: bitcoin::FeeRate::BROADCAST_MIN,
+            longterm_feerate: bitcoin::FeeRate::from_sat_per_vb_unchecked(10),
+            drain_wallet: Default::default(),
+            coin_selection: Default::default(),
+            canonical_params: Default::default(),
+            utxo_filter: Default::default(),
+            maturity_height: Default::default(),
+            manually_selected_only: Default::default(),
+            version: Default::default(),
+            locktime: Default::default(),
+            fallback_sequence: Default::default(),
+            ordering: Default::default(),
+            only_witness_utxo: Default::default(),
+            add_global_xpubs: Default::default(),
+            replace: Default::default(),
+            marker: core::marker::PhantomData,
+        }
+    }
+}
+
+impl PsbtParams<CreateTx> {
+    /// Create a new [`PsbtParams`].
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add UTXOs by outpoint to fund the transaction.
+    ///
+    /// A single outpoint may appear at most once in the list of UTXOs to spend. The caller is
+    /// responsible for ensuring that items of `outpoints` correspond to outputs of previous
+    /// transactions and are currently unspent.
+    ///
+    /// If an outpoint doesn't correspond to an indexed script pubkey, a [`UnknownUtxo`]
+    /// error will occur. See [`Wallet::create_psbt`] for more.
+    ///
+    /// To add a UTXO that did not originate from this wallet (i.e. a "foreign" UTXO), see
+    /// [`PsbtParams::add_planned_input`].
+    ///
+    /// [`UnknownUtxo`]: crate::wallet::error::CreatePsbtError::UnknownUtxo
+    /// [`Wallet::create_psbt`]: crate::Wallet::create_psbt
+    pub fn add_utxos(&mut self, outpoints: &[OutPoint]) -> &mut Self {
+        self.utxos
+            .extend(outpoints.iter().copied().filter(|&op| self.set.insert(op)));
+        self
+    }
+
+    /// Replace spends of the given `txs` and return a [`PsbtParams`] populated with the
+    /// the inputs to spend.
+    ///
+    /// This merges all of the spends into a single transaction while retaining the parameters
+    /// of `self`. Note however that any previously added UTXOs are removed. Call
+    /// [`replace_by_fee_with_rng`](crate::Wallet::replace_by_fee_with_rng) to finish
+    /// building the PSBT.
+    ///
+    /// ## Note
+    ///
+    /// There should be no ancestry linking the elements of `txs`, since replacing an
+    /// ancestor necessarily invalidates the descendant.
+    pub fn replace_txs(self, txs: &[Arc<Transaction>]) -> PsbtParams<Rbf> {
+        let mut params = self.into_replace_params();
+        params.replace(txs);
+        params
+    }
+
+    /// Transition this [`PsbtParams`] to the [`Rbf`] state.
+    fn into_replace_params(self) -> PsbtParams<Rbf> {
+        PsbtParams {
+            set: self.set,
+            utxos: self.utxos,
+            inputs: self.inputs,
+            assets: self.assets,
+            recipients: self.recipients,
+            change_descriptor: self.change_descriptor,
+            feerate: self.feerate,
+            longterm_feerate: self.longterm_feerate,
+            drain_wallet: self.drain_wallet,
+            coin_selection: self.coin_selection,
+            canonical_params: self.canonical_params,
+            utxo_filter: self.utxo_filter,
+            maturity_height: self.maturity_height,
+            manually_selected_only: self.manually_selected_only,
+            version: self.version,
+            locktime: self.locktime,
+            fallback_sequence: self.fallback_sequence,
+            ordering: self.ordering,
+            only_witness_utxo: self.only_witness_utxo,
+            add_global_xpubs: self.add_global_xpubs,
+            replace: self.replace,
+            marker: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<C> PsbtParams<C> {
+    /// Get the currently selected spends.
+    pub fn utxos(&self) -> &HashSet<OutPoint> {
+        &self.set
+    }
+
+    /// Remove a UTXO from the currently selected inputs.
+    pub fn remove_utxo(&mut self, outpoint: &OutPoint) -> &mut Self {
+        if self.set.remove(outpoint) {
+            self.utxos.retain(|op| op != outpoint);
+        }
+        self
+    }
+
+    /// Only include inputs that are selected manually using [`add_utxos`] or [`add_planned_input`].
+    ///
+    /// Since the wallet will skip coin selection for additional candidates, the manually selected
+    /// inputs must be enough to fund the transaction or else an error will be thrown due to
+    /// insufficient funds.
+    ///
+    /// [`add_utxos`]: PsbtParams::add_utxos
+    /// [`add_planned_input`]: PsbtParams::add_planned_input
+    pub fn manually_selected_only(&mut self) -> &mut Self {
+        self.manually_selected_only = true;
+        self
+    }
+
+    /// Add the spend [`Assets`].
+    ///
+    /// Assets are required to create a spending plan for an output controlled by the wallet's
+    /// descriptors. If none are provided here, then we assume all of the keys are equally likely
+    /// to sign.
+    ///
+    /// This may be called multiple times to add additional assets, however only the last
+    /// absolute or relative timelock is retained. See also `AssetsExt`.
+    pub fn add_assets(&mut self, assets: Assets) -> &mut Self {
+        let mut new = match self.assets {
+            Some(ref existing) => {
+                let mut new = Assets::new();
+                new.extend(existing);
+                new
+            }
+            None => Assets::new(),
+        };
+        new.extend(&assets);
+        self.assets = Some(new);
+        self
+    }
+
+    /// Add outgoing recipients to the transaction.
+    ///
+    /// - `recipients`: An iterator of `(S, Amount)` tuples where `S` can be a [`bitcoin::Address`],
+    ///   a script pubkey, or anything that can be converted straight into a [`ScriptBuf`].
+    pub fn add_recipients<I, S>(&mut self, recipients: I) -> &mut Self
+    where
+        I: IntoIterator<Item = (S, Amount)>,
+        S: Into<ScriptBuf>,
+    {
+        self.recipients
+            .extend(recipients.into_iter().map(|(s, amt)| (s.into(), amt)));
+        self
+    }
+
+    /// Set the transaction `nLockTime`.
+    ///
+    /// This can be used as a fallback in case none of the inputs to the transaction require an
+    /// absolute locktime. If no locktime is required and nothing is specified here, then the
+    /// locktime is set to the last known chain tip.
+    pub fn locktime(&mut self, locktime: absolute::LockTime) -> &mut Self {
+        self.locktime = Some(locktime);
+        self
+    }
+
+    /// Set the height to be used when evaluating the maturity of coinbase outputs during coin
+    /// selection.
+    pub fn maturity_height(&mut self, height: absolute::Height) -> &mut Self {
+        self.maturity_height = Some(height.to_consensus_u32());
+        self
+    }
+
+    /// Set the target fee rate.
+    pub fn feerate(&mut self, feerate: FeeRate) -> &mut Self {
+        self.feerate = feerate;
+        self
+    }
+
+    /// Set the strategy to be used when selecting coins.
+    pub fn coin_selection(&mut self, strategy: SelectionStrategy) -> &mut Self {
+        self.coin_selection = strategy;
+        self
+    }
+
+    /// Set the parameters for modifying the wallet's view of canonical transactions.
+    ///
+    /// The `params` can be used to resolve conflicts manually, or to assert that a particular
+    /// transaction should be treated as canonical for the purpose of building the current PSBT.
+    /// Refer to [`CanonicalizationParams`] for more.
+    pub fn canonicalization_params(
+        &mut self,
+        params: bdk_chain::CanonicalizationParams,
+    ) -> &mut Self {
+        self.canonical_params = params;
+        self
+    }
+
+    /// Set the definite descriptor used for generating the change output.
+    pub fn change_descriptor(&mut self, desc: DefiniteDescriptor) -> &mut Self {
+        self.change_descriptor = Some(desc);
+        self
+    }
+
+    /// Filter [`FullTxOut`]s by the provided closure.
+    ///
+    /// This option can be used to mark specific outputs unspendable or apply custom UTXO
+    /// filtering logic.
+    ///
+    /// Any txouts for which the `predicate` returns `false` will be excluded from coin selection,
+    /// otherwise any coin in the wallet that is mature and spendable will be eligible for
+    /// selection.
+    pub fn filter_utxos<F>(&mut self, predicate: F) -> &mut Self
+    where
+        F: Fn(&FullTxOut<ConfirmationBlockTime>) -> bool + Send + Sync + 'static,
+    {
+        self.utxo_filter = UtxoFilter(Arc::new(predicate));
+        self
+    }
+
+    /// Set the [`TxOrdering`] for inputs and outputs of the PSBT.
+    ///
+    /// If not set here, the default ordering is to [`Shuffle`] all inputs and outputs.
+    ///
+    /// Set to [`Untouched`] to preserve the order of UTXOs and recipients in the manner in which
+    /// they are added to the params. If additional inputs are required that aren't manually
+    /// selected, their order will be determined by the [`SelectionStrategy`]. Refer to
+    /// [`TxOrdering`] for more.
+    ///
+    /// [`Shuffle`]: TxOrdering::Shuffle
+    /// [`Untouched`]: TxOrdering::Untouched
+    pub fn ordering(&mut self, ordering: TxOrdering<Input, Output>) -> &mut Self {
+        self.ordering = ordering;
+        self
+    }
+
+    /// Add a planned input.
+    ///
+    /// This can be used to add inputs that come with a [`Plan`] or [`psbt::Input`] provided.
+    /// See [`Input`] for more on how to create inputs manually. Be aware that creating inputs
+    /// in this manner relies on certain assumptions, like the UTXO validity, the satisfaction
+    /// weight, and so on. As such you should only use this method to add inputs you definitely
+    /// trust the values for.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use bdk_tx::Input;
+    /// # use bdk_wallet::psbt::PsbtParams;
+    /// # use bitcoin::{psbt, OutPoint, Sequence, TxOut};
+    /// # let outpoint = OutPoint::null();
+    /// # let sequence = Sequence::ENABLE_LOCKTIME_NO_RBF;
+    /// # let psbt_input = psbt::Input::default();
+    /// # let satisfaction_weight = 0;
+    /// # let tx_status = None;
+    /// # let is_coinbase = false;
+    /// let mut params = PsbtParams::default();
+    /// let input = Input::from_psbt_input(
+    ///     outpoint,
+    ///     sequence,
+    ///     psbt_input,
+    ///     satisfaction_weight,
+    ///     tx_status,
+    ///     is_coinbase,
+    /// )?;
+    /// params.add_planned_input(input);
+    /// # Ok::<_, anyhow::Error>(())
+    /// ```
+    ///
+    /// [`Plan`]: miniscript::plan::Plan
+    /// [`psbt::Input`]: bitcoin::psbt::Input
+    pub fn add_planned_input(&mut self, input: Input) -> &mut Self {
+        if self.set.insert(input.prev_outpoint()) {
+            self.inputs.push(input);
+        }
+        self
+    }
+
+    /// Only fill in the [`witness_utxo`] field of PSBT inputs which spends funds under segwit (v0).
+    ///
+    /// This allows opting out of including the [`non_witness_utxo`] for segwit spends. This reduces
+    /// the size of the PSBT, however be aware that some signers might require the presence of the
+    /// `non_witness_utxo`.
+    ///
+    /// [`witness_utxo`]: bitcoin::psbt::Input::witness_utxo
+    /// [`non_witness_utxo`]: bitcoin::psbt::Input::non_witness_utxo
+    pub fn only_witness_utxo(&mut self) -> &mut Self {
+        self.only_witness_utxo = true;
+        self
+    }
+
+    /// Drain wallet.
+    ///
+    /// This will force selection of the available input candidates. As such, the option is only
+    /// applied to inputs that meet the spending criteria.
+    pub fn drain_wallet(&mut self) -> &mut Self {
+        self.drain_wallet = true;
+        self
+    }
+
+    /// Set the transaction [`Version`].
+    pub fn version(&mut self, version: Version) -> &mut Self {
+        self.version = Some(version);
+        self
+    }
+
+    /// Set the [`Sequence`] value to be used as a fallback if not specified by the input.
+    pub fn fallback_sequence(&mut self, sequence: Sequence) -> &mut Self {
+        self.fallback_sequence = Some(sequence);
+        self
+    }
+
+    // TODO(@valuedmammal): Should we expose an option to set the `longterm_feerate`, and/or
+    // set the coin-select `ChangePolicy`?
+
+    /// Fill in the global [`Psbt::xpub`]s field with the extended keys of the wallet's
+    /// descriptors.
+    ///
+    /// Some offline signers and/or multisig wallets may require this.
+    ///
+    /// [`Psbt::xpub`]: bitcoin::Psbt::xpub
+    pub fn add_global_xpubs(&mut self) -> &mut Self {
+        self.add_global_xpubs = true;
+        self
+    }
+}
+
+/// Coin select strategy.
+#[derive(Debug, Clone, Copy, Default)]
+#[non_exhaustive]
+pub enum SelectionStrategy {
+    /// Single random draw.
+    #[default]
+    SingleRandomDraw,
+    /// Lowest fee, a variation of Branch 'n Bound that allows for change
+    /// while minimizing transaction fees. Refer to
+    /// [`LowestFee`](bdk_coin_select::metrics::LowestFee) metric for more.
+    LowestFee,
+}
+
+/// [`UtxoFilter`] is a user-defined `Fn` closure which decides whether to exclude a UTXO
+/// from being selected.
+#[allow(clippy::type_complexity)]
+pub(crate) struct UtxoFilter(
+    pub Arc<dyn Fn(&FullTxOut<ConfirmationBlockTime>) -> bool + Send + Sync>,
+);
+
+impl Default for UtxoFilter {
+    fn default() -> Self {
+        Self(Arc::new(|_| true))
+    }
+}
+
+impl fmt::Debug for UtxoFilter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "UtxoFilter")
+    }
+}
+
+impl PsbtParams<Rbf> {
+    /// Replace spends of the provided `txs`. This will internally set the list of UTXOs
+    /// to be spent.
+    fn replace(&mut self, txs: &[Arc<Transaction>]) {
+        self.utxos.clear();
+        self.set.clear();
+        let mut utxos = vec![];
+
+        let (mut txids_to_replace, txs): (HashSet<Txid>, Vec<Transaction>) = txs
+            .iter()
+            .map(|tx| (tx.compute_txid(), tx.as_ref().clone()))
+            .unzip();
+        let tx_graph = TxGraph::<BlockId>::new(txs);
+
+        // Sanitize the RBF set by removing elements of `txs` which have ancestors
+        // in the same set. This is to avoid spending outputs of txs that are bound
+        // for replacement.
+        for tx_node in tx_graph.full_txs() {
+            let tx = &tx_node.tx;
+            if tx.is_coinbase()
+                || tx_graph
+                    .walk_ancestors(Arc::clone(tx), |_, tx| Some(tx.compute_txid()))
+                    .any(|ancestor_txid| txids_to_replace.contains(&ancestor_txid))
+            {
+                txids_to_replace.remove(&tx_node.txid);
+            } else {
+                utxos.extend(tx.input.iter().map(|txin| txin.previous_output));
+            }
+        }
+
+        self.replace = txids_to_replace;
+        self.utxos
+            .extend(utxos.iter().copied().filter(|&op| self.set.insert(op)));
+    }
+}
+
+/// Trait to extend the functionality of [`Assets`].
+pub(crate) trait AssetsExt {
+    /// Extend `self` with the contents of `other`.
+    fn extend(&mut self, other: &Self);
+}
+
+impl AssetsExt for Assets {
+    /// Extend `self` with the contents of `other`. Note that if present this preferentially
+    /// uses the absolute and relative timelocks of `other`.
+    fn extend(&mut self, other: &Self) {
+        self.keys.extend(other.keys.clone());
+        self.sha256_preimages.extend(other.sha256_preimages.clone());
+        self.hash256_preimages
+            .extend(other.hash256_preimages.clone());
+        self.ripemd160_preimages
+            .extend(other.ripemd160_preimages.clone());
+        self.hash160_preimages
+            .extend(other.hash160_preimages.clone());
+
+        self.absolute_timelock = other.absolute_timelock.or(self.absolute_timelock);
+        self.relative_timelock = other.relative_timelock.or(self.relative_timelock);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test_utils::new_tx;
+
+    use bitcoin::hashes::Hash;
+    use bitcoin::{TxIn, TxOut};
+
+    #[test]
+    fn test_sanitize_rbf_set() {
+        // To replace the set { [A, B], [C] }, where B is a descendant of A:
+        // We shouldn't try to replace the inputs of B, because replacing A will render A's outputs
+        // unspendable. Therefore the RBF inputs should only contain the inputs of A and C.
+
+        // A is an ancestor
+        let tx_a = Transaction {
+            input: vec![TxIn {
+                previous_output: OutPoint::new(Hash::hash(b"parent_a"), 0),
+                ..Default::default()
+            }],
+            output: vec![TxOut::NULL],
+            ..new_tx(0)
+        };
+        let txid_a = tx_a.compute_txid();
+        // B spends A
+        let tx_b = Transaction {
+            input: vec![TxIn {
+                previous_output: OutPoint::new(txid_a, 0),
+                ..Default::default()
+            }],
+            output: vec![TxOut::NULL],
+            ..new_tx(1)
+        };
+        // C is an ancestor
+        let tx_c = Transaction {
+            input: vec![TxIn {
+                previous_output: OutPoint::new(Hash::hash(b"parent_c"), 0),
+                ..Default::default()
+            }],
+            output: vec![TxOut::NULL],
+            ..new_tx(2)
+        };
+        let txid_c = tx_c.compute_txid();
+        // D is unrelated coinbase tx
+        let tx_d = Transaction {
+            input: vec![TxIn::default()],
+            output: vec![TxOut::NULL],
+            ..new_tx(3)
+        };
+
+        let expect_spends: HashSet<OutPoint> =
+            [tx_a.input[0].previous_output, tx_c.input[0].previous_output].into();
+
+        let txs: Vec<Arc<Transaction>> =
+            [tx_a, tx_b, tx_c, tx_d].into_iter().map(Arc::new).collect();
+        let params = PsbtParams::new().replace_txs(&txs);
+        assert_eq!(params.set, expect_spends);
+        assert_eq!(params.replace, [txid_a, txid_c].into());
+    }
+
+    #[test]
+    fn test_selected_outpoints_are_unique() {
+        let mut params = PsbtParams::default();
+        let op = OutPoint::null();
+
+        // Try adding the same outpoint repeatedly.
+        for _ in 0..3 {
+            params.add_utxos(&[op]);
+        }
+        assert_eq!(
+            params.utxos(),
+            &[op].into(),
+            "Failed to filter duplicate outpoints"
+        );
+        assert!(params.utxos.contains(&op));
+
+        params = PsbtParams::default();
+
+        // Try adding duplicates in the same set.
+        params.add_utxos(&[op, op, op]);
+        assert_eq!(
+            params.utxos(),
+            &[op].into(),
+            "Failed to filter duplicate outpoints"
+        );
+        assert!(params.utxos.contains(&op));
+    }
+}

--- a/src/psbt/params.rs
+++ b/src/psbt/params.rs
@@ -447,8 +447,9 @@ pub enum SelectionStrategy {
     LowestFee,
 }
 
-/// [`UtxoFilter`] is a user-defined `Fn` closure which decides whether to exclude a UTXO
-/// from being selected.
+/// [`UtxoFilter`] is a user-defined `Fn` closure which decides whether to include a UTXO
+/// for coin selection. This has a default implementation that enables selection of all
+/// txouts passed to it.
 #[allow(clippy::type_complexity)]
 pub(crate) struct UtxoFilter(
     pub Arc<dyn Fn(&FullTxOut<ConfirmationBlockTime>) -> bool + Send + Sync>,

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -317,6 +317,31 @@ pub fn insert_checkpoint(wallet: &mut Wallet, block: BlockId) {
         .unwrap();
 }
 
+/// Inserts a transaction to be anchored by `block_id`. This is particularly useful for
+/// adding a coinbase tx to the wallet for testing, since transactions of this kind
+/// must always appear confirmed.
+///
+/// This will also insert the anchor `block_id`. See [`insert_anchor`] for more.
+pub fn insert_tx_anchor(wallet: &mut Wallet, tx: Transaction, block_id: BlockId) {
+    insert_checkpoint(wallet, block_id);
+    let anchor = ConfirmationBlockTime {
+        block_id,
+        confirmation_time: 1234567000,
+    };
+    let txid = tx.compute_txid();
+
+    let mut tx_update = TxUpdate::default();
+    tx_update.txs = vec![Arc::new(tx)];
+    tx_update.anchors = [(anchor, txid)].into();
+
+    wallet
+        .apply_update(Update {
+            tx_update,
+            ..Default::default()
+        })
+        .expect("failed to apply update");
+}
+
 /// Inserts a transaction into the local view, assuming it is currently present in the mempool.
 ///
 /// This can be used, for example, to track a transaction immediately after it is broadcast.

--- a/src/wallet/error.rs
+++ b/src/wallet/error.rs
@@ -273,7 +273,8 @@ pub enum CreatePsbtError {
     /// Failed to create a spending plan for a manually selected output.
     Plan(OutPoint),
     /// Failed to create PSBT.
-    Psbt(bdk_tx::CreatePsbtError),
+    // TODO(@valuedmammal): `Box` shouldn't be needed once we can depend on `bdk_tx` 0.2.0.
+    Psbt(alloc::boxed::Box<bdk_tx::CreatePsbtError>),
     /// Selector error.
     Selector(bdk_tx::SelectorError),
     /// The UTXO of outpoint could not be found.

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -3062,7 +3062,7 @@ impl Wallet {
                 mandate_full_tx_for_segwit_v0: !params.only_witness_utxo,
                 sighash_type: params.sighash_type,
             })
-            .map_err(CreatePsbtError::Psbt)?;
+            .map_err(|e| CreatePsbtError::Psbt(Box::new(e)))?;
 
         // Add global xpubs.
         if params.add_global_xpubs {

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -34,8 +34,8 @@ use bdk_chain::{
     FullTxOut, Indexed, IndexedTxGraph, Indexer, KeychainIndexed, Merge,
 };
 use bdk_tx::{
-    selection_algorithm_lowest_fee_bnb, ChangePolicyType, DefiniteDescriptor, Finalizer, Input,
-    InputCandidates, OriginalTxStats, Output, RbfParams, Selector, SelectorParams, TxStatus,
+    selection_algorithm_lowest_fee_bnb, Finalizer, Input, InputCandidates, OriginalTxStats, Output,
+    RbfParams, ScriptSource, Selector, SelectorParams, TxStatus,
 };
 #[cfg(feature = "std")]
 use bitcoin::secp256k1::rand;
@@ -2794,7 +2794,7 @@ impl Wallet {
         params: &PsbtParams<C>,
     ) -> (
         Assets,
-        DefiniteDescriptor,
+        ScriptSource,
         HashMap<OutPoint, FullTxOut<ConfirmationBlockTime>>,
     ) {
         // Get spend assets.
@@ -2812,12 +2812,14 @@ impl Wallet {
         };
 
         // Get change script.
-        let change_script = params.change_descriptor.clone().unwrap_or_else(|| {
+        let change_script = params.change_script.clone().unwrap_or_else(|| {
             let change_keychain = self.map_keychain(KeychainKind::Internal);
-            let desc = self.public_descriptor(change_keychain);
+            let descriptor = self.public_descriptor(change_keychain);
             let next_index = self.next_derivation_index(change_keychain);
-            desc.at_derivation_index(next_index)
-                .expect("should be valid derivation index")
+            let definite_descriptor = descriptor
+                .at_derivation_index(next_index)
+                .expect("should be valid derivation index");
+            ScriptSource::from_descriptor(definite_descriptor)
         });
 
         // Get wallet txouts.
@@ -2896,6 +2898,7 @@ impl Wallet {
     /// ```rust,no_run
     /// # use std::str::FromStr;
     /// # use bitcoin::{Amount, Address, FeeRate, OutPoint};
+    /// # use bdk_tx::FeeStrategy;
     /// # use bdk_wallet::psbt::{PsbtParams, SelectionStrategy};
     /// # let wallet = bdk_wallet::doctest_wallet!();
     /// # let outpoint = OutPoint::null();
@@ -2906,7 +2909,7 @@ impl Wallet {
     ///     .add_utxos(&[outpoint])
     ///     .add_recipients([(address, amount)])
     ///     .coin_selection(SelectionStrategy::LowestFee)
-    ///     .feerate(FeeRate::BROADCAST_MIN);
+    ///     .fee(FeeStrategy::FeeRate(FeeRate::BROADCAST_MIN));
     ///
     /// let (psbt, finalizer) = wallet.create_psbt(params)?;
     /// # Ok::<_, anyhow::Error>(())
@@ -2983,12 +2986,10 @@ impl Wallet {
         let mut selector = Selector::new(
             &input_candidates,
             SelectorParams {
-                target_feerate: params.feerate,
+                fee_strategy: params.fee_strategy.clone(),
                 target_outputs,
-                change_descriptor: change_script,
-                change_policy: ChangePolicyType::NoDustAndLeastWaste {
-                    longterm_feerate: params.longterm_feerate,
-                },
+                change_script,
+                change_policy: params.change_policy,
                 replace: None,
             },
         )
@@ -3009,6 +3010,8 @@ impl Wallet {
     ) -> Result<(Psbt, Finalizer), CreatePsbtError> {
         // How many times to run bnb before giving up
         const BNB_MAX_ROUNDS: usize = 10_000;
+        /// Longterm feerate
+        const LONGTERM_FEERATE: FeeRate = FeeRate::from_sat_per_vb_unchecked(2);
 
         // Select coins
         if params.drain_wallet {
@@ -3025,7 +3028,7 @@ impl Wallet {
                 SelectionStrategy::LowestFee => {
                     selector
                         .select_with_algorithm(selection_algorithm_lowest_fee_bnb(
-                            params.longterm_feerate,
+                            LONGTERM_FEERATE,
                             BNB_MAX_ROUNDS,
                         ))
                         .map_err(CreatePsbtError::Bnb)?;
@@ -3057,6 +3060,7 @@ impl Wallet {
                 fallback_locktime,
                 fallback_sequence,
                 mandate_full_tx_for_segwit_v0: !params.only_witness_utxo,
+                sighash_type: params.sighash_type,
             })
             .map_err(CreatePsbtError::Psbt)?;
 
@@ -3121,7 +3125,7 @@ impl Wallet {
         recipients: Vec<(ScriptBuf, Amount)>,
     ) -> Result<(Psbt, Finalizer), ReplaceByFeeError> {
         let params = PsbtParams {
-            feerate,
+            fee_strategy: bdk_tx::FeeStrategy::FeeRate(feerate),
             recipients,
             ..Default::default()
         }
@@ -3249,12 +3253,10 @@ impl Wallet {
         let mut selector = Selector::new(
             &input_candidates,
             SelectorParams {
-                target_feerate: params.feerate,
+                fee_strategy: params.fee_strategy.clone(),
                 target_outputs,
-                change_descriptor: change_script,
-                change_policy: ChangePolicyType::NoDustAndLeastWaste {
-                    longterm_feerate: params.longterm_feerate,
-                },
+                change_script,
+                change_policy: params.change_policy,
                 replace: Some(rbf_params),
             },
         )


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

This PR adds support for creating Child-Pays-For-Parent (CPFP) transactions to accelerate unconfirmed parent transactions by creating a child transaction that spends from an unconfirmed parent output with a higher fee rate.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice
#### Added
- `CreateSweepError` enum
- New public wallet APIs:
  - `Wallet::create_sweep`
  - `Wallet::create_sweep_with_rng`
- Documentation and example:
  - `examples/cpfp.rs`
  
<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

Rebased on #297 

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `just p` before pushing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature

#### Bugfixes:

* [x] ~This pull request breaks the existing API~
* [x] ~I've added tests to reproduce the issue which are now passing~
* [x] ~I'm linking the issue being fixed by this PR~
