### PR TITLE
chore: Release 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,12 +56,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Switch to cargo-llvm-cov for code coverage [#371](https://github.com/bitcoindevkit/bdk_wallet/pull/371)
 - docs: Add section on ChangeSet version compatibility [#391](https://github.com/bitcoindevkit/bdk_wallet/pull/391)
 - Implement `core::error::Error` for several types and un-feature-gate `std::error::Error` [#397](https://github.com/bitcoindevkit/bdk_wallet/pull/397)
-- deps: bump `bdk_chain` to 0.23.2
-- deps: bump `bitcoin` to 0.32.8
-- deps: bump `miniscript` to 12.3.5
-- deps: bump `rand_core` to 0.6.4
-- deps: bump `bip39` to 2.2.2
-- deps: bump `tempfile` to 3.26.0
+- deps: bump `bitcoin` to 0.32.8 [#398](https://github.com/bitcoindevkit/bdk_wallet/pull/398)
+- deps: bump `miniscript` to 12.3.5 [#398](https://github.com/bitcoindevkit/bdk_wallet/pull/398)
+- deps: bump `rand_core` to 0.6.4 [#398](https://github.com/bitcoindevkit/bdk_wallet/pull/398)
+- deps: bump `bip39` to 2.2.2 [#398](https://github.com/bitcoindevkit/bdk_wallet/pull/398)
+- deps: bump `tempfile` to 3.26.0 [#398](https://github.com/bitcoindevkit/bdk_wallet/pull/398)
+- build(deps): bump actions/upload-artifact from 6 to 7 [#389](https://github.com/bitcoindevkit/bdk_wallet/pull/389)
+- build(deps): bump Swatinem/rust-cache from 2.8.2 to 2.9.1 [#406](https://github.com/bitcoindevkit/bdk_wallet/pull/406)
+- chore: Bump Rust compiler version to stable (1.94.0) [#407](https://github.com/bitcoindevkit/bdk_wallet/pull/407)
+- ci: add docs check job [#416](https://github.com/bitcoindevkit/bdk_wallet/pull/416)
+- build(deps): bump codecov/codecov-action from 5.5.2 to 6.0.0 [#424](https://github.com/bitcoindevkit/bdk_wallet/pull/424)
+- deps: bump `bdk_chain` to 0.23.3
+- deps: bump `bdk_bitcoind_rpc` to 0.22.0
+- deps: bump `bdk_file_store` to 0.22.0
 
 ### Removed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bdk_wallet"
 homepage = "https://bitcoindevkit.org"
-version = "3.0.0-rc.2"
+version = "3.0.0"
 repository = "https://github.com/bitcoindevkit/bdk_wallet"
 documentation = "https://docs.rs/bdk_wallet"
 description = "A modern, lightweight, descriptor-based wallet library"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
 
 [dependencies]
-bdk_chain = { version = "0.23.2", features = ["miniscript", "serde"], default-features = false }
+bdk_chain = { version = "0.23.3", features = ["miniscript", "serde"], default-features = false }
 bitcoin = { version = "0.32.8", features = ["serde", "base64"], default-features = false }
 miniscript = { version = "12.3.5", features = ["serde"], default-features = false }
 rand_core = { version = "0.6.4" }
@@ -29,7 +29,7 @@ serde = { version = "1", features = ["derive"] }
 
 # Optional dependencies
 anyhow = { version = "1", optional = true }
-bdk_file_store = { version = "0.21.1", optional = true }
+bdk_file_store = { version = "0.22.0", optional = true }
 bip39 = { version = "2.2.2", optional = true }
 tempfile = { version = "3.26.0", optional = true }
 
@@ -46,7 +46,7 @@ test-utils = ["std", "anyhow", "tempfile"]
 [dev-dependencies]
 anyhow = "1"
 assert_matches = "1.5.0"
-bdk_bitcoind_rpc = { version = "0.21.0" }
+bdk_bitcoind_rpc = { version = "0.22.0" }
 bdk_electrum = { version = "0.23.2" }
 bdk_esplora = { version = "0.22.1", features = ["async-https", "blocking-https", "tokio"] }
 bdk_wallet = { path = ".", features = ["rusqlite", "file_store", "test-utils"] }

--- a/src/wallet/persisted.rs
+++ b/src/wallet/persisted.rs
@@ -301,7 +301,6 @@ impl WalletPersister for bdk_chain::rusqlite::Connection {
 /// Error for [`bdk_file_store`]'s implementation of [`WalletPersister`].
 #[cfg(feature = "file_store")]
 #[derive(Debug)]
-#[allow(clippy::large_enum_variant)]
 pub enum FileStoreError {
     /// Error when loading from the store.
     Load(bdk_file_store::StoreErrorWithDump<ChangeSet>),


### PR DESCRIPTION
### Description

This PR updates bdk dependencies to the latest versions, updates `CHANGELOG.md` with merged PRs since `v3.0.0-rc.2` and bumps the version in `Cargo.toml` to 3.0.0.

Full Changelog: https://github.com/bitcoindevkit/bdk_wallet/compare/v3.0.0-rc.2...fb7681a

### Notes to the reviewers

Bumped `bdk_file_store` to 0.22.0 and `bdk_bitcoind_rpc` (dev dependency) to 0.22.0 which were erroneously left out of the previous release candidate.

close #402

### Checklists

#### All Submissions:

* [x] I ran `just p` before pushing