### PR TITLE
fix(doc): fix `TxOrdering::Untouched` doc comment

### DIFF
--- a/src/wallet/tx_builder.rs
+++ b/src/wallet/tx_builder.rs
@@ -848,9 +848,9 @@ pub enum TxOrdering {
     /// Randomized (default)
     #[default]
     Shuffle,
-    /// Unchanged
+    /// Untouched
     ///
-    /// Unchanged insertion order for recipients and for manually added UTXOs. This guarantees all
+    /// Untouched insertion order for recipients and for manually added UTXOs. This guarantees all
     /// recipients preserve insertion order in the transaction's output vector and manually added
     /// UTXOs preserve insertion order in the transaction's input vector, but does not make any
     /// guarantees about algorithmically selected UTXOs. However, by design they will always be


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Fixes the incorrect doc comment on `TxOrdering::Untouched` (Unchanged -> Untouched)

### Checklists

#### All Submissions:

* [X] I've signed all my commits
* [X] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [X] I ran `just p` before pushing