### PR TITLE
Bump Rust compiler version to stable (1.94.0)

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.93.0"
+channel = "1.94.0"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
This is just a bump of the default compiler version specified in `rust-toolchain.toml` to [1.94.0, the latest stable](https://releases.rs/).