### PR TITLE
chore(tests): replace deprecated FeeRate::from_sat_per_vb_unchecked

### DIFF
--- a/src/wallet/coin_selection.rs
+++ b/src/wallet/coin_selection.rs
@@ -939,7 +939,7 @@ mod test {
             .coin_select(
                 utxos,
                 vec![],
-                FeeRate::from_sat_per_vb_unchecked(1),
+                FeeRate::from_sat_per_vb_u32(1),
                 target_amount,
                 &drain_script,
                 &mut thread_rng(),
@@ -961,7 +961,7 @@ mod test {
             .coin_select(
                 utxos,
                 vec![],
-                FeeRate::from_sat_per_vb_unchecked(1),
+                FeeRate::from_sat_per_vb_u32(1),
                 target_amount,
                 &drain_script,
                 &mut thread_rng(),
@@ -983,7 +983,7 @@ mod test {
             .coin_select(
                 vec![],
                 utxos,
-                FeeRate::from_sat_per_vb_unchecked(1),
+                FeeRate::from_sat_per_vb_u32(1),
                 target_amount,
                 &drain_script,
                 &mut thread_rng(),
@@ -1004,7 +1004,7 @@ mod test {
         let result = LargestFirstCoinSelection.coin_select(
             vec![],
             utxos,
-            FeeRate::from_sat_per_vb_unchecked(1),
+            FeeRate::from_sat_per_vb_u32(1),
             target_amount,
             &drain_script,
             &mut thread_rng(),
@@ -1021,7 +1021,7 @@ mod test {
         let result = LargestFirstCoinSelection.coin_select(
             vec![],
             utxos,
-            FeeRate::from_sat_per_vb_unchecked(1000),
+            FeeRate::from_sat_per_vb_u32(1000),
             target_amount,
             &drain_script,
             &mut thread_rng(),
@@ -1039,7 +1039,7 @@ mod test {
             .coin_select(
                 vec![],
                 utxos,
-                FeeRate::from_sat_per_vb_unchecked(1),
+                FeeRate::from_sat_per_vb_u32(1),
                 target_amount,
                 &drain_script,
                 &mut thread_rng(),
@@ -1061,7 +1061,7 @@ mod test {
             .coin_select(
                 utxos,
                 vec![],
-                FeeRate::from_sat_per_vb_unchecked(1),
+                FeeRate::from_sat_per_vb_u32(1),
                 target_amount,
                 &drain_script,
                 &mut thread_rng(),
@@ -1085,7 +1085,7 @@ mod test {
             .coin_select(
                 vec![],
                 all_utxos,
-                FeeRate::from_sat_per_vb_unchecked(1),
+                FeeRate::from_sat_per_vb_u32(1),
                 target_amount,
                 &drain_script,
                 &mut thread_rng(),
@@ -1110,7 +1110,7 @@ mod test {
             .coin_select(
                 vec![],
                 all_utxos,
-                FeeRate::from_sat_per_vb_unchecked(1),
+                FeeRate::from_sat_per_vb_u32(1),
                 target_amount,
                 &drain_script,
                 &mut thread_rng(),
@@ -1136,7 +1136,7 @@ mod test {
             .coin_select(
                 vec![],
                 utxos,
-                FeeRate::from_sat_per_vb_unchecked(1),
+                FeeRate::from_sat_per_vb_u32(1),
                 target_amount,
                 &drain_script,
                 &mut thread_rng(),
@@ -1157,7 +1157,7 @@ mod test {
         let result = OldestFirstCoinSelection.coin_select(
             vec![],
             utxos,
-            FeeRate::from_sat_per_vb_unchecked(1),
+            FeeRate::from_sat_per_vb_u32(1),
             target_amount,
             &drain_script,
             &mut thread_rng(),
@@ -1176,7 +1176,7 @@ mod test {
         let result = OldestFirstCoinSelection.coin_select(
             vec![],
             utxos,
-            FeeRate::from_sat_per_vb_unchecked(1000),
+            FeeRate::from_sat_per_vb_u32(1000),
             target_amount,
             &drain_script,
             &mut thread_rng(),
@@ -1196,7 +1196,7 @@ mod test {
             .coin_select(
                 vec![],
                 utxos,
-                FeeRate::from_sat_per_vb_unchecked(1),
+                FeeRate::from_sat_per_vb_u32(1),
                 target_amount,
                 &drain_script,
                 &mut thread_rng(),
@@ -1218,7 +1218,7 @@ mod test {
             .coin_select(
                 utxos.clone(),
                 utxos,
-                FeeRate::from_sat_per_vb_unchecked(1),
+                FeeRate::from_sat_per_vb_u32(1),
                 target_amount,
                 &drain_script,
                 &mut thread_rng(),
@@ -1260,7 +1260,7 @@ mod test {
         let mut rng: StdRng = SeedableRng::from_seed(seed);
         let mut utxos = generate_random_utxos(&mut rng, 300);
         let target_amount = sum_random_utxos(&mut rng, &mut utxos) + FEE_AMOUNT;
-        let fee_rate = FeeRate::from_sat_per_vb_unchecked(1);
+        let fee_rate = FeeRate::from_sat_per_vb_u32(1);
         let drain_script = ScriptBuf::default();
 
         let result = SingleRandomDraw.coin_select(
@@ -1288,7 +1288,7 @@ mod test {
         // 100_000, 10, 200_000
         let utxos = get_test_utxos();
         let target_amount = Amount::from_sat(300_000) + FEE_AMOUNT;
-        let fee_rate = FeeRate::from_sat_per_vb_unchecked(1);
+        let fee_rate = FeeRate::from_sat_per_vb_u32(1);
         let drain_script = ScriptBuf::default();
 
         let result = SingleRandomDraw.coin_select(
@@ -1361,7 +1361,7 @@ mod test {
         let result = BranchAndBoundCoinSelection::<SingleRandomDraw>::default().coin_select(
             vec![],
             utxos,
-            FeeRate::from_sat_per_vb_unchecked(1),
+            FeeRate::from_sat_per_vb_u32(1),
             target_amount,
             &drain_script,
             &mut thread_rng(),
@@ -1379,7 +1379,7 @@ mod test {
         let result = BranchAndBoundCoinSelection::<SingleRandomDraw>::default().coin_select(
             vec![],
             utxos,
-            FeeRate::from_sat_per_vb_unchecked(1000),
+            FeeRate::from_sat_per_vb_u32(1000),
             target_amount,
             &drain_script,
             &mut thread_rng(),
@@ -1440,7 +1440,7 @@ mod test {
 
     #[test]
     fn test_bnb_function_no_exact_match() {
-        let fee_rate = FeeRate::from_sat_per_vb_unchecked(10);
+        let fee_rate = FeeRate::from_sat_per_vb_u32(10);
         let utxos: Vec<OutputGroup> = get_test_utxos()
             .into_iter()
             .map(|u| OutputGroup::new(u, fee_rate))
@@ -1472,7 +1472,7 @@ mod test {
 
     #[test]
     fn test_bnb_function_tries_exceeded() {
-        let fee_rate = FeeRate::from_sat_per_vb_unchecked(10);
+        let fee_rate = FeeRate::from_sat_per_vb_u32(10);
         let utxos: Vec<OutputGroup> = generate_same_value_utxos(Amount::from_sat(100_000), 100_000)
             .into_iter()
             .map(|u| OutputGroup::new(u, fee_rate))
@@ -1506,7 +1506,7 @@ mod test {
     // The match won't be exact but still in the range
     #[test]
     fn test_bnb_function_almost_exact_match_with_fees() {
-        let fee_rate = FeeRate::from_sat_per_vb_unchecked(1);
+        let fee_rate = FeeRate::from_sat_per_vb_u32(1);
         let size_of_change = 31;
         let cost_of_change = (Weight::from_vb_unchecked(size_of_change) * fee_rate)
             .to_signed()
@@ -1597,7 +1597,7 @@ mod test {
         let selection = BranchAndBoundCoinSelection::<SingleRandomDraw>::default().coin_select(
             vec![],
             utxos,
-            FeeRate::from_sat_per_vb_unchecked(10),
+            FeeRate::from_sat_per_vb_u32(10),
             Amount::from_sat(500_000),
             &drain_script,
             &mut thread_rng(),
@@ -1624,7 +1624,7 @@ mod test {
         let selection = BranchAndBoundCoinSelection::<SingleRandomDraw>::default().coin_select(
             required,
             optional,
-            FeeRate::from_sat_per_vb_unchecked(10),
+            FeeRate::from_sat_per_vb_u32(10),
             Amount::from_sat(500_000),
             &drain_script,
             &mut thread_rng(),
@@ -1647,7 +1647,7 @@ mod test {
         let selection = BranchAndBoundCoinSelection::<SingleRandomDraw>::default().coin_select(
             utxos,
             vec![],
-            FeeRate::from_sat_per_vb_unchecked(10_000),
+            FeeRate::from_sat_per_vb_u32(10_000),
             Amount::from_sat(500_000),
             &drain_script,
             &mut thread_rng(),
@@ -1721,7 +1721,7 @@ mod test {
         ];
 
         let optional = generate_same_value_utxos(Amount::from_sat(100_000), 30);
-        let fee_rate = FeeRate::from_sat_per_vb_unchecked(1);
+        let fee_rate = FeeRate::from_sat_per_vb_u32(1);
         let target_amount = calc_target_amount(&optional[0..3], fee_rate);
         assert_eq!(target_amount, Amount::from_sat(299_796));
         let drain_script = ScriptBuf::default();

--- a/tests/build_fee_bump.rs
+++ b/tests/build_fee_bump.rs
@@ -329,7 +329,7 @@ fn test_bump_fee_drain_wallet() {
     let mut builder = wallet.build_fee_bump(txid).unwrap();
     builder
         .drain_wallet()
-        .fee_rate(FeeRate::from_sat_per_vb_unchecked(5));
+        .fee_rate(FeeRate::from_sat_per_vb_u32(5));
     let psbt = builder.finish().unwrap();
     let (sent, _received) =
         wallet.sent_and_received(&psbt.extract_tx().expect("failed to extract tx"));
@@ -391,7 +391,7 @@ fn test_bump_fee_remove_output_manually_selected_only() {
     let mut builder = wallet.build_fee_bump(txid).unwrap();
     builder
         .manually_selected_only()
-        .fee_rate(FeeRate::from_sat_per_vb_unchecked(255));
+        .fee_rate(FeeRate::from_sat_per_vb_u32(255));
     builder.finish().unwrap();
 }
 
@@ -430,7 +430,7 @@ fn test_bump_fee_add_input() {
     insert_tx(&mut wallet, tx);
 
     let mut builder = wallet.build_fee_bump(txid).unwrap();
-    builder.fee_rate(FeeRate::from_sat_per_vb_unchecked(50));
+    builder.fee_rate(FeeRate::from_sat_per_vb_u32(50));
     let psbt = builder.finish().unwrap();
     let (sent, received) =
         wallet.sent_and_received(&psbt.clone().extract_tx().expect("failed to extract tx"));
@@ -458,7 +458,7 @@ fn test_bump_fee_add_input() {
         received
     );
 
-    assert_fee_rate!(psbt, fee, FeeRate::from_sat_per_vb_unchecked(50), @add_signature);
+    assert_fee_rate!(psbt, fee, FeeRate::from_sat_per_vb_u32(50), @add_signature);
 }
 
 #[test]
@@ -536,7 +536,7 @@ fn test_bump_fee_no_change_add_input_and_change() {
     // Now bump the fees, the wallet should add an extra input and a change output, and leave
     // the original output untouched.
     let mut builder = wallet.build_fee_bump(txid).unwrap();
-    builder.fee_rate(FeeRate::from_sat_per_vb_unchecked(50));
+    builder.fee_rate(FeeRate::from_sat_per_vb_u32(50));
     let psbt = builder.finish().unwrap();
     let (sent, received) =
         wallet.sent_and_received(&psbt.clone().extract_tx().expect("failed to extract tx"));
@@ -569,7 +569,7 @@ fn test_bump_fee_no_change_add_input_and_change() {
         Amount::from_sat(75_000) - original_send_all_amount - fee
     );
 
-    assert_fee_rate!(psbt, fee, FeeRate::from_sat_per_vb_unchecked(50), @add_signature);
+    assert_fee_rate!(psbt, fee, FeeRate::from_sat_per_vb_u32(50), @add_signature);
 }
 
 #[test]
@@ -597,7 +597,7 @@ fn test_bump_fee_force_add_input() {
     builder
         .add_utxo(incoming_op)
         .unwrap()
-        .fee_rate(FeeRate::from_sat_per_vb_unchecked(5));
+        .fee_rate(FeeRate::from_sat_per_vb_u32(5));
     let psbt = builder.finish().unwrap();
     let (sent, received) =
         wallet.sent_and_received(&psbt.clone().extract_tx().expect("failed to extract tx"));
@@ -626,7 +626,7 @@ fn test_bump_fee_force_add_input() {
         received
     );
 
-    assert_fee_rate!(psbt, fee, FeeRate::from_sat_per_vb_unchecked(5), @add_signature);
+    assert_fee_rate!(psbt, fee, FeeRate::from_sat_per_vb_u32(5), @add_signature);
 }
 
 #[test]
@@ -715,7 +715,7 @@ fn test_bump_fee_unconfirmed_inputs_only() {
     }
     insert_tx(&mut wallet, tx);
     let mut builder = wallet.build_fee_bump(txid).unwrap();
-    builder.fee_rate(FeeRate::from_sat_per_vb_unchecked(25));
+    builder.fee_rate(FeeRate::from_sat_per_vb_u32(25));
     builder.finish().unwrap();
 }
 
@@ -746,7 +746,7 @@ fn test_bump_fee_unconfirmed_input() {
 
     let mut builder = wallet.build_fee_bump(txid).unwrap();
     builder
-        .fee_rate(FeeRate::from_sat_per_vb_unchecked(15))
+        .fee_rate(FeeRate::from_sat_per_vb_u32(15))
         // remove original tx drain_to address and amount
         .set_recipients(Vec::new())
         // set back original drain_to address
@@ -823,7 +823,7 @@ fn test_legacy_bump_fee_drain_wallet() {
     let mut builder = wallet.build_fee_bump(txid).unwrap();
     builder
         .drain_wallet()
-        .fee_rate(FeeRate::from_sat_per_vb_unchecked(5));
+        .fee_rate(FeeRate::from_sat_per_vb_u32(5));
     let psbt = builder.finish().unwrap();
     let (sent, _received) =
         wallet.sent_and_received(&psbt.extract_tx().expect("failed to extract tx"));
@@ -866,7 +866,7 @@ fn test_legacy_bump_fee_add_input() {
     insert_tx(&mut wallet, tx);
 
     let mut builder = wallet.build_fee_bump(txid).unwrap();
-    builder.fee_rate(FeeRate::from_sat_per_vb_unchecked(50));
+    builder.fee_rate(FeeRate::from_sat_per_vb_u32(50));
     let psbt = builder.finish().unwrap();
     let (sent, received) =
         wallet.sent_and_received(&psbt.clone().extract_tx().expect("failed to extract tx"));
@@ -894,7 +894,7 @@ fn test_legacy_bump_fee_add_input() {
         received
     );
 
-    assert_fee_rate_legacy!(psbt, fee, FeeRate::from_sat_per_vb_unchecked(50), @add_signature);
+    assert_fee_rate_legacy!(psbt, fee, FeeRate::from_sat_per_vb_u32(50), @add_signature);
 }
 
 #[test]
@@ -971,7 +971,7 @@ fn test_bump_fee_pay_to_anchor_foreign_utxo() {
         .add_foreign_utxo(outpoint, psbt_input, satisfaction_weight)
         .unwrap()
         .only_witness_utxo()
-        .fee_rate(FeeRate::from_sat_per_vb_unchecked(2))
+        .fee_rate(FeeRate::from_sat_per_vb_u32(2))
         .drain_to(drain_spk.clone());
     let psbt = tx_builder.finish().unwrap();
     let tx = psbt.unsigned_tx.clone();
@@ -987,7 +987,7 @@ fn test_bump_fee_pay_to_anchor_foreign_utxo() {
         .set_recipients(vec![])
         .drain_to(drain_spk)
         .only_witness_utxo()
-        .fee_rate(FeeRate::from_sat_per_vb_unchecked(5));
+        .fee_rate(FeeRate::from_sat_per_vb_u32(5));
     let psbt = tx_builder.finish().unwrap();
     let tx = &psbt.unsigned_tx;
     assert!(tx.input.iter().any(|txin| txin.previous_output == outpoint));

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -538,11 +538,11 @@ fn test_create_tx_custom_fee_rate() {
     let mut builder = wallet.build_tx();
     builder
         .add_recipient(addr.script_pubkey(), Amount::from_sat(25_000))
-        .fee_rate(FeeRate::from_sat_per_vb_unchecked(5));
+        .fee_rate(FeeRate::from_sat_per_vb_u32(5));
     let psbt = builder.finish().unwrap();
     let fee = check_fee!(wallet, psbt);
 
-    assert_fee_rate!(psbt, fee, FeeRate::from_sat_per_vb_unchecked(5), @add_signature);
+    assert_fee_rate!(psbt, fee, FeeRate::from_sat_per_vb_u32(5), @add_signature);
 }
 
 #[test]
@@ -552,11 +552,11 @@ fn test_legacy_create_tx_custom_fee_rate() {
     let mut builder = wallet.build_tx();
     builder
         .add_recipient(addr.script_pubkey(), Amount::from_sat(25_000))
-        .fee_rate(FeeRate::from_sat_per_vb_unchecked(5));
+        .fee_rate(FeeRate::from_sat_per_vb_u32(5));
     let psbt = builder.finish().unwrap();
     let fee = check_fee!(wallet, psbt);
 
-    assert_fee_rate_legacy!(psbt, fee, FeeRate::from_sat_per_vb_unchecked(5), @add_signature);
+    assert_fee_rate_legacy!(psbt, fee, FeeRate::from_sat_per_vb_u32(5), @add_signature);
 }
 
 #[test]
@@ -711,7 +711,7 @@ fn test_create_tx_drain_to_dust_amount() {
     builder
         .drain_to(addr.script_pubkey())
         .drain_wallet()
-        .fee_rate(FeeRate::from_sat_per_vb_unchecked(454));
+        .fee_rate(FeeRate::from_sat_per_vb_u32(454));
     builder.finish().unwrap();
 }
 
@@ -2618,7 +2618,7 @@ fn test_fee_rate_sign_no_grinding_high_r() {
     // alright.
     let (mut wallet, _) = get_funded_wallet_single("wpkh(tprv8ZgxMBicQKsPd3EupYiPRhaMooHKUHJxNsTfYuScep13go8QFfHdtkG9nRkFGb7busX4isf6X9dURGCoKgitaApQ6MupRhZMcELAxTBRJgS/*)");
     let addr = wallet.next_unused_address(KeychainKind::External);
-    let fee_rate = FeeRate::from_sat_per_vb_unchecked(1);
+    let fee_rate = FeeRate::from_sat_per_vb_u32(1);
     let mut builder = wallet.build_tx();
     let mut data = PushBytesBuf::try_from(vec![0]).unwrap();
     builder
@@ -2685,7 +2685,7 @@ fn test_fee_rate_sign_grinding_low_r() {
     // signature is 70 bytes.
     let (mut wallet, _) = get_funded_wallet_single("wpkh(tprv8ZgxMBicQKsPd3EupYiPRhaMooHKUHJxNsTfYuScep13go8QFfHdtkG9nRkFGb7busX4isf6X9dURGCoKgitaApQ6MupRhZMcELAxTBRJgS/*)");
     let addr = wallet.next_unused_address(KeychainKind::External);
-    let fee_rate = FeeRate::from_sat_per_vb_unchecked(1);
+    let fee_rate = FeeRate::from_sat_per_vb_u32(1);
     let mut builder = wallet.build_tx();
     builder
         .drain_to(addr.script_pubkey())


### PR DESCRIPTION
### Description

`bitcoin-units 0.1.3` deprecated `FeeRate::from_sat_per_vb_unchecked` in favor of `FeeRate::from_sat_per_vb_u32`. Cargo resolves any 0.1.x automatically, so fresh CI runs started failing on master (and all open PRs) once 0.1.3 was published.

This patch swaps every call site over to the new name. The two functions compute the same value for any input that fits in `u32`; every existing call site passes a small literal (1, 3, 5, 10, 25, 50, 255, 454, 1000, 10_000), so no behavioural change.

All usages are in test/fixture code (`src/wallet/coin_selection.rs` test module, `tests/wallet.rs`, `tests/build_fee_bump.rs`) — no production code path was using the deprecated function.

### Notes to the reviewers

- Pure mechanical rename; no logic or type changes.
- Unblocks CI on master and every open PR (e.g. #449, #442, #445, #448).

### Changelog notice

N/A — internal test-only change.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `just p` before pushing