### PR TITLE
fix(tx_builder)!: Remove `include_output_redeem_witness_script`

### DIFF
--- a/src/wallet/tx_builder.rs
+++ b/src/wallet/tx_builder.rs
@@ -137,7 +137,6 @@ pub(crate) struct TxParams {
     pub(crate) change_policy: ChangeSpendPolicy,
     pub(crate) only_witness_utxo: bool,
     pub(crate) add_global_xpubs: bool,
-    pub(crate) include_output_redeem_witness_script: bool,
     pub(crate) bumping_fee: Option<PreviousFee>,
     pub(crate) current_height: Option<absolute::LockTime>,
     pub(crate) allow_dust: bool,
@@ -596,15 +595,6 @@ impl<'a, Cs> TxBuilder<'a, Cs> {
     /// the `non_witness_utxo`.
     pub fn only_witness_utxo(&mut self) -> &mut Self {
         self.params.only_witness_utxo = true;
-        self
-    }
-
-    /// Fill-in the [`psbt::Output::redeem_script`](bitcoin::psbt::Output::redeem_script) and
-    /// [`psbt::Output::witness_script`](bitcoin::psbt::Output::witness_script) fields.
-    ///
-    /// This is useful for signers which always require it, like ColdCard hardware wallets.
-    pub fn include_output_redeem_witness_script(&mut self) -> &mut Self {
-        self.params.include_output_redeem_witness_script = true;
         self
     }
 

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -1454,36 +1454,13 @@ fn test_sign_single_xprv_no_hd_keypaths() {
 }
 
 #[test]
-fn test_include_output_redeem_witness_script() {
-    let desc = get_test_wpkh();
-    let change_desc = "sh(wsh(multi(1,cVpPVruEDdmutPzisEsYvtST1usBR3ntr8pXSyt6D2YYqXRyPcFW,cRjo6jqfVNP33HhSS76UhXETZsGTZYx8FMFvR9kpbtCSV1PmdZdu)))";
-    let (mut wallet, _) = get_funded_wallet(desc, change_desc);
-    let addr = Address::from_str("2N1Ffz3WaNzbeLFBb51xyFMHYSEUXcbiSoX")
-        .unwrap()
-        .assume_checked();
-    let mut builder = wallet.build_tx();
-    builder
-        .add_recipient(addr.script_pubkey(), Amount::from_sat(45_000))
-        .include_output_redeem_witness_script();
-    let psbt = builder.finish().unwrap();
-
-    // p2sh-p2wsh transaction should contain both witness and redeem scripts
-    assert!(psbt
-        .outputs
-        .iter()
-        .any(|output| output.redeem_script.is_some() && output.witness_script.is_some()));
-}
-
-#[test]
 fn test_signing_only_one_of_multiple_inputs() {
     let (mut wallet, _) = get_funded_wallet_wpkh();
     let addr = Address::from_str("2N1Ffz3WaNzbeLFBb51xyFMHYSEUXcbiSoX")
         .unwrap()
         .assume_checked();
     let mut builder = wallet.build_tx();
-    builder
-        .add_recipient(addr.script_pubkey(), Amount::from_sat(45_000))
-        .include_output_redeem_witness_script();
+    builder.add_recipient(addr.script_pubkey(), Amount::from_sat(45_000));
     let mut psbt = builder.finish().unwrap();
 
     // add another input to the psbt that is at least passable.

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -1454,6 +1454,35 @@ fn test_sign_single_xprv_no_hd_keypaths() {
 }
 
 #[test]
+fn test_output_redeem_witness_script_populated_automatically() {
+    let change_desc = "sh(wsh(multi(1,cVpPVruEDdmutPzisEsYvtST1usBR3ntr8pXSyt6D2YYqXRyPcFW,cRjo6jqfVNP33HhSS76UhXETZsGTZYx8FMFvR9kpbtCSV1PmdZdu)))";
+
+    let (mut wallet, _) = get_funded_wallet(get_test_wpkh(), change_desc);
+    let addr = Address::from_str("2N1Ffz3WaNzbeLFBb51xyFMHYSEUXcbiSoX")
+        .unwrap()
+        .assume_checked();
+
+    let mut builder = wallet.build_tx();
+    builder.add_recipient(addr.script_pubkey(), Amount::from_sat(45_000));
+    let psbt = builder.finish().unwrap();
+
+    let change_output = psbt
+        .outputs
+        .iter()
+        .find(|o| o.redeem_script.is_some() && o.witness_script.is_some())
+        .expect("change output should have scripts populated automatically by update_output_with_descriptor");
+
+    let witness_script = change_output.witness_script.as_ref().unwrap();
+    let expected_redeem = ScriptBuf::new_p2wsh(&witness_script.wscript_hash());
+
+    assert_eq!(
+        change_output.redeem_script.as_ref().unwrap(),
+        &expected_redeem,
+        "redeem_script should be the P2WSH hash of the witness_script"
+    );
+}
+
+#[test]
 fn test_signing_only_one_of_multiple_inputs() {
     let (mut wallet, _) = get_funded_wallet_wpkh();
     let addr = Address::from_str("2N1Ffz3WaNzbeLFBb51xyFMHYSEUXcbiSoX")


### PR DESCRIPTION
### Description

Closes #236

Removes `TxBuilder::include_output_redeem_witness_script` as it currently has no effect.

Originally, this method controlled an explicit block in the transaction creation pipeline that derived the descriptor and populated `psbt::Output::witness_script` and `psbt::Output::redeem_script` for outputs requiring it (e.g. `sh(wsh(...))`). That logic was guarded behind this flag, making it opt-in.

At some point during refactoring, this responsibility was delegated to miniscript.

### Checklists

#### New Features:

* [x] I've added a test to verify that the redeem and witness scritps are still being populated even when the flag is not used. 

#### Workflow:

* [x] Traced all references to `include_output_redeem_witness_script` in the codebase.
* [x] Checked if the existing test `test_include_output_redeem_witness_script` passes with or without calling the method, since the scripts are populated automatically
* [x] Found the original commit that introduced the method, which showed the conditional block that no longer exists in the current code

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `just fmt`, `just check` and `just test` before pushing

### Note on deprecation policy
The contribution guidelines recommend [deprecating APIs before removal](https://github.com/bitcoindevkit/bdk_wallet/blob/master/CONTRIBUTING.md#deprecation-policy). However, given the proximity of the `Wallet 3.0.0` release, it might be reasonable to include this change in that milestone. 

In any case I'll be happy to adjust it if the maintainers prefer following the standard deprectation flow. 