### PR TITLE
fix(ci): pin `idna_adapter` to `1.2.1`

### DIFF
--- a/ci/pin-msrv.sh
+++ b/ci/pin-msrv.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 # cargo clean
 # rustup default 1.85.0
 
+cargo update -p idna_adapter --precise "1.2.1"
 cargo update -p icu_normalizer --precise "2.1.1"
 cargo update -p icu_provider --precise "2.1.1"
 cargo update -p icu_locale_core --precise "2.1.1"


### PR DESCRIPTION
### Description

It fixes the MSRV CI by pining `idna_adapter`.

### Notes to the reviewers

I noticed it's broken after merging #441, this PR should fix it.

### Changelog notice

```

### Changed
- fix(ci): pin `idna_adapter` to `1.2.1`

```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `just p` before pushing
