### PR TITLE
refactor: Delegate `rusqlite::Connection` persister to transaction persister

### DIFF
--- a/src/wallet/persisted.rs
+++ b/src/wallet/persisted.rs
@@ -284,16 +284,16 @@ impl WalletPersister for bdk_chain::rusqlite::Connection {
     type Error = bdk_chain::rusqlite::Error;
 
     fn initialize(persister: &mut Self) -> Result<ChangeSet, Self::Error> {
-        let db_tx = persister.transaction()?;
-        ChangeSet::init_sqlite_tables(&db_tx)?;
-        let changeset = ChangeSet::from_sqlite(&db_tx)?;
+        let mut db_tx = persister.transaction()?;
+        let changeset =
+            <bdk_chain::rusqlite::Transaction<'_> as WalletPersister>::initialize(&mut db_tx)?;
         db_tx.commit()?;
         Ok(changeset)
     }
 
     fn persist(persister: &mut Self, changeset: &ChangeSet) -> Result<(), Self::Error> {
-        let db_tx = persister.transaction()?;
-        changeset.persist_to_sqlite(&db_tx)?;
+        let mut db_tx = persister.transaction()?;
+        <bdk_chain::rusqlite::Transaction<'_> as WalletPersister>::persist(&mut db_tx, changeset)?;
         db_tx.commit()
     }
 }


### PR DESCRIPTION
Fixes #279

### Description

The `WalletPersister` implementations for `rusqlite::Connection` and `rusqlite::Transaction` are currently independent.  The connection persister just creates a new transaction, does what the transaction persister does, and then commits. This refactor removes that duplication by having the Connection impl delegate directly to the Transaction impl.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `just p` before pushing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
