### PR TITLE
fix(audit): add non-witness-utxo validation for psbt

### DIFF
--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -43,8 +43,12 @@ impl PsbtUtils for Psbt {
 
         match (&input.witness_utxo, &input.non_witness_utxo) {
             (Some(_), _) => input.witness_utxo.clone(),
-            (_, Some(_)) => input.non_witness_utxo.as_ref().map(|in_tx| {
-                in_tx.output[tx.input[input_index].previous_output.vout as usize].clone()
+            (_, Some(_)) => input.non_witness_utxo.as_ref().and_then(|prev_tx| {
+                let outpoint = tx.input[input_index].previous_output;
+                if prev_tx.compute_txid() != outpoint.txid {
+                    return None;
+                }
+                prev_tx.output.get(outpoint.vout as usize).cloned()
             }),
             _ => None,
         }
@@ -67,5 +71,87 @@ impl PsbtUtils for Psbt {
         let fee_amount = self.fee_amount();
         let weight = self.clone().extract_tx().ok()?.weight();
         fee_amount.map(|fee| fee / weight)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::psbt::Input;
+    use bitcoin::{
+        absolute, transaction, Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut,
+        Witness,
+    };
+
+    /// Builds a simple transaction with one output of the given value
+    fn build_tx(value: Amount) -> Transaction {
+        Transaction {
+            version: transaction::Version::TWO,
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint::null(),
+                script_sig: ScriptBuf::default(),
+                sequence: Sequence::MAX,
+                witness: Witness::default(),
+            }],
+            output: vec![TxOut {
+                value,
+                script_pubkey: ScriptBuf::default(),
+            }],
+        }
+    }
+
+    /// Builds a PSBT spending from the given previous transaction at the given vout
+    fn build_psbt(prev_tx: &Transaction, vout: u32) -> Psbt {
+        let unsigned_tx = Transaction {
+            version: transaction::Version::TWO,
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: prev_tx.compute_txid(),
+                    vout,
+                },
+                script_sig: ScriptBuf::default(),
+                sequence: Sequence::MAX,
+                witness: Witness::default(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(90_000),
+                script_pubkey: ScriptBuf::default(),
+            }],
+        };
+        Psbt::from_unsigned_tx(unsigned_tx).unwrap()
+    }
+
+    #[test]
+    fn get_utxo_for_returns_none_on_txid_mismatch() {
+        let real_tx = build_tx(Amount::from_sat(100_000));
+
+        // A different transaction with an inflated value — simulates attacker input
+        let fake_tx = build_tx(Amount::from_sat(999_999_999));
+
+        // PSBT spends from real_tx but attacker supplies fake_tx as non_witness_utxo
+        let mut psbt = build_psbt(&real_tx, 0);
+        psbt.inputs[0] = Input {
+            non_witness_utxo: Some(fake_tx), // txid won't match
+            ..Default::default()
+        };
+
+        // Must return None — fake tx rejected
+        assert_eq!(psbt.get_utxo_for(0), None);
+    }
+
+    #[test]
+    fn get_utxo_for_returns_none_on_vout_out_of_bounds() {
+        let prev_tx = build_tx(Amount::from_sat(100_000));
+        // prev_tx only has 1 output (vout 0), but we claim to spend vout 3
+        let mut psbt = build_psbt(&prev_tx, 3);
+        psbt.inputs[0] = Input {
+            non_witness_utxo: Some(prev_tx), // txid matches, but vout 3 doesn't exist
+            ..Default::default()
+        };
+
+        // Must return None — vout out of bounds, no panic
+        assert_eq!(psbt.get_utxo_for(0), None);
     }
 }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

This PR fixes a security vulnerability in `get_utxo_for()` within src/psbt/mod.rs where `non_witness_utxo` was being used without verifying that its txid matches the input's `previous_output.txid`.

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

* The validation silently returns None on txid mismatch rather than propagating an error, which is consistent with the existing behavior of this function.

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

#### Fixed
- [psbt] Validate `non_witness_utxo` txid against `previous_output.txid` in
  `get_utxo_for()` to prevent fee calculation manipulation via substituted
  transactions (fixes #468)

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [ ] I ran `just p` before pushing

#### New Features:

* N/A

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
