### PR TITLE
Replace `std::error::Error` with `core::error::Error`

### DIFF
--- a/examples/compiler.rs
+++ b/examples/compiler.rs
@@ -14,7 +14,7 @@ extern crate bitcoin;
 extern crate miniscript;
 extern crate serde_json;
 
-use std::error::Error;
+use core::error::Error;
 use std::str::FromStr;
 
 use bitcoin::Network;

--- a/examples/policy.rs
+++ b/examples/policy.rs
@@ -11,7 +11,7 @@
 
 extern crate bdk_wallet;
 
-use std::error::Error;
+use core::error::Error;
 
 use bdk_wallet::descriptor::{policy::BuildSatisfaction, ExtractPolicy, IntoWalletDescriptor};
 use bdk_wallet::signer::SignersContainer;

--- a/src/descriptor/dsl.rs
+++ b/src/descriptor/dsl.rs
@@ -440,7 +440,7 @@ macro_rules! apply_modifier {
 /// ```
 /// # use std::str::FromStr;
 /// let (my_descriptor, my_keys_map, network_kinds) = bdk_wallet::descriptor!(sh(wsh(and_v(v:pk("cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy"),older(50)))))?;
-/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// # Ok::<(), Box<dyn core::error::Error>>(())
 /// ```
 ///
 /// -------
@@ -478,7 +478,7 @@ macro_rules! apply_modifier {
 ///
 /// assert_eq!(descriptor_a, descriptor_b);
 /// assert_eq!(key_map_a.len(), key_map_b.len());
-/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// # Ok::<(), Box<dyn core::error::Error>>(())
 /// ```
 ///
 /// ------
@@ -498,7 +498,7 @@ macro_rules! apply_modifier {
 ///         multi(2, my_key_1, my_key_2)
 ///     )
 /// }?;
-/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// # Ok::<(), Box<dyn core::error::Error>>(())
 /// ```
 ///
 /// ------
@@ -510,7 +510,7 @@ macro_rules! apply_modifier {
 ///     bitcoin::PrivateKey::from_wif("cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy")?;
 ///
 /// let (descriptor, key_map, networks_kinds) = bdk_wallet::descriptor!(wpkh(my_key))?;
-/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// # Ok::<(), Box<dyn core::error::Error>>(())
 /// ```
 ///
 /// [`Vec`]: alloc::vec::Vec

--- a/src/descriptor/error.rs
+++ b/src/descriptor/error.rs
@@ -88,8 +88,7 @@ impl fmt::Display for Error {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 
 impl From<bitcoin::bip32::Error> for Error {
     fn from(err: bitcoin::bip32::Error) -> Self {

--- a/src/descriptor/policy.rs
+++ b/src/descriptor/policy.rs
@@ -545,8 +545,7 @@ impl From<IndexOutOfBoundsError> for PolicyError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for PolicyError {}
+impl core::error::Error for PolicyError {}
 
 impl Policy {
     fn new(item: SatisfiableItem) -> Self {

--- a/src/descriptor/template.rs
+++ b/src/descriptor/template.rs
@@ -94,7 +94,7 @@ impl<T: DescriptorTemplate> IntoWalletDescriptor for T {
 ///         .to_string(),
 ///     "mwJ8hxFYW19JLuc65RCTaP4v1rzVU8cVMT"
 /// );
-/// # Ok::<_, Box<dyn std::error::Error>>(())
+/// # Ok::<_, Box<dyn core::error::Error>>(())
 /// ```
 #[derive(Debug, Clone)]
 pub struct P2Pkh<K: IntoDescriptorKey<Legacy>>(pub K);
@@ -129,7 +129,7 @@ impl<K: IntoDescriptorKey<Legacy>> DescriptorTemplate for P2Pkh<K> {
 ///         .to_string(),
 ///     "2NB4ox5VDRw1ecUv6SnT3VQHPXveYztRqk5"
 /// );
-/// # Ok::<_, Box<dyn std::error::Error>>(())
+/// # Ok::<_, Box<dyn core::error::Error>>(())
 /// ```
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone)]
@@ -165,7 +165,7 @@ impl<K: IntoDescriptorKey<Segwitv0>> DescriptorTemplate for P2Wpkh_P2Sh<K> {
 ///         .to_string(),
 ///     "tb1q4525hmgw265tl3drrl8jjta7ayffu6jf68ltjd"
 /// );
-/// # Ok::<_, Box<dyn std::error::Error>>(())
+/// # Ok::<_, Box<dyn core::error::Error>>(())
 /// ```
 #[derive(Debug, Clone)]
 pub struct P2Wpkh<K: IntoDescriptorKey<Segwitv0>>(pub K);
@@ -200,7 +200,7 @@ impl<K: IntoDescriptorKey<Segwitv0>> DescriptorTemplate for P2Wpkh<K> {
 ///         .to_string(),
 ///     "tb1pvjf9t34fznr53u5tqhejz4nr69luzkhlvsdsdfq9pglutrpve2xq7hps46"
 /// );
-/// # Ok::<_, Box<dyn std::error::Error>>(())
+/// # Ok::<_, Box<dyn core::error::Error>>(())
 /// ```
 #[derive(Debug, Clone)]
 pub struct P2TR<K: IntoDescriptorKey<Tap>>(pub K);
@@ -233,7 +233,7 @@ impl<K: IntoDescriptorKey<Tap>> DescriptorTemplate for P2TR<K> {
 ///
 /// assert_eq!(wallet.next_unused_address(KeychainKind::External).to_string(), "mmogjc7HJEZkrLqyQYqJmxUqFaC7i4uf89");
 /// assert_eq!(wallet.public_descriptor(KeychainKind::External).to_string(), "pkh([c55b303f/44'/1'/0']tpubDCuorCpzvYS2LCD75BR46KHE8GdDeg1wsAgNZeNr6DaB5gQK1o14uErKwKLuFmeemkQ6N2m3rNgvctdJLyr7nwu2yia7413Hhg8WWE44cgT/0/*)#5wrnv0xt");
-/// # Ok::<_, Box<dyn std::error::Error>>(())
+/// # Ok::<_, Box<dyn core::error::Error>>(())
 /// ```
 #[derive(Debug, Clone)]
 pub struct Bip44<K: DerivableKey<Legacy>>(pub K, pub KeychainKind);
@@ -279,7 +279,7 @@ impl<K: DerivableKey<Legacy>> DescriptorTemplate for Bip44<K> {
 ///
 /// assert_eq!(wallet.next_unused_address(KeychainKind::External).to_string(), "miNG7dJTzJqNbFS19svRdTCisC65dsubtR");
 /// assert_eq!(wallet.public_descriptor(KeychainKind::External).to_string(), "pkh([c55b303f/44'/1'/0']tpubDDDzQ31JkZB7VxUr9bjvBivDdqoFLrDPyLWtLapArAi51ftfmCb2DPxwLQzX65iNcXz1DGaVvyvo6JQ6rTU73r2gqdEo8uov9QKRb7nKCSU/0/*)#cfhumdqz");
-/// # Ok::<_, Box<dyn std::error::Error>>(())
+/// # Ok::<_, Box<dyn core::error::Error>>(())
 /// ```
 #[derive(Debug, Clone)]
 pub struct Bip44Public<K: DerivableKey<Legacy>>(pub K, pub bip32::Fingerprint, pub KeychainKind);
@@ -322,7 +322,7 @@ impl<K: DerivableKey<Legacy>> DescriptorTemplate for Bip44Public<K> {
 ///
 /// assert_eq!(wallet.next_unused_address(KeychainKind::External).to_string(), "2N4zkWAoGdUv4NXhSsU8DvS5MB36T8nKHEB");
 /// assert_eq!(wallet.public_descriptor(KeychainKind::External).to_string(), "sh(wpkh([c55b303f/49'/1'/0']tpubDDYr4kdnZgjjShzYNjZUZXUUtpXaofdkMaipyS8ThEh45qFmhT4hKYways7UXmg6V7het1QiFo9kf4kYUXyDvV4rHEyvSpys9pjCB3pukxi/0/*))#s9vxlc8e");
-/// # Ok::<_, Box<dyn std::error::Error>>(())
+/// # Ok::<_, Box<dyn core::error::Error>>(())
 /// ```
 #[derive(Debug, Clone)]
 pub struct Bip49<K: DerivableKey<Segwitv0>>(pub K, pub KeychainKind);
@@ -368,7 +368,7 @@ impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for Bip49<K> {
 ///
 /// assert_eq!(wallet.next_unused_address(KeychainKind::External).to_string(), "2N3K4xbVAHoiTQSwxkZjWDfKoNC27pLkYnt");
 /// assert_eq!(wallet.public_descriptor(KeychainKind::External).to_string(), "sh(wpkh([c55b303f/49'/1'/0']tpubDC49r947KGK52X5rBWS4BLs5m9SRY3pYHnvRrm7HcybZ3BfdEsGFyzCMzayi1u58eT82ZeyFZwH7DD6Q83E3fM9CpfMtmnTygnLfP59jL9L/0/*))#3tka9g0q");
-/// # Ok::<_, Box<dyn std::error::Error>>(())
+/// # Ok::<_, Box<dyn core::error::Error>>(())
 /// ```
 #[derive(Debug, Clone)]
 pub struct Bip49Public<K: DerivableKey<Segwitv0>>(pub K, pub bip32::Fingerprint, pub KeychainKind);
@@ -411,7 +411,7 @@ impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for Bip49Public<K> {
 ///
 /// assert_eq!(wallet.next_unused_address(KeychainKind::External).to_string(), "tb1qhl85z42h7r4su5u37rvvw0gk8j2t3n9y7zsg4n");
 /// assert_eq!(wallet.public_descriptor(KeychainKind::External).to_string(), "wpkh([c55b303f/84'/1'/0']tpubDDc5mum24DekpNw92t6fHGp8Gr2JjF9J7i4TZBtN6Vp8xpAULG5CFaKsfugWa5imhrQQUZKXe261asP5koDHo5bs3qNTmf3U3o4v9SaB8gg/0/*)#6kfecsmr");
-/// # Ok::<_, Box<dyn std::error::Error>>(())
+/// # Ok::<_, Box<dyn core::error::Error>>(())
 /// ```
 #[derive(Debug, Clone)]
 pub struct Bip84<K: DerivableKey<Segwitv0>>(pub K, pub KeychainKind);
@@ -457,7 +457,7 @@ impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for Bip84<K> {
 ///
 /// assert_eq!(wallet.next_unused_address(KeychainKind::External).to_string(), "tb1qedg9fdlf8cnnqfd5mks6uz5w4kgpk2pr6y4qc7");
 /// assert_eq!(wallet.public_descriptor(KeychainKind::External).to_string(), "wpkh([c55b303f/84'/1'/0']tpubDC2Qwo2TFsaNC4ju8nrUJ9mqVT3eSgdmy1yPqhgkjwmke3PRXutNGRYAUo6RCHTcVQaDR3ohNU9we59brGHuEKPvH1ags2nevW5opEE9Z5Q/0/*)#dhu402yv");
-/// # Ok::<_, Box<dyn std::error::Error>>(())
+/// # Ok::<_, Box<dyn core::error::Error>>(())
 /// ```
 #[derive(Debug, Clone)]
 pub struct Bip84Public<K: DerivableKey<Segwitv0>>(pub K, pub bip32::Fingerprint, pub KeychainKind);
@@ -500,7 +500,7 @@ impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for Bip84Public<K> {
 ///
 /// assert_eq!(wallet.next_unused_address(KeychainKind::External).to_string(), "tb1p5unlj09djx8xsjwe97269kqtxqpwpu2epeskgqjfk4lnf69v4tnqpp35qu");
 /// assert_eq!(wallet.public_descriptor(KeychainKind::External).to_string(), "tr([c55b303f/86'/1'/0']tpubDCiHofpEs47kx358bPdJmTZHmCDqQ8qw32upCSxHrSEdeeBs2T5Mq6QMB2ukeMqhNBiyhosBvJErteVhfURPGXPv3qLJPw5MVpHUewsbP2m/0/*)#dkgvr5hm");
-/// # Ok::<_, Box<dyn std::error::Error>>(())
+/// # Ok::<_, Box<dyn core::error::Error>>(())
 /// ```
 #[derive(Debug, Clone)]
 pub struct Bip86<K: DerivableKey<Tap>>(pub K, pub KeychainKind);
@@ -546,7 +546,7 @@ impl<K: DerivableKey<Tap>> DescriptorTemplate for Bip86<K> {
 ///
 /// assert_eq!(wallet.next_unused_address(KeychainKind::External).to_string(), "tb1pwjp9f2k5n0xq73ecuu0c5njvgqr3vkh7yaylmpqvsuuaafymh0msvcmh37");
 /// assert_eq!(wallet.public_descriptor(KeychainKind::External).to_string(), "tr([c55b303f/86'/1'/0']tpubDC2Qwo2TFsaNC4ju8nrUJ9mqVT3eSgdmy1yPqhgkjwmke3PRXutNGRYAUo6RCHTcVQaDR3ohNU9we59brGHuEKPvH1ags2nevW5opEE9Z5Q/0/*)#2p65srku");
-/// # Ok::<_, Box<dyn std::error::Error>>(())
+/// # Ok::<_, Box<dyn core::error::Error>>(())
 /// ```
 #[derive(Debug, Clone)]
 pub struct Bip86Public<K: DerivableKey<Tap>>(pub K, pub bip32::Fingerprint, pub KeychainKind);

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -304,7 +304,7 @@ impl<Ctx: ScriptContext + 'static> ExtScriptContext for Ctx {
 /// let (descriptor, _, _) = bdk_wallet::descriptor!(pkh(key))?;
 /// //                                               ^^^^^ changing this to `wpkh` would make it compile
 ///
-/// # Ok::<_, Box<dyn std::error::Error>>(())
+/// # Ok::<_, Box<dyn core::error::Error>>(())
 /// ```
 pub trait IntoDescriptorKey<Ctx: ScriptContext>: Sized {
     /// Turn the key into a [`DescriptorKey`] within the requested [`ScriptContext`]
@@ -472,7 +472,7 @@ use bdk_wallet::bitcoin::NetworkKind;
 use bdk_wallet::keys::{DerivableKey, ExtendedKey};
 use bdk_wallet::keys::bip39::{Mnemonic, Language};
 
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
+# fn main() -> Result<(), Box<dyn core::error::Error>> {
 let xkey: ExtendedKey =
     Mnemonic::parse_in(
         Language::English,
@@ -1038,8 +1038,7 @@ impl fmt::Display for KeyError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for KeyError {}
+impl core::error::Error for KeyError {}
 
 #[cfg_attr(coverage_nightly, coverage(off))]
 #[cfg(test)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -171,5 +171,4 @@ impl fmt::Display for IndexOutOfBoundsError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for IndexOutOfBoundsError {}
+impl core::error::Error for IndexOutOfBoundsError {}

--- a/src/wallet/coin_selection.rs
+++ b/src/wallet/coin_selection.rs
@@ -141,8 +141,7 @@ impl fmt::Display for InsufficientFunds {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for InsufficientFunds {}
+impl core::error::Error for InsufficientFunds {}
 
 #[derive(Debug)]
 /// Remaining amount after performing coin selection

--- a/src/wallet/error.rs
+++ b/src/wallet/error.rs
@@ -51,8 +51,7 @@ impl fmt::Display for LoadError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for LoadError {}
+impl core::error::Error for LoadError {}
 
 /// Represents a mismatch with what is loaded and what is expected from [`LoadParams`].
 #[derive(Debug, PartialEq)]
@@ -148,8 +147,7 @@ impl fmt::Display for MiniscriptPsbtError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for MiniscriptPsbtError {}
+impl core::error::Error for MiniscriptPsbtError {}
 
 #[derive(Debug)]
 /// Error returned from [`TxBuilder::finish`]
@@ -312,8 +310,7 @@ impl From<coin_selection::InsufficientFunds> for CreateTxError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for CreateTxError {}
+impl core::error::Error for CreateTxError {}
 
 #[derive(Debug)]
 /// Error returned from [`Wallet::build_fee_bump`]
@@ -362,5 +359,4 @@ impl fmt::Display for BuildFeeBumpError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for BuildFeeBumpError {}
+impl core::error::Error for BuildFeeBumpError {}

--- a/src/wallet/export.rs
+++ b/src/wallet/export.rs
@@ -38,7 +38,7 @@
 //! )
 //! .network(Network::Testnet)
 //! .create_wallet_no_persist()?;
-//! # Ok::<_, Box<dyn std::error::Error>>(())
+//! # Ok::<_, Box<dyn core::error::Error>>(())
 //! ```
 //!
 //! ### Export a `Wallet` to FullyNoded format
@@ -55,7 +55,7 @@
 //! let export = FullyNodedExport::export_wallet(&wallet, "exported wallet", true).unwrap();
 //!
 //! println!("Exported: {}", export.to_string());
-//! # Ok::<_, Box<dyn std::error::Error>>(())
+//! # Ok::<_, Box<dyn core::error::Error>>(())
 //! ```
 //!
 //! ### Export a `Wallet` to Caravan format
@@ -72,7 +72,7 @@
 //! let export = CaravanExport::export_wallet(&wallet, "My Multisig Wallet").unwrap();
 //!
 //! println!("Exported: {}", export.to_string());
-//! # Ok::<_, Box<dyn std::error::Error>>(())
+//! # Ok::<_, Box<dyn core::error::Error>>(())
 //! ```
 //!
 //! ### Import from Caravan format
@@ -113,7 +113,7 @@
 //! let (external, internal) = import.to_descriptors()?;
 //! # assert_eq!(external, "wsh(sortedmulti(2,[73756c7f/48'/0'/0'/2']tpubDCKxNyM3bLgbEX13Mcd8mYxbVg9ajDkWXMh29hMWBurKfVmBfWAM96QVP3zaUcN51HvkZ3ar4VwP82kC8JZhhux8vFQoJintSpVBwpFvyU3/0/*,[f9f62194/48'/0'/0'/2']tpubDDp3ZSH1yCwusRppH7zgSxq2t1VEUyXSeEp8E5aFS8m43MknUjiF1bSLo3CGWAxbDyhF1XowA5ukPzyJZjznYk3kYi6oe7QxtX2euvKWsk4/0/*))#pgthjwtg");
 //! # assert_eq!(internal, "wsh(sortedmulti(2,[73756c7f/48'/0'/0'/2']tpubDCKxNyM3bLgbEX13Mcd8mYxbVg9ajDkWXMh29hMWBurKfVmBfWAM96QVP3zaUcN51HvkZ3ar4VwP82kC8JZhhux8vFQoJintSpVBwpFvyU3/1/*,[f9f62194/48'/0'/0'/2']tpubDDp3ZSH1yCwusRppH7zgSxq2t1VEUyXSeEp8E5aFS8m43MknUjiF1bSLo3CGWAxbDyhF1XowA5ukPzyJZjznYk3kYi6oe7QxtX2euvKWsk4/1/*))#cmcnua7a");
-//! # Ok::<_, Box<dyn std::error::Error>>(())
+//! # Ok::<_, Box<dyn core::error::Error>>(())
 //! ```
 //!
 //! ## Important Notes on Import/Export Operations

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -1177,7 +1177,7 @@ impl Wallet {
     ///     println!("secret_key: {}", secret_key);
     /// }
     ///
-    /// Ok::<(), Box<dyn std::error::Error>>(())
+    /// Ok::<(), Box<dyn core::error::Error>>(())
     /// ```
     pub fn get_signers(&self, keychain: KeychainKind) -> Arc<SignersContainer> {
         match keychain {

--- a/src/wallet/persisted.rs
+++ b/src/wallet/persisted.rs
@@ -1,5 +1,5 @@
 use core::{
-    fmt,
+    error, fmt,
     future::Future,
     marker::PhantomData,
     ops::{Deref, DerefMut},
@@ -321,7 +321,7 @@ impl core::fmt::Display for FileStoreError {
 }
 
 #[cfg(feature = "file_store")]
-impl std::error::Error for FileStoreError {}
+impl error::Error for FileStoreError {}
 
 #[cfg(feature = "file_store")]
 impl WalletPersister for bdk_file_store::Store<ChangeSet> {
@@ -357,8 +357,7 @@ impl<E: fmt::Display> fmt::Display for LoadWithPersistError<E> {
     }
 }
 
-#[cfg(feature = "std")]
-impl<E: fmt::Debug + fmt::Display> std::error::Error for LoadWithPersistError<E> {}
+impl<E: fmt::Debug + fmt::Display> error::Error for LoadWithPersistError<E> {}
 
 /// Error type for [`PersistedWallet::create`].
 #[derive(Debug)]
@@ -389,8 +388,7 @@ impl<E: fmt::Display> fmt::Display for CreateWithPersistError<E> {
     }
 }
 
-#[cfg(feature = "std")]
-impl<E: fmt::Debug + fmt::Display> std::error::Error for CreateWithPersistError<E> {}
+impl<E: fmt::Debug + fmt::Display> error::Error for CreateWithPersistError<E> {}
 
 /// Helper function to display basic information about a [`ChangeSet`].
 fn changeset_info(f: &mut fmt::Formatter<'_>, changeset: &ChangeSet) -> fmt::Result {

--- a/src/wallet/signer.rs
+++ b/src/wallet/signer.rs
@@ -202,8 +202,7 @@ impl From<IndexOutOfBoundsError> for SignerError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for SignerError {}
+impl core::error::Error for SignerError {}
 
 /// Signing context
 ///

--- a/src/wallet/tx_builder.rs
+++ b/src/wallet/tx_builder.rs
@@ -787,8 +787,7 @@ impl fmt::Display for AddUtxoError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for AddUtxoError {}
+impl core::error::Error for AddUtxoError {}
 
 #[derive(Debug)]
 /// Error returned from [`TxBuilder::add_foreign_utxo`].
@@ -827,8 +826,7 @@ impl fmt::Display for AddForeignUtxoError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for AddForeignUtxoError {}
+impl core::error::Error for AddForeignUtxoError {}
 
 type TxSort<T> = dyn (Fn(&T, &T) -> core::cmp::Ordering) + Send + Sync;
 

--- a/tests/persisted_wallet.rs
+++ b/tests/persisted_wallet.rs
@@ -94,7 +94,7 @@ fn wallet_is_persisted() -> anyhow::Result<()> {
         CreateDb: Fn(&Path) -> anyhow::Result<Db>,
         OpenDb: Fn(&Path) -> anyhow::Result<Db>,
         Db: WalletPersister,
-        Db::Error: std::error::Error + Send + Sync + 'static,
+        Db::Error: core::error::Error + Send + Sync + 'static,
     {
         let temp_dir = tempfile::tempdir().expect("must create tempdir");
         let file_path = temp_dir.path().join(filename);
@@ -240,7 +240,7 @@ fn wallet_load_checks() -> anyhow::Result<()> {
         CreateDb: Fn(&Path) -> anyhow::Result<Db>,
         OpenDb: Fn(&Path) -> anyhow::Result<Db>,
         Db: WalletPersister + std::fmt::Debug,
-        Db::Error: std::error::Error + Send + Sync + 'static,
+        Db::Error: core::error::Error + Send + Sync + 'static,
     {
         let temp_dir = tempfile::tempdir().expect("must create tempdir");
         let file_path = temp_dir.path().join(filename);


### PR DESCRIPTION
The `Error` trait is stable as of 1.81.0, so import it from `core` instead.

### Changelog notice
```
# Changed

- Implement `core::error::Error` for several types and un-feature-gate `std::error::Error`.
```
### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
