### PR TITLE
fix(descriptor): reject bare descriptors in check_wallet_descriptor

### DIFF
--- a/src/descriptor/error.rs
+++ b/src/descriptor/error.rs
@@ -44,6 +44,8 @@ pub enum Error {
     Hex(bitcoin::hex::HexToBytesError),
     /// The provided wallet descriptors are identical
     ExternalAndInternalAreTheSame,
+    /// Descriptor type is not supported by the wallet (e.g. bare scripts have no address form)
+    UnsupportedDescriptorType,
 }
 
 impl From<crate::keys::KeyError> for Error {
@@ -83,6 +85,12 @@ impl fmt::Display for Error {
             Self::Hex(err) => write!(f, "Hex decoding error: {err}"),
             Self::ExternalAndInternalAreTheSame => {
                 write!(f, "External and internal descriptors are the same")
+            }
+            Self::UnsupportedDescriptorType => {
+                write!(
+                    f,
+                    "Descriptor type is not supported by the wallet; bare scripts have no address form"
+                )
             }
         }
     }

--- a/src/descriptor/error.rs
+++ b/src/descriptor/error.rs
@@ -44,7 +44,7 @@ pub enum Error {
     Hex(bitcoin::hex::HexToBytesError),
     /// The provided wallet descriptors are identical
     ExternalAndInternalAreTheSame,
-    /// Descriptor type is not supported by the wallet (e.g. bare scripts have no address form)
+    /// Descriptor type is not supported by the wallet (e.g. bare or raw scripts have no address form)
     UnsupportedDescriptorType,
 }
 
@@ -89,7 +89,7 @@ impl fmt::Display for Error {
             Self::UnsupportedDescriptorType => {
                 write!(
                     f,
-                    "Descriptor type is not supported by the wallet; bare scripts have no address form"
+                    "Descriptor type is not supported by the wallet; bare and raw scripts have no address form"
                 )
             }
         }

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -321,6 +321,12 @@ pub(crate) fn check_wallet_descriptor(
         ));
     }
 
+    // Reject bare descriptors: they have no standard address form and would cause panics
+    // inside the wallet when address derivation is attempted.
+    if descriptor.desc_type() == DescriptorType::Bare {
+        return Err(DescriptorError::UnsupportedDescriptorType);
+    }
+
     // Run miniscript's sanity check, which will look for duplicated keys and other potential
     // issues.
     descriptor.sanity_check()?;
@@ -912,6 +918,16 @@ mod test {
         let result = check_wallet_descriptor(&descriptor);
 
         assert!(result.is_err());
+
+        // Bare descriptors (e.g. pk()) have no standard address form and must be rejected.
+        let descriptor = Descriptor::<DescriptorPublicKey>::from_str(
+            "pk(tpubD6NzVbkrYhZ4XHndKkuB8FifXm8r5FQHwrN6oZuWCz13qb93rtgKvD4PQsqC4HP4yhV3tA2fqr2RbY5mNXfM7RxXUoeABoDtsFUq2zJq6YK/0/*)",
+        )
+        .expect("must parse");
+        assert_matches!(
+            check_wallet_descriptor(&descriptor),
+            Err(DescriptorError::UnsupportedDescriptorType)
+        );
     }
 
     #[test]

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -321,10 +321,20 @@ pub(crate) fn check_wallet_descriptor(
         ));
     }
 
-    // Reject bare descriptors: they have no standard address form and would cause panics
-    // inside the wallet when address derivation is attempted.
-    if descriptor.desc_type() == DescriptorType::Bare {
-        return Err(DescriptorError::UnsupportedDescriptorType);
+    // Reject descriptor types that have no standard address form (e.g. bare scripts, raw scripts).
+    // Using an allowlist guards against any future unsupported types as well.
+    match descriptor.desc_type() {
+        DescriptorType::Pkh
+        | DescriptorType::Wpkh
+        | DescriptorType::ShWpkh
+        | DescriptorType::Sh
+        | DescriptorType::ShSortedMulti
+        | DescriptorType::Wsh
+        | DescriptorType::ShWsh
+        | DescriptorType::ShWshSortedMulti
+        | DescriptorType::WshSortedMulti
+        | DescriptorType::Tr => {}
+        _ => return Err(DescriptorError::UnsupportedDescriptorType),
     }
 
     // Run miniscript's sanity check, which will look for duplicated keys and other potential
@@ -924,6 +934,14 @@ mod test {
             "pk(tpubD6NzVbkrYhZ4XHndKkuB8FifXm8r5FQHwrN6oZuWCz13qb93rtgKvD4PQsqC4HP4yhV3tA2fqr2RbY5mNXfM7RxXUoeABoDtsFUq2zJq6YK/0/*)",
         )
         .expect("must parse");
+        assert_matches!(
+            check_wallet_descriptor(&descriptor),
+            Err(DescriptorError::UnsupportedDescriptorType)
+        );
+
+        // Raw script descriptors have no standard address form and must be rejected.
+        let descriptor = Descriptor::<DescriptorPublicKey>::from_str("raw(deadbeef)")
+            .expect("must parse");
         assert_matches!(
             check_wallet_descriptor(&descriptor),
             Err(DescriptorError::UnsupportedDescriptorType)


### PR DESCRIPTION
Bare descriptors (e.g. `pk()`) have no standard address form. Passing one to the wallet wasn't caught at creation time, causing panics later when address derivation is attempted. Closes #54.

Adds `UnsupportedDescriptorType` to `DescriptorError` and checks for `DescriptorType::Bare` in `check_wallet_descriptor`, returning the new error before the descriptor reaches wallet internals.

---

### Checklist

#### All Submissions:
* [x] I've signed all my commits
* [x] I followed the contribution guidelines
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:
* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR