### PR TITLE
deprecate `descriptor` and `change_descriptor` fields

### DIFF
--- a/src/persist_test_utils.rs
+++ b/src/persist_test_utils.rs
@@ -74,6 +74,7 @@ fn spk_at_index(descriptor: &Descriptor<DescriptorPublicKey>, index: u32) -> Scr
 /// We create a dummy [`ChangeSet`], persist it and check if loaded [`ChangeSet`] matches
 /// the persisted one. We then create another such dummy [`ChangeSet`], persist it and load it to
 /// check if merged [`ChangeSet`] is returned.
+#[allow(deprecated)]
 pub fn persist_wallet_changeset<Store, CreateStore>(filename: &str, create_store: CreateStore)
 where
     CreateStore: Fn(&Path) -> anyhow::Result<Store>,
@@ -250,6 +251,7 @@ where
 /// We create a dummy [`ChangeSet`] for first wallet and persist it then we create a dummy
 /// [`ChangeSet`] for second wallet and persist that. Finally we load these two [`ChangeSet`]s and
 /// check if they were persisted correctly.
+#[allow(deprecated)]
 pub fn persist_multiple_wallet_changesets<Store, CreateStores>(
     filename: &str,
     create_dbs: CreateStores,
@@ -357,6 +359,7 @@ where
 ///
 /// We create a dummy [`ChangeSet`] with only descriptor fields populated, persist it and check if
 /// loaded [`ChangeSet`] has the same descriptors as what we persisted.
+#[allow(deprecated)]
 pub fn persist_keychains<Store, CreateStore>(filename: &str, create_store: CreateStore)
 where
     CreateStore: Fn(&Path) -> anyhow::Result<Store>,
@@ -399,6 +402,7 @@ where
 ///
 /// We create a dummy [`ChangeSet`] with only descriptor field populated, persist it and check if
 /// loaded [`ChangeSet`] has the same descriptor as what we persisted.
+#[allow(deprecated)]
 pub fn persist_single_keychain<Store, CreateStore>(filename: &str, create_store: CreateStore)
 where
     CreateStore: Fn(&Path) -> anyhow::Result<Store>,

--- a/src/wallet/changeset.rs
+++ b/src/wallet/changeset.rs
@@ -105,8 +105,10 @@ type IndexedTxGraphChangeSet =
 #[derive(Default, Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct ChangeSet {
     /// Descriptor for recipient addresses.
+    #[deprecated(since = "3.0.0", note = "To be removed in v5.0")]
     pub descriptor: Option<Descriptor<DescriptorPublicKey>>,
     /// Descriptor for change addresses.
+    #[deprecated(since = "3.0.0", note = "To be removed in v5.0")]
     pub change_descriptor: Option<Descriptor<DescriptorPublicKey>>,
     /// Stores the network type of the transaction data.
     pub network: Option<bitcoin::Network>,
@@ -122,6 +124,7 @@ pub struct ChangeSet {
 
 impl Merge for ChangeSet {
     /// Merge another [`ChangeSet`] into itself.
+    #[allow(deprecated)]
     fn merge(&mut self, other: Self) {
         if other.descriptor.is_some() {
             debug_assert!(
@@ -154,6 +157,7 @@ impl Merge for ChangeSet {
         Merge::merge(&mut self.indexer, other.indexer);
     }
 
+    #[allow(deprecated)]
     fn is_empty(&self) -> bool {
         self.descriptor.is_none()
             && self.change_descriptor.is_none()
@@ -215,6 +219,7 @@ impl ChangeSet {
     }
 
     /// Recover a [`ChangeSet`] from sqlite database.
+    #[allow(deprecated)]
     pub fn from_sqlite(db_tx: &chain::rusqlite::Transaction) -> chain::rusqlite::Result<Self> {
         use bitcoin::{OutPoint, Txid};
         use chain::rusqlite::OptionalExtension;
@@ -269,6 +274,7 @@ impl ChangeSet {
     }
 
     /// Persist [`ChangeSet`] to sqlite database.
+    #[allow(deprecated)]
     pub fn persist_to_sqlite(
         &self,
         db_tx: &chain::rusqlite::Transaction,

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -309,6 +309,7 @@ impl Wallet {
     /// Create a new [`Wallet`] with given `params`.
     ///
     /// Refer to [`Wallet::create`] for more.
+    #[allow(deprecated)]
     pub fn create_with_params(params: CreateParams) -> Result<Self, DescriptorError> {
         let secp = SecpCtx::new();
         let network = params.network;
@@ -428,6 +429,7 @@ impl Wallet {
     /// Load [`Wallet`] from the given previously persisted [`ChangeSet`] and `params`.
     ///
     /// Returns `Ok(None)` if the changeset is empty. Refer to [`Wallet::load`] for more.
+    #[allow(deprecated)]
     pub fn load_with_params(
         changeset: ChangeSet,
         params: LoadParams,

--- a/src/wallet/persisted.rs
+++ b/src/wallet/persisted.rs
@@ -393,6 +393,7 @@ impl<E: fmt::Display> fmt::Display for CreateWithPersistError<E> {
 impl<E: fmt::Debug + fmt::Display> std::error::Error for CreateWithPersistError<E> {}
 
 /// Helper function to display basic information about a [`ChangeSet`].
+#[allow(deprecated)]
 fn changeset_info(f: &mut fmt::Formatter<'_>, changeset: &ChangeSet) -> fmt::Result {
     let network = changeset
         .network


### PR DESCRIPTION
### Description
These fields are planned to be replaced by `keyring` field when we have the multi-keychain wallet so need to be deprecated following the policy in #391 .

### Changelog notice

- Deprecated `network`, `descriptor` and `change_descriptor` fields of `wallet::ChangeSet` .

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `just p` before pushing
