### PR TITLE
ci: add docs check job

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -146,3 +146,18 @@ jobs:
       - name: Clippy
         run: cargo clippy --all-features --all-targets -- -D warnings
 
+  docs_check:
+    name: Check cargo doc
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      # This action automatically reads and applies rust-toolchain.toml
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: true
+      - name: Check docs
+        run: RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps

--- a/ci/pin-msrv.sh
+++ b/ci/pin-msrv.sh
@@ -9,3 +9,7 @@ set -euo pipefail
 
 # cargo clean
 # rustup default 1.85.0
+
+cargo update -p icu_normalizer --precise "2.1.1"
+cargo update -p icu_provider --precise "2.1.1"
+cargo update -p icu_locale_core --precise "2.1.1"

--- a/justfile
+++ b/justfile
@@ -3,6 +3,7 @@ alias c := check
 alias f := fmt
 alias t := test
 alias p := pre-push
+alias d := doc
 
 _default:
    @just --list
@@ -28,5 +29,9 @@ fmt:
 test:
    cargo test --all-features
 
+# Check docs on the workspace
+doc:
+   RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps
+
 # Run pre-push suite: format, check, and test
-pre-push: fmt check test
+pre-push: fmt check test doc

--- a/src/wallet/changeset.rs
+++ b/src/wallet/changeset.rs
@@ -127,7 +127,7 @@ type IndexedTxGraphChangeSet =
 /// [merged]: bdk_chain::Merge
 /// [`network`]: Self::network
 /// [`PersistedWallet`]: crate::PersistedWallet
-/// [SQLite]: bdk_chain::rusqlite_impl
+/// [SQLite]: <https://docs.rs/rusqlite/0.31.0/rusqlite/>
 /// [`Update`]: crate::Update
 /// [`WalletPersister`]: crate::WalletPersister
 /// [`Wallet::staged`]: crate::Wallet::staged

--- a/src/wallet/error.rs
+++ b/src/wallet/error.rs
@@ -23,6 +23,9 @@ use bitcoin::{absolute, psbt, Amount, BlockHash, Network, OutPoint, Sequence, Tx
 use core::fmt;
 
 /// The error type when loading a [`Wallet`] from a [`ChangeSet`].
+///
+/// [`Wallet`]: crate::wallet::Wallet
+/// [`ChangeSet`]: crate::wallet::ChangeSet
 #[derive(Debug, PartialEq)]
 pub enum LoadError {
     /// There was a problem with the passed-in descriptor(s).
@@ -54,6 +57,8 @@ impl fmt::Display for LoadError {
 impl core::error::Error for LoadError {}
 
 /// Represents a mismatch with what is loaded and what is expected from [`LoadParams`].
+///
+/// [`LoadParams`]: crate::wallet::LoadParams
 #[derive(Debug, PartialEq)]
 pub enum LoadMismatch {
     /// Network does not match.


### PR DESCRIPTION
### Description

As we are adding in https://github.com/bitcoindevkit/bdk/pull/2158, this PR adds a new CI job and justfile recipe to check for the documentation.

### Notes to the reviewers


### Changelog notice

```
### Added

- ci: add new `docs_check` job to check for any error or warning in docs.

### Changed
- ci(msrv): pin `icu_*` dependencies for 1.85.0 supported MSRV
- fix(docs): use correct `intra_doc_links`.
```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `just p` before pushing
