### PR TITLE
chore: allow local justfile overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ Cargo.lock
 
 *.swp
 .idea
+justfile.local
 
 # Example persisted files.
 *.db

--- a/examples/justfile
+++ b/examples/justfile
@@ -1,3 +1,5 @@
+import? "justfile.local"
+
 set quiet := true
 default_wallet := 'test'
 default_private := 'false'

--- a/justfile
+++ b/justfile
@@ -1,3 +1,5 @@
+import? "justfile.local"
+
 alias b := build
 alias c := check
 alias f := fmt


### PR DESCRIPTION
### Description

Closes #401

Adds support for local justfile overrides by including an optional `justfile.local` import at the top of the repository justfiles.

This allows contributors to define their own local recipes without modifying tracked files. The import uses `import?`, so it remains optional and does not affect existing workflows if the file is absent.

Also adds `justfile.local` to `.gitignore` to prevent accidental commits.

---

### Notes to the reviewers

Followed the Just optional import feature as documented:
https://just.systems/man/en/imports.html

The change is intentionally minimal and only adds the optional import without modifying any existing recipes or behavior.

Applies the change to both root and examples justfiles for consistency.

---

### Changelog notice

Added support for optional local justfile overrides via `justfile.local`.

---

### Checklists

#### All Submissions:

- [x] I've signed all my commits
- [x] I followed the contribution guidelines
- [x] I ran `just p` before pushing

#### New Features:

- [ ] I've added tests for the new feature
- [ ] I've added docs for the new feature

#### Bugfixes:

- [ ] This pull request breaks the existing API
- [ ] I've added tests to reproduce the issue which are now passing
- [x] I'm linking the issue being fixed by this PR