### PR TITLE
fix(wallet): allow fee bump without opt-in RBF signaling

### DIFF
--- a/src/wallet/error.rs
+++ b/src/wallet/error.rs
@@ -328,8 +328,6 @@ pub enum BuildFeeBumpError {
     TransactionNotFound(Txid),
     /// Happens when trying to bump a transaction that is already confirmed
     TransactionConfirmed(Txid),
-    /// Trying to replace a tx that has a sequence >= `0xFFFFFFFE`
-    IrreplaceableTransaction(Txid),
     /// Node doesn't have data to estimate a fee rate
     FeeRateUnavailable,
     /// Input references an invalid output index in the previous transaction
@@ -352,9 +350,6 @@ impl fmt::Display for BuildFeeBumpError {
             }
             Self::TransactionConfirmed(txid) => {
                 write!(f, "Transaction already confirmed with txid: {txid}")
-            }
-            Self::IrreplaceableTransaction(txid) => {
-                write!(f, "Transaction can't be replaced with txid: {txid}")
             }
             Self::FeeRateUnavailable => write!(f, "Fee rate unavailable"),
             Self::InvalidOutputIndex(op) => {

--- a/src/wallet/error.rs
+++ b/src/wallet/error.rs
@@ -333,8 +333,6 @@ pub enum BuildFeeBumpError {
     TransactionNotFound(Txid),
     /// Happens when trying to bump a transaction that is already confirmed
     TransactionConfirmed(Txid),
-    /// Trying to replace a tx that has a sequence >= `0xFFFFFFFE`
-    IrreplaceableTransaction(Txid),
     /// Node doesn't have data to estimate a fee rate
     FeeRateUnavailable,
     /// Input references an invalid output index in the previous transaction
@@ -357,9 +355,6 @@ impl fmt::Display for BuildFeeBumpError {
             }
             Self::TransactionConfirmed(txid) => {
                 write!(f, "Transaction already confirmed with txid: {txid}")
-            }
-            Self::IrreplaceableTransaction(txid) => {
-                write!(f, "Transaction can't be replaced with txid: {txid}")
             }
             Self::FeeRateUnavailable => write!(f, "Fee rate unavailable"),
             Self::InvalidOutputIndex(op) => {

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -1551,9 +1551,14 @@ impl Wallet {
 
     /// Bump the fee of a transaction previously created with this wallet.
     ///
-    /// Returns an error if the transaction is already confirmed or doesn't explicitly signal
-    /// *replace by fee* (RBF). If the transaction can be fee bumped then it returns a [`TxBuilder`]
-    /// pre-populated with the inputs and outputs of the original transaction.
+    /// Returns an error if the transaction is already confirmed. If the transaction can be fee
+    /// bumped then it returns a [`TxBuilder`] pre-populated with the inputs and outputs of the
+    /// original transaction.
+    ///
+    /// Replacing an unconfirmed transaction does not require the original to signal opt-in RBF
+    /// (`nSequence` ≤ `0xFFFFFFFD`). Relay and mining acceptance depend on local policy; Bitcoin
+    /// Core 28+ defaults to full-RBF mempool relay, while other implementations or configs may
+    /// differ.
     ///
     /// ## Example
     ///
@@ -1614,16 +1619,6 @@ impl Wallet {
             .is_confirmed()
         {
             return Err(BuildFeeBumpError::TransactionConfirmed(txid));
-        }
-
-        if !tx
-            .input
-            .iter()
-            .any(|txin| txin.sequence.to_consensus_u32() <= 0xFFFFFFFD)
-        {
-            return Err(BuildFeeBumpError::IrreplaceableTransaction(
-                tx.compute_txid(),
-            ));
         }
 
         let fee = self

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -1589,9 +1589,13 @@ impl Wallet {
 
     /// Bump the fee of a transaction previously created with this wallet.
     ///
-    /// Returns an error if the transaction is already confirmed or doesn't explicitly signal
-    /// *replace by fee* (RBF). If the transaction can be fee bumped then it returns a [`TxBuilder`]
-    /// pre-populated with the inputs and outputs of the original transaction.
+    /// Returns an error if the transaction is already confirmed. If the transaction can be fee
+    /// bumped then it returns a [`TxBuilder`] pre-populated with the inputs and outputs of the
+    /// original transaction.
+    ///
+    /// This builder does not require the original transaction to signal opt-in RBF
+    /// (`nSequence` <= `0xFFFFFFFD`). Whether the resulting replacement is accepted
+    /// for relay or mining depends on the local policy of the broadcasting node.
     ///
     /// ## Example
     ///
@@ -1652,16 +1656,6 @@ impl Wallet {
             .is_confirmed()
         {
             return Err(BuildFeeBumpError::TransactionConfirmed(txid));
-        }
-
-        if !tx
-            .input
-            .iter()
-            .any(|txin| txin.sequence.to_consensus_u32() <= 0xFFFFFFFD)
-        {
-            return Err(BuildFeeBumpError::IrreplaceableTransaction(
-                tx.compute_txid(),
-            ));
         }
 
         let fee = self

--- a/tests/build_fee_bump.rs
+++ b/tests/build_fee_bump.rs
@@ -16,19 +16,39 @@ mod common;
 use common::*;
 
 #[test]
-#[should_panic(expected = "IrreplaceableTransaction")]
-fn test_bump_fee_irreplaceable_tx() {
+fn test_bump_fee_tx_without_rbf_signaling() {
     let (mut wallet, _) = get_funded_wallet_wpkh();
     let addr = wallet.next_unused_address(KeychainKind::External);
     let mut builder = wallet.build_tx();
     builder.add_recipient(addr.script_pubkey(), Amount::from_sat(25_000));
     builder.set_exact_sequence(Sequence(0xFFFFFFFE));
     let psbt = builder.finish().unwrap();
+    let original_fee = check_fee!(wallet, psbt);
 
     let tx = psbt.extract_tx().expect("failed to extract tx");
     let txid = tx.compute_txid();
     insert_tx(&mut wallet, tx);
-    wallet.build_fee_bump(txid).unwrap().finish().unwrap();
+
+    let feerate = FeeRate::from_sat_per_kwu(625);
+    let mut builder = wallet
+        .build_fee_bump(txid)
+        .expect("fee bump without opt-in RBF");
+    builder.fee_rate(feerate);
+    let psbt = builder.finish().expect("finish fee bump");
+    let fee = check_fee!(wallet, psbt);
+    assert!(
+        fee > original_fee,
+        "fee bump must increase absolute fee: {fee} > {original_fee}"
+    );
+
+    let new_tx = psbt.clone().extract_tx().expect("failed to extract tx");
+    assert_ne!(
+        new_tx.compute_txid(),
+        txid,
+        "replacement transaction must differ from the original"
+    );
+
+    assert_fee_rate!(psbt, fee, feerate, @add_signature);
 }
 
 #[test]

--- a/tests/build_fee_bump.rs
+++ b/tests/build_fee_bump.rs
@@ -16,19 +16,51 @@ mod common;
 use common::*;
 
 #[test]
-#[should_panic(expected = "IrreplaceableTransaction")]
-fn test_bump_fee_irreplaceable_tx() {
+fn test_bump_fee_tx_without_rbf_signaling() {
     let (mut wallet, _) = get_funded_wallet_wpkh();
     let addr = wallet.next_unused_address(KeychainKind::External);
     let mut builder = wallet.build_tx();
     builder.add_recipient(addr.script_pubkey(), Amount::from_sat(25_000));
     builder.set_exact_sequence(Sequence(0xFFFFFFFE));
     let psbt = builder.finish().unwrap();
+    let original_fee = check_fee!(wallet, psbt);
 
     let tx = psbt.extract_tx().expect("failed to extract tx");
+    assert!(!tx.is_explicitly_rbf());
+    let original_prevouts = tx
+        .input
+        .iter()
+        .map(|txin| txin.previous_output)
+        .collect::<Vec<_>>();
     let txid = tx.compute_txid();
     insert_tx(&mut wallet, tx);
-    wallet.build_fee_bump(txid).unwrap().finish().unwrap();
+
+    let feerate = FeeRate::from_sat_per_kwu(625);
+    let mut builder = wallet
+        .build_fee_bump(txid)
+        .expect("fee bump without opt-in RBF");
+    builder.fee_rate(feerate);
+    let psbt = builder.finish().expect("finish fee bump");
+    let fee = check_fee!(wallet, psbt);
+    assert!(
+        fee > original_fee,
+        "fee bump must increase absolute fee: {fee} > {original_fee}"
+    );
+
+    let new_tx = psbt.clone().extract_tx().expect("failed to extract tx");
+    assert!(
+        new_tx
+            .input
+            .iter()
+            .any(|txin| original_prevouts.contains(&txin.previous_output)),
+    );
+    assert_ne!(
+        new_tx.compute_txid(),
+        txid,
+        "replacement transaction must differ from the original"
+    );
+
+    assert_fee_rate!(psbt, fee, feerate, @add_signature);
 }
 
 #[test]


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Fixes #65.

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->
`Wallet::build_fee_bump` previously refused to build a replacement when **no** input signaled opt-in RBF (`nSequence` ≤ `0xFFFFFFFD`). That guard is removed so the wallet can **construct** a fee-bump transaction even if the original did not opt in. Whether a replacement is accepted is a **mempool / relay policy** concern (e.g. default full-RBF in recent Bitcoin Core), not something this API can enforce by requiring a specific `nSequence` on the **prior** tx.

Also removes `BuildFeeBumpError::IrreplaceableTransaction`, since that path is no longer reachable.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->
- **API:** `BuildFeeBumpError::IrreplaceableTransaction` is removed (breaking public enum). If you prefer a deprecation cycle for the variant only, say so and we can adjust.
- **Semantics:** Callers could previously rely on an error when the original tx did not signal opt-in RBF; they must not assume that anymore.
- **Tests:** `tests/build_fee_bump.rs` — the old test expected failure for non–opt-in-RBF; it now asserts a successful fee bump with a higher fee rate.

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->
`fix(wallet): allow build_fee_bump without opt-in RBF on the original tx; remove IrreplaceableTransaction (#65)`

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `just p` before pushing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [x] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
