### PR TITLE
chore: bump dev version to 3.1.0-alpha.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bdk_wallet"
 homepage = "https://bitcoindevkit.org"
-version = "3.0.0"
+version = "3.1.0-alpha.0"
 repository = "https://github.com/bitcoindevkit/bdk_wallet"
 documentation = "https://docs.rs/bdk_wallet"
 description = "A modern, lightweight, descriptor-based wallet library"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.94.0"
+channel = "1.95.0"
 components = ["clippy", "rustfmt"]

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -82,12 +82,6 @@ fn test_get_funded_wallet_balance() {
 fn test_get_funded_wallet_sent_and_received() {
     let (wallet, txid) = get_funded_wallet_wpkh();
 
-    let mut tx_amounts: Vec<(Txid, (Amount, Amount))> = wallet
-        .transactions()
-        .map(|ct| (ct.tx_node.txid, wallet.sent_and_received(&ct.tx_node)))
-        .collect();
-    tx_amounts.sort_by(|a1, a2| a1.0.cmp(&a2.0));
-
     let tx = wallet.get_tx(txid).expect("transaction").tx_node.tx;
     let (sent, received) = wallet.sent_and_received(&tx);
 


### PR DESCRIPTION
### Description

This PR bumps the package version in `Cargo.toml` from `3.0.0` to `3.1.0-alpha.0` following the coding conventions outlined in #19. Also bump toolchain channel to 1.95.0 in `rust-toolchain.toml`.

### Checklists

#### All Submissions:

* [x] I ran `just p` before pushing