### PR TITLE
fix(wallet): retry coin selection on NoChange to avoid dust/zero drai…

### DIFF
--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -1473,31 +1473,40 @@ impl Wallet {
         let should_retry_for_dust_drain = params.recipients.is_empty()
             && params.drain_to.is_some()
             && (params.drain_wallet || !params.utxos.is_empty())
+            && !optional_utxos.is_empty()
             && !params.manually_selected_only;
 
         let selection_result = if should_retry_for_dust_drain {
             let mut required_for_attempt = required_utxos;
             let mut optional_remaining = optional_utxos;
+            let mut last_successful_result = None;
             loop {
-                let result = coin_selection
-                    .coin_select(
-                        required_for_attempt.clone(),
-                        optional_remaining.clone(),
-                        fee_rate,
-                        outgoing + fee_amount,
-                        &drain_script,
-                        rng,
-                    )
-                    .map_err(CreateTxError::CoinSelection)?;
+                match coin_selection.coin_select(
+                    required_for_attempt.clone(),
+                    optional_remaining.clone(),
+                    fee_rate,
+                    outgoing + fee_amount,
+                    &drain_script,
+                    rng,
+                ) {
+                    Ok(result) => {
+                        if !matches!(&result.excess, Excess::NoChange { .. }) {
+                            break result;
+                        }
 
-                if !matches!(&result.excess, Excess::NoChange { .. }) {
-                    break result;
+                        let Some(w) = optional_remaining.pop() else {
+                            break result;
+                        };
+                        last_successful_result = Some(result);
+                        required_for_attempt.push(w);
+                    }
+                    Err(err) => {
+                        if let Some(result) = last_successful_result {
+                            break result;
+                        }
+                        return Err(CreateTxError::CoinSelection(err));
+                    }
                 }
-
-                let Some(w) = optional_remaining.pop() else {
-                    break result;
-                };
-                required_for_attempt.push(w);
             }
         } else {
             coin_selection

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -1467,16 +1467,37 @@ impl Wallet {
             }
         };
 
-        let coin_selection = coin_selection
-            .coin_select(
-                required_utxos,
-                optional_utxos,
-                fee_rate,
-                outgoing + fee_amount,
-                &drain_script,
-                rng,
-            )
-            .map_err(CreateTxError::CoinSelection)?;
+        // Retry coin selection to avoid dust/zero drain outputs (see issue #376). If the
+        // selection yields NoChange the loop promotes an optional UTXO to required and retries;
+        // it exits when optional_remaining is exhausted or a viable drain output is found.
+        let should_retry_for_dust_drain = params.recipients.is_empty()
+            && params.drain_to.is_some()
+            && (params.drain_wallet || !params.utxos.is_empty())
+            && !params.manually_selected_only;
+
+        let mut required_for_attempt = required_utxos;
+        let mut optional_remaining = optional_utxos;
+        let coin_selection = loop {
+            let result = coin_selection
+                .coin_select(
+                    required_for_attempt.clone(),
+                    optional_remaining.clone(),
+                    fee_rate,
+                    outgoing + fee_amount,
+                    &drain_script,
+                    rng,
+                )
+                .map_err(CreateTxError::CoinSelection)?;
+
+            if !should_retry_for_dust_drain || !matches!(&result.excess, Excess::NoChange { .. }) {
+                break result;
+            }
+
+            let Some(w) = optional_remaining.pop() else {
+                break result;
+            };
+            required_for_attempt.push(w);
+        };
 
         let excess = &coin_selection.excess;
         tx.input = coin_selection

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -1501,8 +1501,15 @@ impl Wallet {
                         required_for_attempt.push(w);
                     }
                     Err(err) => {
-                        if let Some(result) = last_successful_result {
-                            break result;
+                        if let Some(result) = last_successful_result.take() {
+                            // The last promoted optional UTXO made selection fail.
+                            // Drop it and keep trying remaining optionals.
+                            required_for_attempt.pop();
+                            if optional_remaining.is_empty() {
+                                break result;
+                            }
+                            last_successful_result = Some(result);
+                            continue;
                         }
                         return Err(CreateTxError::CoinSelection(err));
                     }

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -1475,32 +1475,45 @@ impl Wallet {
             && (params.drain_wallet || !params.utxos.is_empty())
             && !params.manually_selected_only;
 
-        let mut required_for_attempt = required_utxos;
-        let mut optional_remaining = optional_utxos;
-        let coin_selection = loop {
-            let result = coin_selection
+        let selection_result = if should_retry_for_dust_drain {
+            let mut required_for_attempt = required_utxos;
+            let mut optional_remaining = optional_utxos;
+            loop {
+                let result = coin_selection
+                    .coin_select(
+                        required_for_attempt.clone(),
+                        optional_remaining.clone(),
+                        fee_rate,
+                        outgoing + fee_amount,
+                        &drain_script,
+                        rng,
+                    )
+                    .map_err(CreateTxError::CoinSelection)?;
+
+                if !matches!(&result.excess, Excess::NoChange { .. }) {
+                    break result;
+                }
+
+                let Some(w) = optional_remaining.pop() else {
+                    break result;
+                };
+                required_for_attempt.push(w);
+            }
+        } else {
+            coin_selection
                 .coin_select(
-                    required_for_attempt.clone(),
-                    optional_remaining.clone(),
+                    required_utxos,
+                    optional_utxos,
                     fee_rate,
                     outgoing + fee_amount,
                     &drain_script,
                     rng,
                 )
-                .map_err(CreateTxError::CoinSelection)?;
-
-            if !should_retry_for_dust_drain || !matches!(&result.excess, Excess::NoChange { .. }) {
-                break result;
-            }
-
-            let Some(w) = optional_remaining.pop() else {
-                break result;
-            };
-            required_for_attempt.push(w);
+                .map_err(CreateTxError::CoinSelection)?
         };
 
-        let excess = &coin_selection.excess;
-        tx.input = coin_selection
+        let excess = &selection_result.excess;
+        tx.input = selection_result
             .selected
             .iter()
             .map(|u| bitcoin::TxIn {
@@ -1555,7 +1568,7 @@ impl Wallet {
         // Sort inputs/outputs according to the chosen algorithm.
         params.ordering.sort_tx_with_aux_rand(&mut tx, rng);
 
-        let psbt = self.complete_transaction(tx, coin_selection.selected, params)?;
+        let psbt = self.complete_transaction(tx, selection_result.selected, params)?;
 
         // Recording changes to the change keychain.
         if let (Excess::Change { .. }, Some((keychain, index))) = (excess, drain_index) {

--- a/tests/drain_to_dust_pull_utxo.rs
+++ b/tests/drain_to_dust_pull_utxo.rs
@@ -1,0 +1,77 @@
+use bdk_wallet::test_utils::*;
+use bdk_wallet::KeychainKind;
+use bitcoin::{hashes::Hash, psbt, Amount, OutPoint, ScriptBuf, TxOut, Weight};
+
+// Ensures coin selection pulls a local UTXO when drain-only selection would produce dust.
+#[test]
+fn test_drain_to_pulls_local_utxo_when_foreign_only_dust() {
+    let (mut wallet, _) = get_funded_wallet_wpkh();
+    let drain_spk = wallet
+        .next_unused_address(KeychainKind::External)
+        .script_pubkey();
+
+    let witness_utxo = TxOut {
+        value: Amount::from_sat(500),
+        script_pubkey: ScriptBuf::new_p2a(),
+    };
+    // Remember to include this as a "floating" txout in the wallet.
+    let outpoint = OutPoint::new(Hash::hash(b"foreign-p2a-prev"), 1);
+    wallet.insert_txout(outpoint, witness_utxo.clone());
+    let satisfaction_weight = Weight::from_wu(71);
+    let psbt_input = psbt::Input {
+        witness_utxo: Some(witness_utxo),
+        ..Default::default()
+    };
+
+    let mut tx_builder = wallet.build_tx();
+    tx_builder
+        .add_foreign_utxo(outpoint, psbt_input, satisfaction_weight)
+        .unwrap()
+        .only_witness_utxo()
+        .fee_absolute(Amount::from_sat(400))
+        .drain_to(drain_spk);
+
+    let psbt = tx_builder.finish().unwrap();
+    let tx = psbt.unsigned_tx;
+    assert!(tx.input.len() >= 2);
+    assert!(!tx.output.is_empty());
+    assert!(
+        tx.input.iter().any(|txin| txin.previous_output == outpoint),
+        "foreign_utxo should be in there"
+    );
+}
+
+// Foreign value equals fee: no satoshis left for a drain output until a wallet UTXO is included.
+#[test]
+fn test_drain_to_pulls_local_utxo_when_foreign_value_equals_fee() {
+    let (mut wallet, _) = get_funded_wallet_wpkh();
+    let drain_spk = wallet
+        .next_unused_address(KeychainKind::External)
+        .script_pubkey();
+
+    let witness_utxo = TxOut {
+        value: Amount::from_sat(200),
+        script_pubkey: ScriptBuf::new_p2a(),
+    };
+    let outpoint = OutPoint::new(Hash::hash(b"foreign-p2a-prev-200"), 1);
+    wallet.insert_txout(outpoint, witness_utxo.clone());
+    let satisfaction_weight = Weight::from_wu(71);
+    let psbt_input = psbt::Input {
+        witness_utxo: Some(witness_utxo),
+        ..Default::default()
+    };
+
+    let mut tx_builder = wallet.build_tx();
+    tx_builder
+        .add_foreign_utxo(outpoint, psbt_input, satisfaction_weight)
+        .unwrap()
+        .only_witness_utxo()
+        .fee_absolute(Amount::from_sat(200))
+        .drain_to(drain_spk);
+
+    let psbt = tx_builder.finish().unwrap();
+    let tx = psbt.unsigned_tx;
+    assert!(tx.input.len() >= 2);
+    assert!(!tx.output.is_empty());
+    assert!(tx.input.iter().any(|txin| txin.previous_output == outpoint));
+}


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Fixes #376.

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

`Wallet::create_tx` could return `CreateTxError::CoinSelection` for drain-only transactions (`drain_to`, **no explicit recipients**) when spending a foreign input (e.g P2A) with `fee_absolute`.

In that situation, the initial `coin_select` pass may select only required inputs and yield `Excess::NoChange` (i.e. zero or dust remaining for the drain output). This results in a coin selection failure despite sufficient total funds, because the drain-only path cannot produce a non-dust output under `Excess::NoChange`.

This change adds a retry for that scenario : optional wallet UTXOs are promoted to required inputs one at a time and `coin_select` is run again until `Excess` is no longer `NoChange` or there are no optional UTXOs left. That yields a valid (non-dust) drain output when possible.

**Scope:** General coin selection behavior is unchanged. This only adds a retry for the `NoChange` + drain-only case. Optional UTXOs are taken in existing order (`pop()`), so no new selection policy is introduced.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

- **Guards:** Retry is gated on:
  - no explicit recipients (`params.recipients.is_empty()`)
  - `drain_to` is set
  - `(params.drain_wallet || !params.utxos.is_empty())` (preserves `NoRecipients` behavior vs the empty-output path in `mod.rs`)
  - not `manually_selected_only`
- **Tests:** `tests/drain_to_dust_pull_utxo.rs`
  - Foreign P2A-style UTXOs via `insert_txout`, `fee_absolute`, `drain_to`
  - Covers dust remainder (500 sat value, 400 sat fee) and zero remainder (200 sat value, 200 sat fee)
  - Asserts at least 2 inputs (foreign + local) non-empty outputs, foreign outpoint present in inputs

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

`fix(wallet): retry coin selection on NoChange to avoid dust/zero drain outputs (#376)`

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `just p` before pushing

#### New Features:
* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
