### PR TITLE
Bump Rust compiler version to stable (1.93.0)

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.92.0"
+channel = "1.93.0"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
This PR bumps the Rust compiler to the lastest [stable release](https://releases.rs/).