### PR TITLE
docs(wallet): fix misleading RBF comment in `create_tx`

### DIFF
--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -1492,10 +1492,10 @@ impl Wallet {
 
         if tx.output.is_empty() {
             // Uh oh, our transaction has no outputs.
-            // We allow this when:
-            // - We have a drain_to address and the utxos we must spend (this happens,
-            // for example, when we RBF).
-            // - We have a drain_to address and drain_wallet set.
+            // We allow this when we have a `drain_to` address and either:
+            // - `drain_wallet` is enabled
+            // - there are UTXOs we must spend (this happens, for example, when
+            // sweeping specific UTXOs to a given address)
             // Otherwise, we don't know who we should send the funds to, and how much
             // we should send!
             if params.drain_to.is_some() && (params.drain_wallet || !params.utxos.is_empty()) {


### PR DESCRIPTION
### Description

Fix misleading comment in `create_tx` regarding empty tx output logic. This addresses a documentation nitpick brought up by the 2024 [WizardSardine report](https://bitcoindevkit.org/audits/2024_q4/bdk_audit_report).

- Replaced incorrect RBF example with sweeping UTXOs
- Reordered comment items to match the code's condition order

Closes #45 

### Changelog notice

Fixed:
- Fix docs for `Wallet:create_tx` when empty output vector

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `just p` before pushing
