### PR TITLE
refactor: rename `Wallet::indexed_graph` field

### DIFF
--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -106,7 +106,7 @@ pub struct Wallet {
     signers: Arc<SignersContainer>,
     change_signers: Arc<SignersContainer>,
     chain: LocalChain,
-    indexed_graph: IndexedTxGraph<ConfirmationBlockTime, KeychainTxOutIndex<KeychainKind>>,
+    tx_graph: IndexedTxGraph<ConfirmationBlockTime, KeychainTxOutIndex<KeychainKind>>,
     stage: ChangeSet,
     network: Network,
     secp: SecpCtx,
@@ -486,7 +486,7 @@ impl Wallet {
             ..Default::default()
         };
 
-        let indexed_graph = make_indexed_graph(
+        let tx_graph = make_indexed_graph(
             &mut stage,
             Default::default(),
             Default::default(),
@@ -501,7 +501,7 @@ impl Wallet {
             change_signers,
             network,
             chain,
-            indexed_graph,
+            tx_graph,
             stage,
             secp,
             locked_outpoints,
@@ -692,7 +692,7 @@ impl Wallet {
 
         let mut stage = ChangeSet::default();
 
-        let indexed_graph = make_indexed_graph(
+        let tx_graph = make_indexed_graph(
             &mut stage,
             changeset.tx_graph,
             changeset.indexer,
@@ -707,7 +707,7 @@ impl Wallet {
             signers,
             change_signers,
             chain,
-            indexed_graph,
+            tx_graph,
             stage,
             network,
             secp,
@@ -722,7 +722,7 @@ impl Wallet {
 
     /// Iterator over all keychains in this wallet
     pub fn keychains(&self) -> impl Iterator<Item = (KeychainKind, &ExtendedDescriptor)> {
-        self.indexed_graph.index.keychains()
+        self.tx_graph.index.keychains()
     }
 
     /// Peek an address of the given `keychain` at `index` without revealing it.
@@ -736,7 +736,7 @@ impl Wallet {
     pub fn peek_address(&self, keychain: KeychainKind, mut index: u32) -> AddressInfo {
         let keychain = self.map_keychain(keychain);
         let mut spk_iter = self
-            .indexed_graph
+            .tx_graph
             .index
             .unbounded_spk_iter(keychain)
             .expect("keychain must exist");
@@ -781,7 +781,7 @@ impl Wallet {
     /// ```
     pub fn reveal_next_address(&mut self, keychain: KeychainKind) -> AddressInfo {
         let keychain = self.map_keychain(keychain);
-        let index = &mut self.indexed_graph.index;
+        let index = &mut self.tx_graph.index;
         let stage = &mut self.stage;
 
         let ((index, spk), index_changeset) = index
@@ -814,7 +814,7 @@ impl Wallet {
     ) -> impl Iterator<Item = AddressInfo> + '_ {
         let keychain = self.map_keychain(keychain);
         let (spks, index_changeset) = self
-            .indexed_graph
+            .tx_graph
             .index
             .reveal_to_target(keychain, index)
             .expect("keychain must exist");
@@ -839,7 +839,7 @@ impl Wallet {
     /// calls to this method before closing the wallet. See [`Wallet::reveal_next_address`].
     pub fn next_unused_address(&mut self, keychain: KeychainKind) -> AddressInfo {
         let keychain = self.map_keychain(keychain);
-        let index = &mut self.indexed_graph.index;
+        let index = &mut self.tx_graph.index;
 
         let ((index, spk), index_changeset) = index
             .next_unused_spk(keychain)
@@ -860,7 +860,7 @@ impl Wallet {
     ///
     /// Returns whether the given index was present and then removed from the unused set.
     pub fn mark_used(&mut self, keychain: KeychainKind, index: u32) -> bool {
-        self.indexed_graph.index.mark_used(keychain, index)
+        self.tx_graph.index.mark_used(keychain, index)
     }
 
     /// Undoes the effect of [`mark_used`] and returns whether the `index` was inserted
@@ -872,7 +872,7 @@ impl Wallet {
     ///
     /// [`mark_used`]: Self::mark_used
     pub fn unmark_used(&mut self, keychain: KeychainKind, index: u32) -> bool {
-        self.indexed_graph.index.unmark_used(keychain, index)
+        self.tx_graph.index.unmark_used(keychain, index)
     }
 
     /// List addresses that are revealed but unused.
@@ -884,7 +884,7 @@ impl Wallet {
         &self,
         keychain: KeychainKind,
     ) -> impl DoubleEndedIterator<Item = AddressInfo> + '_ {
-        self.indexed_graph
+        self.tx_graph
             .index
             .unused_keychain_spks(self.map_keychain(keychain))
             .map(move |(index, spk)| AddressInfo {
@@ -897,25 +897,25 @@ impl Wallet {
 
     /// Return whether or not a `script` is part of this wallet (either internal or external)
     pub fn is_mine(&self, script: ScriptBuf) -> bool {
-        self.indexed_graph.index.index_of_spk(script).is_some()
+        self.tx_graph.index.index_of_spk(script).is_some()
     }
 
     /// Finds how the wallet derived the script pubkey `spk`.
     ///
     /// Will only return `Some(_)` if the wallet has given out the spk.
     pub fn derivation_of_spk(&self, spk: ScriptBuf) -> Option<(KeychainKind, u32)> {
-        self.indexed_graph.index.index_of_spk(spk).cloned()
+        self.tx_graph.index.index_of_spk(spk).cloned()
     }
 
     /// Return the list of unspent outputs of this wallet
     pub fn list_unspent(&self) -> impl Iterator<Item = LocalOutput> + '_ {
-        self.indexed_graph
+        self.tx_graph
             .graph()
             .filter_chain_unspents(
                 &self.chain,
                 self.chain.tip().block_id(),
                 CanonicalizationParams::default(),
-                self.indexed_graph.index.outpoints().iter().cloned(),
+                self.tx_graph.index.outpoints().iter().cloned(),
             )
             .map(|((k, i), full_txo)| new_local_utxo(k, i, full_txo))
     }
@@ -930,7 +930,7 @@ impl Wallet {
         let (sent, received) = self.sent_and_received(&tx.tx_node.tx);
         let fee: Option<Amount> = self.calculate_fee(&tx.tx_node.tx).ok();
         let fee_rate: Option<FeeRate> = self.calculate_fee_rate(&tx.tx_node.tx).ok();
-        let balance_delta: SignedAmount = self.indexed_graph.index.net_value(&tx.tx_node.tx, ..);
+        let balance_delta: SignedAmount = self.tx_graph.index.net_value(&tx.tx_node.tx, ..);
         let chain_position = tx.chain_position;
 
         let tx_details: TxDetails = TxDetails {
@@ -951,13 +951,13 @@ impl Wallet {
     ///
     /// To list only unspent outputs (UTXOs), use [`Wallet::list_unspent`] instead.
     pub fn list_output(&self) -> impl Iterator<Item = LocalOutput> + '_ {
-        self.indexed_graph
+        self.tx_graph
             .graph()
             .filter_chain_txouts(
                 &self.chain,
                 self.chain.tip().block_id(),
                 CanonicalizationParams::default(),
-                self.indexed_graph.index.outpoints().iter().cloned(),
+                self.tx_graph.index.outpoints().iter().cloned(),
             )
             .map(|((k, i), full_txo)| new_local_utxo(k, i, full_txo))
     }
@@ -983,7 +983,7 @@ impl Wallet {
     pub fn all_unbounded_spk_iters(
         &self,
     ) -> BTreeMap<KeychainKind, impl Iterator<Item = Indexed<ScriptBuf>> + Clone> {
-        self.indexed_graph.index.all_unbounded_spk_iters()
+        self.tx_graph.index.all_unbounded_spk_iters()
     }
 
     /// Get an unbounded script pubkey iterator for the given `keychain`.
@@ -995,7 +995,7 @@ impl Wallet {
         &self,
         keychain: KeychainKind,
     ) -> impl Iterator<Item = Indexed<ScriptBuf>> + Clone {
-        self.indexed_graph
+        self.tx_graph
             .index
             .unbounded_spk_iter(self.map_keychain(keychain))
             .expect("keychain must exist")
@@ -1004,8 +1004,8 @@ impl Wallet {
     /// Returns the utxo owned by this wallet corresponding to `outpoint` if it exists in the
     /// wallet's database.
     pub fn get_utxo(&self, op: OutPoint) -> Option<LocalOutput> {
-        let ((keychain, index), _) = self.indexed_graph.index.txout(op)?;
-        self.indexed_graph
+        let ((keychain, index), _) = self.tx_graph.index.txout(op)?;
+        self.tx_graph
             .graph()
             .filter_chain_unspents(
                 &self.chain,
@@ -1035,7 +1035,7 @@ impl Wallet {
     /// [`list_unspent`]: Self::list_unspent
     /// [`list_output`]: Self::list_output
     pub fn insert_txout(&mut self, outpoint: OutPoint, txout: TxOut) {
-        let additions = self.indexed_graph.insert_txout(outpoint, txout);
+        let additions = self.tx_graph.insert_txout(outpoint, txout);
         self.stage.merge(additions.into());
     }
 
@@ -1068,7 +1068,7 @@ impl Wallet {
     /// ```
     /// [`insert_txout`]: Self::insert_txout
     pub fn calculate_fee(&self, tx: &Transaction) -> Result<Amount, CalculateFeeError> {
-        self.indexed_graph.graph().calculate_fee(tx)
+        self.tx_graph.graph().calculate_fee(tx)
     }
 
     /// Calculate the [`FeeRate`] for a given transaction.
@@ -1128,7 +1128,7 @@ impl Wallet {
     /// let (sent, received) = wallet.sent_and_received(tx);
     /// ```
     pub fn sent_and_received(&self, tx: &Transaction) -> (Amount, Amount) {
-        self.indexed_graph.index.sent_and_received(tx, ..)
+        self.tx_graph.index.sent_and_received(tx, ..)
     }
 
     /// Get a single transaction from the wallet as a [`WalletTx`] (if the transaction exists).
@@ -1185,7 +1185,7 @@ impl Wallet {
     ///
     /// [`Anchor`]: bdk_chain::Anchor
     pub fn get_tx(&self, txid: Txid) -> Option<WalletTx<'_>> {
-        let graph = self.indexed_graph.graph();
+        let graph = self.tx_graph.graph();
         graph
             .list_canonical_txs(
                 &self.chain,
@@ -1207,8 +1207,8 @@ impl Wallet {
     /// To iterate over all canonical transactions, including those that are irrelevant, use
     /// [`TxGraph::list_canonical_txs`].
     pub fn transactions<'a>(&'a self) -> impl Iterator<Item = WalletTx<'a>> + 'a {
-        let tx_graph = self.indexed_graph.graph();
-        let tx_index = &self.indexed_graph.index;
+        let tx_graph = self.tx_graph.graph();
+        let tx_index = &self.tx_graph.index;
         tx_graph
             .list_canonical_txs(
                 &self.chain,
@@ -1246,11 +1246,11 @@ impl Wallet {
     /// Return the balance, separated into available, trusted-pending, untrusted-pending, and
     /// immature values.
     pub fn balance(&self) -> Balance {
-        self.indexed_graph.graph().balance(
+        self.tx_graph.graph().balance(
             &self.chain,
             self.chain.tip().block_id(),
             CanonicalizationParams::default(),
-            self.indexed_graph.index.outpoints().iter().cloned(),
+            self.tx_graph.index.outpoints().iter().cloned(),
             |&(k, _), _| k == KeychainKind::Internal,
         )
     }
@@ -1281,7 +1281,7 @@ impl Wallet {
             KeychainKind::External => Arc::make_mut(&mut self.signers),
             KeychainKind::Internal => Arc::make_mut(&mut self.change_signers),
         };
-        if let Some(descriptor) = self.indexed_graph.index.get_descriptor(keychain) {
+        if let Some(descriptor) = self.tx_graph.index.get_descriptor(keychain) {
             *wallet_signers = SignersContainer::build(keymap, descriptor, &self.secp)
         }
     }
@@ -1362,7 +1362,7 @@ impl Wallet {
         params: TxParams,
         rng: &mut impl RngCore,
     ) -> Result<Psbt, CreateTxError> {
-        let keychains: BTreeMap<_, _> = self.indexed_graph.index.keychains().collect();
+        let keychains: BTreeMap<_, _> = self.tx_graph.index.keychains().collect();
         let external_descriptor = keychains.get(&KeychainKind::External).expect("must exist");
         let internal_descriptor = keychains.get(&KeychainKind::Internal);
 
@@ -1578,13 +1578,13 @@ impl Wallet {
             None => {
                 let change_keychain = self.map_keychain(KeychainKind::Internal);
                 let (index, spk) = self
-                    .indexed_graph
+                    .tx_graph
                     .index
                     .unused_keychain_spks(change_keychain)
                     .next()
                     .unwrap_or_else(|| {
                         let (next_index, _) = self
-                            .indexed_graph
+                            .tx_graph
                             .index
                             .next_index(change_keychain)
                             .expect("keychain must exist");
@@ -1670,7 +1670,7 @@ impl Wallet {
         // Recording changes to the change keychain.
         if let (Excess::Change { .. }, Some((keychain, index))) = (excess, drain_index) {
             if let Some((_, index_changeset)) =
-                self.indexed_graph.index.reveal_to_target(keychain, index)
+                self.tx_graph.index.reveal_to_target(keychain, index)
             {
                 self.stage.merge(index_changeset.into());
                 self.mark_used(keychain, index);
@@ -1725,8 +1725,8 @@ impl Wallet {
         &mut self,
         txid: Txid,
     ) -> Result<TxBuilder<'_, DefaultCoinSelectionAlgorithm>, BuildFeeBumpError> {
-        let tx_graph = self.indexed_graph.graph();
-        let txout_index = &self.indexed_graph.index;
+        let tx_graph = self.tx_graph.graph();
+        let txout_index = &self.tx_graph.index;
         let chain_tip = self.chain.tip().block_id();
         let chain_positions: HashMap<Txid, ChainPosition<_>> = tx_graph
             .list_canonical_txs(&self.chain, chain_tip, CanonicalizationParams::default())
@@ -1953,7 +1953,7 @@ impl Wallet {
     /// the same structure but with the all secret keys replaced by their corresponding public key.
     /// This can be used to build a watch-only version of a wallet.
     pub fn public_descriptor(&self, keychain: KeychainKind) -> &ExtendedDescriptor {
-        self.indexed_graph
+        self.tx_graph
             .index
             .get_descriptor(self.map_keychain(keychain))
             .expect("keychain must exist")
@@ -1981,7 +1981,7 @@ impl Wallet {
             .map(|txin| txin.previous_output.txid)
             .collect::<HashSet<Txid>>();
         let confirmation_heights = self
-            .indexed_graph
+            .tx_graph
             .graph()
             .list_canonical_txs(&self.chain, chain_tip, CanonicalizationParams::default())
             .filter(|canon_tx| prev_txids.contains(&canon_tx.tx_node.txid))
@@ -2025,7 +2025,7 @@ impl Wallet {
                 .get_utxo_for(n)
                 .and_then(|txout| self.get_descriptor_for_txout(&txout))
                 .or_else(|| {
-                    self.indexed_graph.index.keychains().find_map(|(_, desc)| {
+                    self.tx_graph.index.keychains().find_map(|(_, desc)| {
                         desc.derive_from_psbt_input(psbt_input, psbt.get_utxo_for(n), &self.secp)
                     })
                 });
@@ -2085,13 +2085,13 @@ impl Wallet {
     /// The derivation index of this wallet. It will return `None` if it has not derived any
     /// addresses. Otherwise, it will return the index of the highest address it has derived.
     pub fn derivation_index(&self, keychain: KeychainKind) -> Option<u32> {
-        self.indexed_graph.index.last_revealed_index(keychain)
+        self.tx_graph.index.last_revealed_index(keychain)
     }
 
     /// The index of the next address that you would get if you were to ask the wallet for a new
     /// address.
     pub fn next_derivation_index(&self, keychain: KeychainKind) -> u32 {
-        self.indexed_graph
+        self.tx_graph
             .index
             .next_index(self.map_keychain(keychain))
             .expect("keychain must exist")
@@ -2103,7 +2103,7 @@ impl Wallet {
     /// This frees up the change address used when creating the tx for use in future transactions.
     // TODO: Make this free up reserved utxos when that's implemented
     pub fn cancel_tx(&mut self, tx: &Transaction) {
-        let txout_index = &mut self.indexed_graph.index;
+        let txout_index = &mut self.tx_graph.index;
         for txout in &tx.output {
             if let Some((keychain, index)) = txout_index.index_of_spk(txout.script_pubkey.clone()) {
                 // NOTE: unmark_used will **not** make something unused if it has actually been used
@@ -2115,7 +2115,7 @@ impl Wallet {
 
     fn get_descriptor_for_txout(&self, txout: &TxOut) -> Option<DerivedDescriptor> {
         let &(keychain, child) = self
-            .indexed_graph
+            .tx_graph
             .index
             .index_of_spk(txout.script_pubkey.clone())?;
         let descriptor = self.public_descriptor(keychain);
@@ -2134,7 +2134,7 @@ impl Wallet {
                 .iter()
                 .map(|wutxo| wutxo.utxo.outpoint())
                 .collect::<HashSet<OutPoint>>();
-            self.indexed_graph
+            self.tx_graph
                 .graph()
                 // Get all unspent UTxOs from wallet.
                 // NOTE: the UTxOs returned by the following method already belong to wallet as the
@@ -2143,7 +2143,7 @@ impl Wallet {
                     &self.chain,
                     self.chain.tip().block_id(),
                     CanonicalizationParams::default(),
-                    self.indexed_graph.index.outpoints().iter().cloned(),
+                    self.tx_graph.index.outpoints().iter().cloned(),
                 )
                 // Filter out locked outpoints.
                 .filter(|(_, txo)| !self.is_outpoint_locked(txo.outpoint))
@@ -2269,7 +2269,7 @@ impl Wallet {
         // Try to find the prev_script in our db to figure out if this is internal or external,
         // and the derivation index.
         let &(keychain, child) = self
-            .indexed_graph
+            .tx_graph
             .index
             .index_of_spk(utxo.txout.script_pubkey)
             .ok_or(CreateTxError::UnknownUtxo)?;
@@ -2289,7 +2289,7 @@ impl Wallet {
             .map_err(MiniscriptPsbtError::Conversion)?;
 
         let prev_output = utxo.outpoint;
-        if let Some(prev_tx) = self.indexed_graph.graph().get_tx(prev_output.txid) {
+        if let Some(prev_tx) = self.tx_graph.graph().get_tx(prev_output.txid) {
             // We want to check that the prevout actually exists in the transaction before
             // continuing.
             let prevout = prev_tx.output.get(prev_output.vout as usize).ok_or(
@@ -2321,9 +2321,7 @@ impl Wallet {
 
         // Try to figure out the keychain and derivation for every input and output.
         for (is_input, index, out) in utxos.into_iter() {
-            if let Some(&(keychain, child)) =
-                self.indexed_graph.index.index_of_spk(out.script_pubkey)
-            {
+            if let Some(&(keychain, child)) = self.tx_graph.index.index_of_spk(out.script_pubkey) {
                 let desc = self.public_descriptor(keychain);
                 let desc = desc
                     .at_derivation_index(child)
@@ -2369,11 +2367,11 @@ impl Wallet {
         };
 
         let index_changeset = self
-            .indexed_graph
+            .tx_graph
             .index
             .reveal_to_target_multi(&update.last_active_indices);
         changeset.merge(index_changeset.into());
-        changeset.merge(self.indexed_graph.apply_update(update.tx_update).into());
+        changeset.merge(self.tx_graph.apply_update(update.tx_update).into());
         self.stage.merge(changeset);
         Ok(())
     }
@@ -2403,12 +2401,12 @@ impl Wallet {
 
     /// Get a reference to the inner [`TxGraph`].
     pub fn tx_graph(&self) -> &TxGraph<ConfirmationBlockTime> {
-        self.indexed_graph.graph()
+        self.tx_graph.graph()
     }
 
     /// Get a reference to the inner [`KeychainTxOutIndex`].
     pub fn spk_index(&self) -> &KeychainTxOutIndex<KeychainKind> {
-        &self.indexed_graph.index
+        &self.tx_graph.index
     }
 
     /// Get a reference to the inner [`LocalChain`].
@@ -2510,11 +2508,7 @@ impl Wallet {
                 .apply_header_connected_to(&block.header, height, connected_to)?
                 .into(),
         );
-        changeset.merge(
-            self.indexed_graph
-                .apply_block_relevant(block, height)
-                .into(),
-        );
+        changeset.merge(self.tx_graph.apply_block_relevant(block, height).into());
         self.stage.merge(changeset);
         Ok(())
     }
@@ -2536,7 +2530,7 @@ impl Wallet {
         unconfirmed_txs: impl IntoIterator<Item = (T, u64)>,
     ) {
         let indexed_graph_changeset = self
-            .indexed_graph
+            .tx_graph
             .batch_insert_relevant_unconfirmed(unconfirmed_txs);
         self.stage.merge(indexed_graph_changeset.into());
     }
@@ -2582,7 +2576,7 @@ impl Wallet {
     pub fn apply_evicted_txs(&mut self, evicted_txs: impl IntoIterator<Item = (Txid, u64)>) {
         let chain = &self.chain;
         let canon_txids: Vec<Txid> = self
-            .indexed_graph
+            .tx_graph
             .graph()
             .list_canonical_txs(
                 chain,
@@ -2592,7 +2586,7 @@ impl Wallet {
             .map(|c| c.tx_node.txid)
             .collect();
 
-        let changeset = self.indexed_graph.batch_insert_relevant_evicted_at(
+        let changeset = self.tx_graph.batch_insert_relevant_evicted_at(
             evicted_txs
                 .into_iter()
                 .filter(|(txid, _)| canon_txids.contains(txid)),
@@ -2627,8 +2621,8 @@ impl Wallet {
         use bdk_chain::keychain_txout::SyncRequestBuilderExt;
         SyncRequest::builder_at(start_time)
             .chain_tip(self.chain.tip())
-            .revealed_spks_from_indexer(&self.indexed_graph.index, ..)
-            .expected_spk_txids(self.indexed_graph.list_expected_spk_txids(
+            .revealed_spks_from_indexer(&self.tx_graph.index, ..)
+            .expected_spk_txids(self.tx_graph.list_expected_spk_txids(
                 &self.chain,
                 self.chain.tip().block_id(),
                 ..,
@@ -2652,8 +2646,8 @@ impl Wallet {
         use bdk_chain::keychain_txout::SyncRequestBuilderExt;
         SyncRequest::builder()
             .chain_tip(self.chain.tip())
-            .revealed_spks_from_indexer(&self.indexed_graph.index, ..)
-            .expected_spk_txids(self.indexed_graph.list_expected_spk_txids(
+            .revealed_spks_from_indexer(&self.tx_graph.index, ..)
+            .expected_spk_txids(self.tx_graph.list_expected_spk_txids(
                 &self.chain,
                 self.chain.tip().block_id(),
                 ..,
@@ -2677,7 +2671,7 @@ impl Wallet {
         use bdk_chain::keychain_txout::FullScanRequestBuilderExt;
         FullScanRequest::builder()
             .chain_tip(self.chain.tip())
-            .spks_from_indexer(&self.indexed_graph.index)
+            .spks_from_indexer(&self.tx_graph.index)
     }
 
     /// Create a [`FullScanRequest`] builder at `start_time`.
@@ -2685,13 +2679,13 @@ impl Wallet {
         use bdk_chain::keychain_txout::FullScanRequestBuilderExt;
         FullScanRequest::builder_at(start_time)
             .chain_tip(self.chain.tip())
-            .spks_from_indexer(&self.indexed_graph.index)
+            .spks_from_indexer(&self.tx_graph.index)
     }
 }
 
 impl AsRef<bdk_chain::tx_graph::TxGraph<ConfirmationBlockTime>> for Wallet {
     fn as_ref(&self) -> &bdk_chain::tx_graph::TxGraph<ConfirmationBlockTime> {
-        self.indexed_graph.graph()
+        self.tx_graph.graph()
     }
 }
 


### PR DESCRIPTION
### Description

Renamed `Wallet::indexed_graph` to `Wallet::tx_graph` as the latter is a better name representing the field.

### Notes to the reviewers

This PR helps with the multi-keychain work being done in #318 and #367 .

### Changelog notice

### Changed

- Renamed `Wallet::indexed_graph` to `Wallet::tx_graph`.


### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `just p` before pushing
