### PR TITLE
fix(wallet): exclude unconfirmed v3 outputs from non-v3 coin selection

### DIFF
--- a/src/wallet/coin_selection.rs
+++ b/src/wallet/coin_selection.rs
@@ -471,10 +471,10 @@ impl<Cs: CoinSelectionAlgorithm> CoinSelectionAlgorithm for BranchAndBoundCoinSe
             .iter()
             .fold(SignedAmount::ZERO, |acc, x| acc + x.effective_value);
 
-        let cost_of_change = (Weight::from_vb(self.size_of_change).expect("overflow occurred")
-            * fee_rate)
-            .to_signed()
-            .expect("signed amount");
+        let cost_of_change = (fee_rate
+            * Weight::from_vb(self.size_of_change).expect("overflow occurred"))
+        .to_signed()
+        .expect("signed amount");
 
         // `curr_value` and `curr_available_value` are both the sum of *effective_values* of
         // the UTXOs. For the optional UTXOs (curr_available_value) we filter out UTXOs with
@@ -940,7 +940,7 @@ mod test {
             .coin_select(
                 utxos,
                 vec![],
-                FeeRate::from_sat_per_vb_u32(1),
+                FeeRate::from_sat_per_vb(1).unwrap(),
                 target_amount,
                 &drain_script,
                 &mut thread_rng(),
@@ -962,7 +962,7 @@ mod test {
             .coin_select(
                 utxos,
                 vec![],
-                FeeRate::from_sat_per_vb_u32(1),
+                FeeRate::from_sat_per_vb(1).unwrap(),
                 target_amount,
                 &drain_script,
                 &mut thread_rng(),
@@ -984,7 +984,7 @@ mod test {
             .coin_select(
                 vec![],
                 utxos,
-                FeeRate::from_sat_per_vb_u32(1),
+                FeeRate::from_sat_per_vb(1).unwrap(),
                 target_amount,
                 &drain_script,
                 &mut thread_rng(),
@@ -1005,7 +1005,7 @@ mod test {
         let result = LargestFirstCoinSelection.coin_select(
             vec![],
             utxos,
-            FeeRate::from_sat_per_vb_u32(1),
+            FeeRate::from_sat_per_vb(1).unwrap(),
             target_amount,
             &drain_script,
             &mut thread_rng(),
@@ -1022,7 +1022,7 @@ mod test {
         let result = LargestFirstCoinSelection.coin_select(
             vec![],
             utxos,
-            FeeRate::from_sat_per_vb_u32(1000),
+            FeeRate::from_sat_per_vb(1000).unwrap(),
             target_amount,
             &drain_script,
             &mut thread_rng(),
@@ -1040,7 +1040,7 @@ mod test {
             .coin_select(
                 vec![],
                 utxos,
-                FeeRate::from_sat_per_vb_u32(1),
+                FeeRate::from_sat_per_vb(1).unwrap(),
                 target_amount,
                 &drain_script,
                 &mut thread_rng(),
@@ -1062,7 +1062,7 @@ mod test {
             .coin_select(
                 utxos,
                 vec![],
-                FeeRate::from_sat_per_vb_u32(1),
+                FeeRate::from_sat_per_vb(1).unwrap(),
                 target_amount,
                 &drain_script,
                 &mut thread_rng(),
@@ -1086,7 +1086,7 @@ mod test {
             .coin_select(
                 vec![],
                 all_utxos,
-                FeeRate::from_sat_per_vb_u32(1),
+                FeeRate::from_sat_per_vb(1).unwrap(),
                 target_amount,
                 &drain_script,
                 &mut thread_rng(),
@@ -1111,7 +1111,7 @@ mod test {
             .coin_select(
                 vec![],
                 all_utxos,
-                FeeRate::from_sat_per_vb_u32(1),
+                FeeRate::from_sat_per_vb(1).unwrap(),
                 target_amount,
                 &drain_script,
                 &mut thread_rng(),
@@ -1137,7 +1137,7 @@ mod test {
             .coin_select(
                 vec![],
                 utxos,
-                FeeRate::from_sat_per_vb_u32(1),
+                FeeRate::from_sat_per_vb(1).unwrap(),
                 target_amount,
                 &drain_script,
                 &mut thread_rng(),
@@ -1158,7 +1158,7 @@ mod test {
         let result = OldestFirstCoinSelection.coin_select(
             vec![],
             utxos,
-            FeeRate::from_sat_per_vb_u32(1),
+            FeeRate::from_sat_per_vb(1).unwrap(),
             target_amount,
             &drain_script,
             &mut thread_rng(),
@@ -1177,7 +1177,7 @@ mod test {
         let result = OldestFirstCoinSelection.coin_select(
             vec![],
             utxos,
-            FeeRate::from_sat_per_vb_u32(1000),
+            FeeRate::from_sat_per_vb(1000).unwrap(),
             target_amount,
             &drain_script,
             &mut thread_rng(),
@@ -1197,7 +1197,7 @@ mod test {
             .coin_select(
                 vec![],
                 utxos,
-                FeeRate::from_sat_per_vb_u32(1),
+                FeeRate::from_sat_per_vb(1).unwrap(),
                 target_amount,
                 &drain_script,
                 &mut thread_rng(),
@@ -1219,7 +1219,7 @@ mod test {
             .coin_select(
                 utxos.clone(),
                 utxos,
-                FeeRate::from_sat_per_vb_u32(1),
+                FeeRate::from_sat_per_vb(1).unwrap(),
                 target_amount,
                 &drain_script,
                 &mut thread_rng(),
@@ -1261,7 +1261,7 @@ mod test {
         let mut rng: StdRng = SeedableRng::from_seed(seed);
         let mut utxos = generate_random_utxos(&mut rng, 300);
         let target_amount = sum_random_utxos(&mut rng, &mut utxos) + FEE_AMOUNT;
-        let fee_rate = FeeRate::from_sat_per_vb_u32(1);
+        let fee_rate = FeeRate::from_sat_per_vb(1).unwrap();
         let drain_script = ScriptBuf::default();
 
         let result = SingleRandomDraw.coin_select(
@@ -1289,7 +1289,7 @@ mod test {
         // 100_000, 10, 200_000
         let utxos = get_test_utxos();
         let target_amount = Amount::from_sat(300_000) + FEE_AMOUNT;
-        let fee_rate = FeeRate::from_sat_per_vb_u32(1);
+        let fee_rate = FeeRate::from_sat_per_vb(1).unwrap();
         let drain_script = ScriptBuf::default();
 
         let result = SingleRandomDraw.coin_select(
@@ -1362,7 +1362,7 @@ mod test {
         let result = BranchAndBoundCoinSelection::<SingleRandomDraw>::default().coin_select(
             vec![],
             utxos,
-            FeeRate::from_sat_per_vb_u32(1),
+            FeeRate::from_sat_per_vb(1).unwrap(),
             target_amount,
             &drain_script,
             &mut thread_rng(),
@@ -1380,7 +1380,7 @@ mod test {
         let result = BranchAndBoundCoinSelection::<SingleRandomDraw>::default().coin_select(
             vec![],
             utxos,
-            FeeRate::from_sat_per_vb_u32(1000),
+            FeeRate::from_sat_per_vb(1000).unwrap(),
             target_amount,
             &drain_script,
             &mut thread_rng(),
@@ -1441,7 +1441,7 @@ mod test {
 
     #[test]
     fn test_bnb_function_no_exact_match() {
-        let fee_rate = FeeRate::from_sat_per_vb_u32(10);
+        let fee_rate = FeeRate::from_sat_per_vb(10).unwrap();
         let utxos: Vec<OutputGroup> = get_test_utxos()
             .into_iter()
             .map(|u| OutputGroup::new(u, fee_rate))
@@ -1452,7 +1452,7 @@ mod test {
             .fold(SignedAmount::ZERO, |acc, x| acc + x.effective_value);
 
         let size_of_change = 31;
-        let cost_of_change = (Weight::from_vb_unchecked(size_of_change) * fee_rate)
+        let cost_of_change = (fee_rate * Weight::from_vb_unchecked(size_of_change))
             .to_signed()
             .unwrap();
 
@@ -1473,7 +1473,7 @@ mod test {
 
     #[test]
     fn test_bnb_function_tries_exceeded() {
-        let fee_rate = FeeRate::from_sat_per_vb_u32(10);
+        let fee_rate = FeeRate::from_sat_per_vb(10).unwrap();
         let utxos: Vec<OutputGroup> = generate_same_value_utxos(Amount::from_sat(100_000), 100_000)
             .into_iter()
             .map(|u| OutputGroup::new(u, fee_rate))
@@ -1484,7 +1484,7 @@ mod test {
             .fold(SignedAmount::ZERO, |acc, x| acc + x.effective_value);
 
         let size_of_change = 31;
-        let cost_of_change = (Weight::from_vb_unchecked(size_of_change) * fee_rate)
+        let cost_of_change = (fee_rate * Weight::from_vb_unchecked(size_of_change))
             .to_signed()
             .unwrap();
         let target_amount = SignedAmount::from_sat(20_000) + FEE_AMOUNT.to_signed().unwrap();
@@ -1507,9 +1507,9 @@ mod test {
     // The match won't be exact but still in the range
     #[test]
     fn test_bnb_function_almost_exact_match_with_fees() {
-        let fee_rate = FeeRate::from_sat_per_vb_u32(1);
+        let fee_rate = FeeRate::from_sat_per_vb(1).unwrap();
         let size_of_change = 31;
-        let cost_of_change = (Weight::from_vb_unchecked(size_of_change) * fee_rate)
+        let cost_of_change = (fee_rate * Weight::from_vb_unchecked(size_of_change))
             .to_signed()
             .unwrap();
 
@@ -1598,7 +1598,7 @@ mod test {
         let selection = BranchAndBoundCoinSelection::<SingleRandomDraw>::default().coin_select(
             vec![],
             utxos,
-            FeeRate::from_sat_per_vb_u32(10),
+            FeeRate::from_sat_per_vb(10).unwrap(),
             Amount::from_sat(500_000),
             &drain_script,
             &mut thread_rng(),
@@ -1625,7 +1625,7 @@ mod test {
         let selection = BranchAndBoundCoinSelection::<SingleRandomDraw>::default().coin_select(
             required,
             optional,
-            FeeRate::from_sat_per_vb_u32(10),
+            FeeRate::from_sat_per_vb(10).unwrap(),
             Amount::from_sat(500_000),
             &drain_script,
             &mut thread_rng(),
@@ -1648,7 +1648,7 @@ mod test {
         let selection = BranchAndBoundCoinSelection::<SingleRandomDraw>::default().coin_select(
             utxos,
             vec![],
-            FeeRate::from_sat_per_vb_u32(10_000),
+            FeeRate::from_sat_per_vb(10_000).unwrap(),
             Amount::from_sat(500_000),
             &drain_script,
             &mut thread_rng(),
@@ -1722,7 +1722,7 @@ mod test {
         ];
 
         let optional = generate_same_value_utxos(Amount::from_sat(100_000), 30);
-        let fee_rate = FeeRate::from_sat_per_vb_u32(1);
+        let fee_rate = FeeRate::from_sat_per_vb(1).unwrap();
         let target_amount = calc_target_amount(&optional[0..3], fee_rate);
         assert_eq!(target_amount, Amount::from_sat(299_796));
         let drain_script = ScriptBuf::default();

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -1983,13 +1983,14 @@ impl Wallet {
             vec![]
         // Only process optional UTxOs if manually_selected_only is false.
         } else {
+            let tx_graph = self.tx_graph.graph();
+            let target_is_truc = params.version.unwrap_or(transaction::Version::TWO).0 == 3;
             let manually_selected_outpoints = params
                 .utxos
                 .iter()
                 .map(|wutxo| wutxo.utxo.outpoint())
                 .collect::<HashSet<OutPoint>>();
-            self.tx_graph
-                .graph()
+            tx_graph
                 // Get all unspent UTxOs from wallet.
                 // NOTE: the UTxOs returned by the following method already belong to wallet as the
                 // call chain uses get_tx_node infallibly.
@@ -2022,6 +2023,14 @@ impl Wallet {
                 // If bumping fees only add to optional UTxOs those confirmed.
                 .filter(|local_output| {
                     params.bumping_fee.is_none() || local_output.chain_position.is_confirmed()
+                })
+                // Bitcoin Core's TRUC policy requires a transaction and each unconfirmed parent it
+                // spends from to both be either TRUC (version 3) or both non-TRUC.
+                .filter(|local_output| {
+                    local_output.chain_position.is_confirmed()
+                        || tx_graph
+                            .get_tx(local_output.outpoint.txid)
+                            .is_some_and(|tx| (tx.version.0 == 3) == target_is_truc)
                 })
                 .map(|utxo| WeightedUtxo {
                     satisfaction_weight: self

--- a/src/wallet/tx_builder.rs
+++ b/src/wallet/tx_builder.rs
@@ -322,6 +322,10 @@ impl<'a, Cs> TxBuilder<'a, Cs> {
     ///
     /// These have priority over the "unspendable" UTXOs, meaning that if a UTXO is present both in
     /// the "UTXOs" and the "unspendable" list, it will be spent.
+    ///
+    /// Manually selected UTXOs bypass optional-UTXO filtering (for example TRUC version
+    /// compatibility checks). Callers must ensure any manually selected unconfirmed UTXO is valid
+    /// for the transaction version being built.
     pub fn add_utxo(&mut self, outpoint: OutPoint) -> Result<&mut Self, AddUtxoError> {
         self.add_utxos(&[outpoint])
     }
@@ -338,6 +342,10 @@ impl<'a, Cs> TxBuilder<'a, Cs> {
     /// UTXOs through the [`TxBuilder::add_utxo`] method.
     /// A manually added local UTXO will always have greater precedence than a foreign UTXO. No
     /// matter if it was added before or after the foreign UTXO.
+    ///
+    /// Manually selected UTXOs bypass optional-UTXO filtering (for example TRUC version
+    /// compatibility checks). Callers must ensure any manually selected unconfirmed UTXO is valid
+    /// for the transaction version being built.
     ///
     /// At a minimum to add a foreign UTXO we need:
     ///

--- a/tests/build_fee_bump.rs
+++ b/tests/build_fee_bump.rs
@@ -329,7 +329,7 @@ fn test_bump_fee_drain_wallet() {
     let mut builder = wallet.build_fee_bump(txid).unwrap();
     builder
         .drain_wallet()
-        .fee_rate(FeeRate::from_sat_per_vb_u32(5));
+        .fee_rate(FeeRate::from_sat_per_vb(5).unwrap());
     let psbt = builder.finish().unwrap();
     let (sent, _received) =
         wallet.sent_and_received(&psbt.extract_tx().expect("failed to extract tx"));
@@ -391,7 +391,7 @@ fn test_bump_fee_remove_output_manually_selected_only() {
     let mut builder = wallet.build_fee_bump(txid).unwrap();
     builder
         .manually_selected_only()
-        .fee_rate(FeeRate::from_sat_per_vb_u32(255));
+        .fee_rate(FeeRate::from_sat_per_vb(255).unwrap());
     builder.finish().unwrap();
 }
 
@@ -430,7 +430,7 @@ fn test_bump_fee_add_input() {
     insert_tx(&mut wallet, tx);
 
     let mut builder = wallet.build_fee_bump(txid).unwrap();
-    builder.fee_rate(FeeRate::from_sat_per_vb_u32(50));
+    builder.fee_rate(FeeRate::from_sat_per_vb(50).unwrap());
     let psbt = builder.finish().unwrap();
     let (sent, received) =
         wallet.sent_and_received(&psbt.clone().extract_tx().expect("failed to extract tx"));
@@ -458,7 +458,7 @@ fn test_bump_fee_add_input() {
         received
     );
 
-    assert_fee_rate!(psbt, fee, FeeRate::from_sat_per_vb_u32(50), @add_signature);
+    assert_fee_rate!(psbt, fee, FeeRate::from_sat_per_vb(50).unwrap(), @add_signature);
 }
 
 #[test]
@@ -536,7 +536,7 @@ fn test_bump_fee_no_change_add_input_and_change() {
     // Now bump the fees, the wallet should add an extra input and a change output, and leave
     // the original output untouched.
     let mut builder = wallet.build_fee_bump(txid).unwrap();
-    builder.fee_rate(FeeRate::from_sat_per_vb_u32(50));
+    builder.fee_rate(FeeRate::from_sat_per_vb(50).unwrap());
     let psbt = builder.finish().unwrap();
     let (sent, received) =
         wallet.sent_and_received(&psbt.clone().extract_tx().expect("failed to extract tx"));
@@ -569,7 +569,7 @@ fn test_bump_fee_no_change_add_input_and_change() {
         Amount::from_sat(75_000) - original_send_all_amount - fee
     );
 
-    assert_fee_rate!(psbt, fee, FeeRate::from_sat_per_vb_u32(50), @add_signature);
+    assert_fee_rate!(psbt, fee, FeeRate::from_sat_per_vb(50).unwrap(), @add_signature);
 }
 
 #[test]
@@ -597,7 +597,7 @@ fn test_bump_fee_force_add_input() {
     builder
         .add_utxo(incoming_op)
         .unwrap()
-        .fee_rate(FeeRate::from_sat_per_vb_u32(5));
+        .fee_rate(FeeRate::from_sat_per_vb(5).unwrap());
     let psbt = builder.finish().unwrap();
     let (sent, received) =
         wallet.sent_and_received(&psbt.clone().extract_tx().expect("failed to extract tx"));
@@ -626,7 +626,7 @@ fn test_bump_fee_force_add_input() {
         received
     );
 
-    assert_fee_rate!(psbt, fee, FeeRate::from_sat_per_vb_u32(5), @add_signature);
+    assert_fee_rate!(psbt, fee, FeeRate::from_sat_per_vb(5).unwrap(), @add_signature);
 }
 
 #[test]
@@ -715,7 +715,7 @@ fn test_bump_fee_unconfirmed_inputs_only() {
     }
     insert_tx(&mut wallet, tx);
     let mut builder = wallet.build_fee_bump(txid).unwrap();
-    builder.fee_rate(FeeRate::from_sat_per_vb_u32(25));
+    builder.fee_rate(FeeRate::from_sat_per_vb(25).unwrap());
     builder.finish().unwrap();
 }
 
@@ -746,7 +746,7 @@ fn test_bump_fee_unconfirmed_input() {
 
     let mut builder = wallet.build_fee_bump(txid).unwrap();
     builder
-        .fee_rate(FeeRate::from_sat_per_vb_u32(15))
+        .fee_rate(FeeRate::from_sat_per_vb(15).unwrap())
         // remove original tx drain_to address and amount
         .set_recipients(Vec::new())
         // set back original drain_to address
@@ -823,7 +823,7 @@ fn test_legacy_bump_fee_drain_wallet() {
     let mut builder = wallet.build_fee_bump(txid).unwrap();
     builder
         .drain_wallet()
-        .fee_rate(FeeRate::from_sat_per_vb_u32(5));
+        .fee_rate(FeeRate::from_sat_per_vb(5).unwrap());
     let psbt = builder.finish().unwrap();
     let (sent, _received) =
         wallet.sent_and_received(&psbt.extract_tx().expect("failed to extract tx"));
@@ -866,7 +866,7 @@ fn test_legacy_bump_fee_add_input() {
     insert_tx(&mut wallet, tx);
 
     let mut builder = wallet.build_fee_bump(txid).unwrap();
-    builder.fee_rate(FeeRate::from_sat_per_vb_u32(50));
+    builder.fee_rate(FeeRate::from_sat_per_vb(50).unwrap());
     let psbt = builder.finish().unwrap();
     let (sent, received) =
         wallet.sent_and_received(&psbt.clone().extract_tx().expect("failed to extract tx"));
@@ -894,7 +894,7 @@ fn test_legacy_bump_fee_add_input() {
         received
     );
 
-    assert_fee_rate_legacy!(psbt, fee, FeeRate::from_sat_per_vb_u32(50), @add_signature);
+    assert_fee_rate_legacy!(psbt, fee, FeeRate::from_sat_per_vb(50).unwrap(), @add_signature);
 }
 
 #[test]
@@ -971,7 +971,7 @@ fn test_bump_fee_pay_to_anchor_foreign_utxo() {
         .add_foreign_utxo(outpoint, psbt_input, satisfaction_weight)
         .unwrap()
         .only_witness_utxo()
-        .fee_rate(FeeRate::from_sat_per_vb_u32(2))
+        .fee_rate(FeeRate::from_sat_per_vb(2).unwrap())
         .drain_to(drain_spk.clone());
     let psbt = tx_builder.finish().unwrap();
     let tx = psbt.unsigned_tx.clone();
@@ -987,7 +987,7 @@ fn test_bump_fee_pay_to_anchor_foreign_utxo() {
         .set_recipients(vec![])
         .drain_to(drain_spk)
         .only_witness_utxo()
-        .fee_rate(FeeRate::from_sat_per_vb_u32(5));
+        .fee_rate(FeeRate::from_sat_per_vb(5).unwrap());
     let psbt = tx_builder.finish().unwrap();
     let tx = &psbt.unsigned_tx;
     assert!(tx.input.iter().any(|txin| txin.previous_output == outpoint));

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -230,6 +230,239 @@ fn test_create_tx_custom_version() {
 }
 
 #[test]
+fn test_create_tx_non_v3_excludes_unconfirmed_v3_utxos() {
+    let (descriptor, change_descriptor) = get_test_wpkh_and_change_desc();
+    let mut wallet = Wallet::create(descriptor, change_descriptor)
+        .network(Network::Regtest)
+        .create_wallet_no_persist()
+        .expect("wallet");
+
+    insert_checkpoint(
+        &mut wallet,
+        BlockId {
+            height: 1,
+            hash: BlockHash::all_zeros(),
+        },
+    );
+
+    let confirmed_tx = Transaction {
+        version: transaction::Version::ONE,
+        lock_time: absolute::LockTime::ZERO,
+        input: vec![],
+        output: vec![TxOut {
+            script_pubkey: wallet
+                .next_unused_address(KeychainKind::External)
+                .script_pubkey(),
+            value: Amount::from_sat(10_000),
+        }],
+    };
+    let confirmed_txid = confirmed_tx.compute_txid();
+    insert_tx(&mut wallet, confirmed_tx);
+    let block_id = wallet.latest_checkpoint().block_id();
+    insert_anchor(
+        &mut wallet,
+        confirmed_txid,
+        ConfirmationBlockTime {
+            block_id,
+            confirmation_time: 1,
+        },
+    );
+
+    let truc_tx = Transaction {
+        version: transaction::Version(3),
+        lock_time: absolute::LockTime::ZERO,
+        input: vec![],
+        output: vec![TxOut {
+            script_pubkey: wallet
+                .next_unused_address(KeychainKind::External)
+                .script_pubkey(),
+            value: Amount::from_sat(30_000),
+        }],
+    };
+    let truc_txid = truc_tx.compute_txid();
+    insert_tx(&mut wallet, truc_tx);
+
+    let recipient = wallet.next_unused_address(KeychainKind::External);
+
+    let mut builder = wallet.build_tx();
+    builder
+        .fee_rate(FeeRate::ZERO)
+        .add_recipient(recipient.script_pubkey(), Amount::from_sat(20_000));
+    assert_matches!(
+        builder.finish(),
+        Err(CreateTxError::CoinSelection(
+            coin_selection::InsufficientFunds { .. }
+        ))
+    );
+
+    let mut builder = wallet.build_tx();
+    builder
+        .fee_rate(FeeRate::ZERO)
+        .version(3)
+        .add_recipient(recipient.script_pubkey(), Amount::from_sat(20_000));
+    let psbt = builder
+        .finish()
+        .expect("v3 transaction should be buildable");
+
+    assert_eq!(psbt.unsigned_tx.version, transaction::Version(3));
+    assert!(
+        psbt.unsigned_tx
+            .input
+            .iter()
+            .any(|input| input.previous_output.txid == truc_txid),
+        "version=3 transaction should be able to spend the unconfirmed v3 output"
+    );
+}
+
+#[test]
+fn test_create_tx_non_v3_allows_unconfirmed_non_v3_utxos() {
+    let (descriptor, change_descriptor) = get_test_wpkh_and_change_desc();
+    let mut wallet = Wallet::create(descriptor, change_descriptor)
+        .network(Network::Regtest)
+        .create_wallet_no_persist()
+        .expect("wallet");
+
+    let unconfirmed_tx = Transaction {
+        version: transaction::Version::ONE,
+        lock_time: absolute::LockTime::ZERO,
+        input: vec![],
+        output: vec![TxOut {
+            script_pubkey: wallet
+                .next_unused_address(KeychainKind::External)
+                .script_pubkey(),
+            value: Amount::from_sat(30_000),
+        }],
+    };
+    let unconfirmed_txid = unconfirmed_tx.compute_txid();
+    insert_tx(&mut wallet, unconfirmed_tx);
+
+    let recipient = wallet.next_unused_address(KeychainKind::External);
+    let mut builder = wallet.build_tx();
+    builder
+        .fee_rate(FeeRate::ZERO)
+        .add_recipient(recipient.script_pubkey(), Amount::from_sat(20_000));
+    let psbt = builder
+        .finish()
+        .expect("non-v3 unconfirmed outputs should remain spendable");
+
+    assert!(
+        psbt.unsigned_tx
+            .input
+            .iter()
+            .any(|input| input.previous_output.txid == unconfirmed_txid),
+        "expected the unconfirmed non-v3 output to be available for selection"
+    );
+}
+
+#[test]
+fn test_create_tx_v3_excludes_unconfirmed_non_v3_utxos() {
+    let (descriptor, change_descriptor) = get_test_wpkh_and_change_desc();
+    let mut wallet = Wallet::create(descriptor, change_descriptor)
+        .network(Network::Regtest)
+        .create_wallet_no_persist()
+        .expect("wallet");
+
+    insert_checkpoint(
+        &mut wallet,
+        BlockId {
+            height: 1,
+            hash: BlockHash::all_zeros(),
+        },
+    );
+
+    let confirmed_tx = Transaction {
+        version: transaction::Version::ONE,
+        lock_time: absolute::LockTime::ZERO,
+        input: vec![],
+        output: vec![TxOut {
+            script_pubkey: wallet
+                .next_unused_address(KeychainKind::External)
+                .script_pubkey(),
+            value: Amount::from_sat(10_000),
+        }],
+    };
+    let confirmed_txid = confirmed_tx.compute_txid();
+    insert_tx(&mut wallet, confirmed_tx);
+    let block_id = wallet.latest_checkpoint().block_id();
+    insert_anchor(
+        &mut wallet,
+        confirmed_txid,
+        ConfirmationBlockTime {
+            block_id,
+            confirmation_time: 1,
+        },
+    );
+
+    let unconfirmed_non_v3_tx = Transaction {
+        version: transaction::Version::ONE,
+        lock_time: absolute::LockTime::ZERO,
+        input: vec![],
+        output: vec![TxOut {
+            script_pubkey: wallet
+                .next_unused_address(KeychainKind::External)
+                .script_pubkey(),
+            value: Amount::from_sat(30_000),
+        }],
+    };
+    let unconfirmed_non_v3_txid = unconfirmed_non_v3_tx.compute_txid();
+    insert_tx(&mut wallet, unconfirmed_non_v3_tx);
+
+    let recipient_script = wallet
+        .next_unused_address(KeychainKind::External)
+        .script_pubkey();
+
+    let mut builder = wallet.build_tx();
+    builder
+        .fee_rate(FeeRate::ZERO)
+        .version(3)
+        .add_recipient(recipient_script.clone(), Amount::from_sat(20_000));
+    assert_matches!(
+        builder.finish(),
+        Err(CreateTxError::CoinSelection(
+            coin_selection::InsufficientFunds { .. }
+        ))
+    );
+
+    let unconfirmed_v3_tx = Transaction {
+        version: transaction::Version(3),
+        lock_time: absolute::LockTime::ZERO,
+        input: vec![],
+        output: vec![TxOut {
+            script_pubkey: wallet
+                .next_unused_address(KeychainKind::External)
+                .script_pubkey(),
+            value: Amount::from_sat(30_000),
+        }],
+    };
+    let unconfirmed_v3_txid = unconfirmed_v3_tx.compute_txid();
+    insert_tx(&mut wallet, unconfirmed_v3_tx);
+
+    let mut builder = wallet.build_tx();
+    builder
+        .fee_rate(FeeRate::ZERO)
+        .version(3)
+        .add_recipient(recipient_script, Amount::from_sat(20_000));
+    let psbt = builder
+        .finish()
+        .expect("v3 transaction should not select unconfirmed non-v3 inputs");
+
+    assert!(
+        psbt.unsigned_tx
+            .input
+            .iter()
+            .all(|input| input.previous_output.txid != unconfirmed_non_v3_txid),
+        "unconfirmed non-v3 outputs should be excluded from v3 transaction selection"
+    );
+    assert!(
+        psbt.unsigned_tx
+            .input
+            .iter()
+            .any(|input| input.previous_output.txid == unconfirmed_v3_txid),
+        "expected at least one unconfirmed v3 input to be selected"
+    );
+}
+
+#[test]
 fn test_create_tx_default_locktime_is_last_sync_height() {
     let (mut wallet, _) = get_funded_wallet_wpkh();
 
@@ -532,11 +765,11 @@ fn test_create_tx_custom_fee_rate() {
     let mut builder = wallet.build_tx();
     builder
         .add_recipient(addr.script_pubkey(), Amount::from_sat(25_000))
-        .fee_rate(FeeRate::from_sat_per_vb_u32(5));
+        .fee_rate(FeeRate::from_sat_per_vb(5).unwrap());
     let psbt = builder.finish().unwrap();
     let fee = check_fee!(wallet, psbt);
 
-    assert_fee_rate!(psbt, fee, FeeRate::from_sat_per_vb_u32(5), @add_signature);
+    assert_fee_rate!(psbt, fee, FeeRate::from_sat_per_vb(5).unwrap(), @add_signature);
 }
 
 #[test]
@@ -546,11 +779,11 @@ fn test_legacy_create_tx_custom_fee_rate() {
     let mut builder = wallet.build_tx();
     builder
         .add_recipient(addr.script_pubkey(), Amount::from_sat(25_000))
-        .fee_rate(FeeRate::from_sat_per_vb_u32(5));
+        .fee_rate(FeeRate::from_sat_per_vb(5).unwrap());
     let psbt = builder.finish().unwrap();
     let fee = check_fee!(wallet, psbt);
 
-    assert_fee_rate_legacy!(psbt, fee, FeeRate::from_sat_per_vb_u32(5), @add_signature);
+    assert_fee_rate_legacy!(psbt, fee, FeeRate::from_sat_per_vb(5).unwrap(), @add_signature);
 }
 
 #[test]
@@ -705,7 +938,7 @@ fn test_create_tx_drain_to_dust_amount() {
     builder
         .drain_to(addr.script_pubkey())
         .drain_wallet()
-        .fee_rate(FeeRate::from_sat_per_vb_u32(454));
+        .fee_rate(FeeRate::from_sat_per_vb(454).unwrap());
     builder.finish().unwrap();
 }
 
@@ -2612,7 +2845,7 @@ fn test_fee_rate_sign_no_grinding_high_r() {
     // alright.
     let (mut wallet, _) = get_funded_wallet_single("wpkh(tprv8ZgxMBicQKsPd3EupYiPRhaMooHKUHJxNsTfYuScep13go8QFfHdtkG9nRkFGb7busX4isf6X9dURGCoKgitaApQ6MupRhZMcELAxTBRJgS/*)");
     let addr = wallet.next_unused_address(KeychainKind::External);
-    let fee_rate = FeeRate::from_sat_per_vb_u32(1);
+    let fee_rate = FeeRate::from_sat_per_vb(1).unwrap();
     let mut builder = wallet.build_tx();
     let mut data = PushBytesBuf::try_from(vec![0]).unwrap();
     builder
@@ -2679,7 +2912,7 @@ fn test_fee_rate_sign_grinding_low_r() {
     // signature is 70 bytes.
     let (mut wallet, _) = get_funded_wallet_single("wpkh(tprv8ZgxMBicQKsPd3EupYiPRhaMooHKUHJxNsTfYuScep13go8QFfHdtkG9nRkFGb7busX4isf6X9dURGCoKgitaApQ6MupRhZMcELAxTBRJgS/*)");
     let addr = wallet.next_unused_address(KeychainKind::External);
-    let fee_rate = FeeRate::from_sat_per_vb_u32(1);
+    let fee_rate = FeeRate::from_sat_per_vb(1).unwrap();
     let mut builder = wallet.build_tx();
     builder
         .drain_to(addr.script_pubkey())


### PR DESCRIPTION
### Description
BIP-431 (TRUC) requires that any transaction spending an unconfirmed v3 output must itself be v3. BDK's coin selection had no awareness of this and would freely include unconfirmed v3 parent outputs when building standard non-v3 transactions, causing bitcoind to reject the broadcast.

This PR threads `tx_version` into `filter_utxos` to exclude such UTXOs when the target transaction is not v3. Confirmed outputs are unaffected.

Fixes #419.

### Notes to the reviewers
The fix is intentionally minimal only the cross-version spending restriction from BIP-431 is addressed here. The broader TRUC topological constraints (cluster size, child vbyte limit) are out of scope for this PR and can be tracked separately.

Manually selected UTXOs via `TxBuilder::add_utxo` bypass `filter_utxos` entirely and are not covered by this fix. Callers are responsible for not adding unconfirmed v3 outputs to non-v3 transactions manually.

### Changelog notice
- Fixed: `filter_utxos` now excludes unconfirmed UTXOs from v3 parent transactions when constructing non-v3 transactions, preventing TRUC policy violations at broadcast.

### Checklists
#### All Submissions:
* [x] I've signed all my commits
* [x] I followed the contribution guidelines
* [x] I ran `just p` before pushing

#### Bugfixes:
* [ ] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR