### PR TITLE
test(locked_outpoints): add unit tests for ChangeSet merge and is_empty

### DIFF
--- a/src/wallet/changeset.rs
+++ b/src/wallet/changeset.rs
@@ -417,3 +417,116 @@ impl From<locked_outpoints::ChangeSet> for ChangeSet {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use alloc::string::ToString;
+    use bdk_chain::Merge;
+    use bitcoin::Network;
+
+    /// Helper to get public descriptors via a temporary wallet.
+    fn test_descriptors() -> (
+        Descriptor<DescriptorPublicKey>,
+        Descriptor<DescriptorPublicKey>,
+    ) {
+        let (desc, change_desc) = crate::test_utils::get_test_wpkh_and_change_desc();
+        let wallet = crate::Wallet::create(desc.to_string(), change_desc.to_string())
+            .network(Network::Regtest)
+            .create_wallet_no_persist()
+            .unwrap();
+        (
+            wallet
+                .public_descriptor(crate::KeychainKind::External)
+                .clone(),
+            wallet
+                .public_descriptor(crate::KeychainKind::Internal)
+                .clone(),
+        )
+    }
+
+    #[test]
+    fn test_default_is_empty() {
+        let cs = ChangeSet::default();
+        assert!(cs.is_empty());
+    }
+
+    #[test]
+    fn test_is_empty_with_descriptor() {
+        let (desc, _) = test_descriptors();
+        let cs = ChangeSet {
+            descriptor: Some(desc),
+            ..Default::default()
+        };
+        assert!(!cs.is_empty());
+    }
+
+    #[test]
+    fn test_is_empty_with_network() {
+        let cs = ChangeSet {
+            network: Some(Network::Regtest),
+            ..Default::default()
+        };
+        assert!(!cs.is_empty());
+    }
+
+    #[test]
+    fn test_merge_sets_descriptor() {
+        let (desc, _) = test_descriptors();
+        let mut cs = ChangeSet::default();
+        let other = ChangeSet {
+            descriptor: Some(desc.clone()),
+            ..Default::default()
+        };
+        cs.merge(other);
+        assert_eq!(cs.descriptor, Some(desc));
+    }
+
+    #[test]
+    fn test_merge_sets_network() {
+        let mut cs = ChangeSet::default();
+        let other = ChangeSet {
+            network: Some(Network::Regtest),
+            ..Default::default()
+        };
+        cs.merge(other);
+        assert_eq!(cs.network, Some(Network::Regtest));
+    }
+
+    #[test]
+    fn test_merge_same_descriptor_is_ok() {
+        let (desc, _) = test_descriptors();
+        let mut cs = ChangeSet {
+            descriptor: Some(desc.clone()),
+            ..Default::default()
+        };
+        let other = ChangeSet {
+            descriptor: Some(desc.clone()),
+            ..Default::default()
+        };
+        cs.merge(other);
+        assert_eq!(cs.descriptor, Some(desc));
+    }
+
+    #[test]
+    fn test_merge_empty_into_non_empty() {
+        let (desc, change_desc) = test_descriptors();
+        let mut cs = ChangeSet {
+            descriptor: Some(desc),
+            change_descriptor: Some(change_desc),
+            network: Some(Network::Regtest),
+            ..Default::default()
+        };
+        let snapshot = cs.clone();
+        cs.merge(ChangeSet::default());
+        assert_eq!(cs, snapshot);
+    }
+
+    #[test]
+    fn test_from_local_chain() {
+        let chain_cs = local_chain::ChangeSet::default();
+        let cs = ChangeSet::from(chain_cs);
+        assert!(cs.descriptor.is_none());
+        assert!(cs.network.is_none());
+    }
+}

--- a/src/wallet/locked_outpoints.rs
+++ b/src/wallet/locked_outpoints.rs
@@ -24,3 +24,81 @@ impl Merge for ChangeSet {
         self.outpoints.is_empty()
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use bdk_chain::Merge;
+    use bitcoin::{hashes::Hash, OutPoint, Txid};
+
+    /// Helper to create an `OutPoint` from an index byte.
+    fn outpoint(vout: u32) -> OutPoint {
+        OutPoint {
+            txid: Txid::from_byte_array([vout as u8; 32]),
+            vout,
+        }
+    }
+
+    #[test]
+    fn test_is_empty_default() {
+        let cs = ChangeSet::default();
+        assert!(cs.is_empty());
+    }
+
+    #[test]
+    fn test_is_empty_with_entries() {
+        let cs = ChangeSet {
+            outpoints: [(outpoint(0), true)].into(),
+        };
+        assert!(!cs.is_empty());
+    }
+
+    #[test]
+    fn test_merge_into_empty() {
+        let mut cs = ChangeSet::default();
+        let other = ChangeSet {
+            outpoints: [(outpoint(1), true)].into(),
+        };
+        cs.merge(other);
+        assert_eq!(cs.outpoints.len(), 1);
+        assert!(cs.outpoints[&outpoint(1)]);
+    }
+
+    #[test]
+    fn test_merge_empty_into_non_empty() {
+        let mut cs = ChangeSet {
+            outpoints: [(outpoint(0), true)].into(),
+        };
+        let snapshot = cs.clone();
+        cs.merge(ChangeSet::default());
+        assert_eq!(cs, snapshot);
+    }
+
+    #[test]
+    fn test_merge_disjoint() {
+        let mut cs = ChangeSet {
+            outpoints: [(outpoint(0), true)].into(),
+        };
+        let other = ChangeSet {
+            outpoints: [(outpoint(1), false)].into(),
+        };
+        cs.merge(other);
+        assert_eq!(cs.outpoints.len(), 2);
+        assert!(cs.outpoints[&outpoint(0)]);
+        assert!(!cs.outpoints[&outpoint(1)]);
+    }
+
+    #[test]
+    fn test_merge_overwrites_duplicate() {
+        let op = outpoint(0);
+        let mut cs = ChangeSet {
+            outpoints: [(op, true)].into(),
+        };
+        let other = ChangeSet {
+            outpoints: [(op, false)].into(),
+        };
+        cs.merge(other);
+        assert_eq!(cs.outpoints.len(), 1);
+        assert!(!cs.outpoints[&op], "other's value should overwrite self");
+    }
+}


### PR DESCRIPTION
### Description

This PR adds unit test coverage for `locked_outpoints::ChangeSet`, which previously had zero inline tests. It tests the `Merge` trait implementations, ensuring that [merge](https://github.com/bitcoindevkit/bdk_wallet/blob/5df32ca707e859506e8198f1f102aed87a837bf0/src/wallet/locked_outpoints.rs#L17) and [is_empty](https://github.com/bitcoindevkit/bdk_wallet/blob/5df32ca707e859506e8198f1f102aed87a837bf0/src/wallet/locked_outpoints.rs#L23) behave correctly under various conditions.

### Notes to the reviewers

- Added 6 deterministic tests verifying:
  - Default initialization is empty
  - Merging with empty datasets are clean no-ops
  - Disjoint changeset merges successfully combine outpoints
  - Overwriting logic accurately fulfills the `extend()` semantics where the incoming `other` duplicate outpoints overwrite `self`
- Uses idiomatic boolean assertions (`assert!(...)`) verified cleanly by `cargo clippy`.
- Tests use `Txid::from_byte_array` internally to maintain deterministic speed without relying on `rand`.

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `just p` before pushing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
