### PR TITLE
test(utils): add boundary tests for Older::check_older and After::check_after

### DIFF
--- a/src/wallet/utils.rs
+++ b/src/wallet/utils.rs
@@ -278,4 +278,116 @@ mod test {
         shuffle_slice(&mut test, &mut rng);
         assert_eq!(test, &[0, 4, 1, 2, 5]);
     }
+
+    // --- Older::check_older boundary tests (addresses TODO on line 111) ---
+
+    use super::{After, Older};
+    use bitcoin::{absolute, relative, PublicKey};
+    use miniscript::Satisfier;
+
+    #[test]
+    fn test_check_older_at_boundary() {
+        // current_height == create_height + n → should pass (>=)
+        let older = Older::new(Some(110), Some(100), false);
+        assert!(Satisfier::<PublicKey>::check_older(
+            &older,
+            relative::LockTime::from_height(10)
+        ));
+    }
+
+    #[test]
+    fn test_check_older_above_boundary() {
+        // current_height > create_height + n → should pass
+        let older = Older::new(Some(111), Some(100), false);
+        assert!(Satisfier::<PublicKey>::check_older(
+            &older,
+            relative::LockTime::from_height(10)
+        ));
+    }
+
+    #[test]
+    fn test_check_older_below_boundary() {
+        // current_height < create_height + n → should fail
+        let older = Older::new(Some(109), Some(100), false);
+        assert!(!Satisfier::<PublicKey>::check_older(
+            &older,
+            relative::LockTime::from_height(10)
+        ));
+    }
+
+    #[test]
+    fn test_check_older_none_height_assume_true() {
+        let older = Older::new(None, Some(100), true);
+        assert!(Satisfier::<PublicKey>::check_older(
+            &older,
+            relative::LockTime::from_height(10)
+        ));
+    }
+
+    #[test]
+    fn test_check_older_none_height_assume_false() {
+        let older = Older::new(None, Some(100), false);
+        assert!(!Satisfier::<PublicKey>::check_older(
+            &older,
+            relative::LockTime::from_height(10)
+        ));
+    }
+
+    #[test]
+    fn test_check_older_none_create_height() {
+        // create_height defaults to 0, so current_height >= 0 + 10
+        let older = Older::new(Some(10), None, false);
+        assert!(Satisfier::<PublicKey>::check_older(
+            &older,
+            relative::LockTime::from_height(10)
+        ));
+    }
+
+    // --- After::check_after boundary tests ---
+
+    #[test]
+    fn test_check_after_at_boundary() {
+        // current_height == locktime → should pass (>=)
+        let after = After::new(Some(100_000), false);
+        assert!(Satisfier::<PublicKey>::check_after(
+            &after,
+            absolute::LockTime::from_consensus(100_000)
+        ));
+    }
+
+    #[test]
+    fn test_check_after_above_boundary() {
+        let after = After::new(Some(100_001), false);
+        assert!(Satisfier::<PublicKey>::check_after(
+            &after,
+            absolute::LockTime::from_consensus(100_000)
+        ));
+    }
+
+    #[test]
+    fn test_check_after_below_boundary() {
+        let after = After::new(Some(99_999), false);
+        assert!(!Satisfier::<PublicKey>::check_after(
+            &after,
+            absolute::LockTime::from_consensus(100_000)
+        ));
+    }
+
+    #[test]
+    fn test_check_after_none_height_assume_true() {
+        let after = After::new(None, true);
+        assert!(Satisfier::<PublicKey>::check_after(
+            &after,
+            absolute::LockTime::from_consensus(100_000)
+        ));
+    }
+
+    #[test]
+    fn test_check_after_none_height_assume_false() {
+        let after = After::new(None, false);
+        assert!(!Satisfier::<PublicKey>::check_after(
+            &after,
+            absolute::LockTime::from_consensus(100_000)
+        ));
+    }
 }


### PR DESCRIPTION
### Description

Addresses the `// TODO: test >= / >` on line 111 of [utils.rs](cci:7://file:///home/krishna/Contribution/bdk_wallet/src/test_utils.rs:0:0-0:0). Adds 11 boundary-condition tests for the `Satisfier` impls of [Older](cci:2://file:///home/krishna/Contribution/bdk_wallet/src/wallet/utils.rs:87:0-91:1) and [After](cci:2://file:///home/krishna/Contribution/bdk_wallet/src/wallet/utils.rs:43:0-46:1).

### Notes to the reviewers

Uses `Satisfier::<PublicKey>::check_older(...)` fully-qualified syntax because the trait is generic over `Pk`.

### Changelog notice

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `just p` before pushing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
