### PR TITLE
revert: "chore: deprecate `wallet::signer` mod"

### DIFF
--- a/ci/pin-msrv.sh
+++ b/ci/pin-msrv.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 # cargo clean
 # rustup override set 1.63.0
 
+cargo update -p clap --precise "4.5.17"
 cargo update -p once_cell --precise "1.20.3"
 cargo update -p syn --precise "2.0.106"
 cargo update -p quote --precise "1.0.41"

--- a/examples/example_wallet_electrum/src/main.rs
+++ b/examples/example_wallet_electrum/src/main.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated)]
 use bdk_electrum::electrum_client;
 use bdk_electrum::BdkElectrumClient;
 use bdk_wallet::bitcoin::Amount;

--- a/examples/example_wallet_esplora_async/src/main.rs
+++ b/examples/example_wallet_esplora_async/src/main.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated)]
 use anyhow::Ok;
 use bdk_esplora::{esplora_client, EsploraAsyncExt};
 use bdk_wallet::{

--- a/examples/example_wallet_esplora_blocking/src/main.rs
+++ b/examples/example_wallet_esplora_blocking/src/main.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated)]
 use bdk_esplora::{esplora_client, EsploraExt};
 use bdk_wallet::rusqlite::Connection;
 use bdk_wallet::{

--- a/wallet/examples/policy.rs
+++ b/wallet/examples/policy.rs
@@ -9,7 +9,6 @@
 // You may not use this file except in accordance with one or both of these
 // licenses.
 
-#![allow(deprecated)]
 extern crate bdk_wallet;
 use std::error::Error;
 

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -6,7 +6,6 @@
     doc(html_logo_url = "https://github.com/bitcoindevkit/bdk/raw/master/static/bdk.png")
 )]
 #![no_std]
-#![allow(deprecated)] // Signers are being removed.
 #![warn(missing_docs)]
 #![allow(clippy::uninlined_format_args)]
 

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -57,10 +57,6 @@ pub mod export;
 pub mod migration;
 mod params;
 mod persisted;
-#[deprecated(
-    since = "2.2.0",
-    note = "PSBT signing was moved to `bitcoin::psbt` module"
-)]
 pub mod signer;
 pub mod tx_builder;
 pub(crate) mod utils;

--- a/wallet/tests/add_foreign_utxo.rs
+++ b/wallet/tests/add_foreign_utxo.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated)]
 use std::str::FromStr;
 
 use bdk_wallet::psbt::PsbtUtils;

--- a/wallet/tests/persisted_wallet.rs
+++ b/wallet/tests/persisted_wallet.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated)]
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 

--- a/wallet/tests/psbt.rs
+++ b/wallet/tests/psbt.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated)]
 use bdk_wallet::bitcoin::{Amount, FeeRate, Psbt, TxIn};
 use bdk_wallet::test_utils::*;
 use bdk_wallet::{psbt, KeychainKind, SignOptions};

--- a/wallet/tests/wallet.rs
+++ b/wallet/tests/wallet.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated)]
 use std::str::FromStr;
 use std::sync::Arc;
 

--- a/wallet/tests/wallet_event.rs
+++ b/wallet/tests/wallet_event.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated)]
 use bdk_chain::{BlockId, CheckPoint, ConfirmationBlockTime};
 use bdk_wallet::event::WalletEvent;
 use bdk_wallet::test_utils::{get_test_wpkh_and_change_desc, new_wallet_and_funding_update};


### PR DESCRIPTION
### Description

This reverts commit 4c4e0b19e5f8f1754ca8c627e147f6c3166741d0.

Will deprecate the signer mod again when the new psbt signer is ready.

### Notes to the reviewers

The signer mod is not deprecated in `master` branch and won't be until the psbt signer is ready, likely in the 3.1 release. 

### Changelog notice

- Un-deprecate the existing bdk_wallet signer mod due to unfinished work on the new psbt signer.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `just p` before pushing

