### PR TITLE
Refactor: Move `Wallet` errors into their dedicated file

### DIFF
--- a/src/wallet/persisted.rs
+++ b/src/wallet/persisted.rs
@@ -9,6 +9,7 @@ use core::{
 use alloc::{boxed::Box, string::ToString};
 use chain::Merge;
 
+use crate::error::LoadError;
 use crate::{
     descriptor::{calc_checksum, DescriptorError},
     ChangeSet, CreateParams, LoadParams, Wallet,
@@ -344,7 +345,7 @@ pub enum LoadWithPersistError<E> {
     /// Error from persistence.
     Persist(E),
     /// Occurs when the loaded changeset cannot construct [`Wallet`].
-    InvalidChangeSet(crate::LoadError),
+    InvalidChangeSet(LoadError),
 }
 
 impl<E: fmt::Display> fmt::Display for LoadWithPersistError<E> {


### PR DESCRIPTION
The `src/wallet/mod.rs` is currently a very big file (3200 lines exactly), and over the course of my work on #318 I noticed a few small refactors that could help keep things tidy (ok it's a drop in the bucket but still a win!) and reduce the line count a bit.

### Notes to the reviewers

We had 3 wallet-related errors that were defined in the mod.rs file, but we also have a dedicated `error.rs` file which states:

```rs
//! Errors that can be thrown by the `Wallet`
```

The errors belong there in my opinion, and this is a small refactor moving them over.

### Changelog notice

No changelog required.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `just p` before pushing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
