### PR TITLE
feat: add initial fuzz testing infrastructure (closes #61)

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -39,8 +39,8 @@ jobs:
         run: ./ci/pin-msrv.sh
       - name: Build + Test
         run: |
-          cargo build --workspace --all-targets ${{ matrix.features }}
-          cargo test --workspace ${{ matrix.features }}
+          cargo build --workspace --exclude bdk_wallet_fuzz --all-targets ${{ matrix.features }}
+          cargo test --workspace --exclude bdk_wallet_fuzz ${{ matrix.features }}
 
   build-test-stable:
     name: Build & Test Rust Stable
@@ -66,8 +66,8 @@ jobs:
           cache: true
       - name: Build + Test
         run: |
-          cargo build --workspace --all-targets ${{ matrix.features }}
-          cargo test --workspace ${{ matrix.features }}
+          cargo build --workspace --exclude bdk_wallet_fuzz --all-targets ${{ matrix.features }}
+          cargo test --workspace --exclude bdk_wallet_fuzz ${{ matrix.features }}
 
   check-no-std:
     name: Check no_std
@@ -144,7 +144,7 @@ jobs:
         with:
           cache: true
       - name: Clippy
-        run: cargo clippy --all-features --all-targets -- -D warnings
+        run: cargo clippy --workspace --exclude bdk_wallet_fuzz --all-features --all-targets -- -D warnings
 
   docs_check:
     name: Check cargo doc
@@ -160,4 +160,4 @@ jobs:
         with:
           cache: true
       - name: Check docs
-        run: RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps
+        run: RUSTDOCFLAGS='-D warnings' cargo doc --workspace --exclude bdk_wallet_fuzz --all-features --no-deps

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,75 @@
+on:
+  # Build fuzz targets on every PR to catch compilation regressions.
+  pull_request:
+  push:
+    branches:
+      - master
+  # Run a short fuzzing session weekly to catch regressions over time.
+  schedule:
+    - cron: "0 4 * * 1" # Every Monday at 04:00 UTC
+
+name: Fuzz
+
+permissions: {}
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-fuzz-targets:
+    name: Build fuzz targets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Install nightly Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: nightly
+          cache: true
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz
+
+      - name: Build all fuzz targets
+        run: cargo fuzz build --sanitizer none
+
+  fuzz-scheduled:
+    name: Run fuzz targets (${{ matrix.target }})
+    if: github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/master')
+    runs-on: ubuntu-latest
+    needs: build-fuzz-targets
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - apply_update
+          - create_tx
+          - descriptor_parse
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Install nightly Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: nightly
+          cache: true
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz
+
+      - name: Run ${{ matrix.target }} for 60 seconds
+        run: cargo fuzz run ${{ matrix.target }} -- -max_total_time=60 -max_len=4096
+
+      - name: Upload crash artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-crash-${{ matrix.target }}
+          path: fuzz/artifacts/${{ matrix.target }}/

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,9 @@ examples/test_data
 
 # Coverage reports
 lcov.info
+
+# Fuzz testing artifacts
+fuzz/target
+fuzz/corpus
+fuzz/artifacts
+fuzz/coverage

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,3 +77,6 @@ name = "esplora_blocking"
 
 [[example]]
 name = "bitcoind_rpc"
+
+[workspace]
+members = ["fuzz"]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "bdk_wallet_fuzz"
+version = "0.0.1"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+arbitrary = { version = "1", features = ["derive"] }
+bdk_wallet = { path = "..", features = ["test-utils"] }
+
+# Needed for accessing bitcoin types directly
+bitcoin = { version = "0.32.8" }
+
+[[bin]]
+name = "apply_update"
+path = "fuzz_targets/apply_update.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "create_tx"
+path = "fuzz_targets/create_tx.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "descriptor_parse"
+path = "fuzz_targets/descriptor_parse.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/apply_update.rs
+++ b/fuzz/fuzz_targets/apply_update.rs
@@ -1,0 +1,163 @@
+//! Fuzz target: apply arbitrary blockchain updates to a fresh wallet.
+//!
+//! Exercises `Wallet::apply_update` with structured random inputs including
+//! transactions, confirmation anchors, mempool timestamps, and chain checkpoints.
+//! Any panic is a bug; errors returned by `apply_update` are expected and ignored.
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bdk_wallet_fuzz::{create_wallet, p2wpkh_script};
+use libfuzzer_sys::fuzz_target;
+
+use bdk_wallet::{
+    bitcoin::{
+        absolute::LockTime, hashes::Hash, transaction::Version, Amount, BlockHash, OutPoint,
+        Sequence, Transaction, TxIn, TxOut, Txid,
+    },
+    chain::{BlockId, CheckPoint, ConfirmationBlockTime, TxUpdate},
+    KeychainKind, Update,
+};
+use std::{collections::BTreeMap, sync::Arc};
+
+/// Maximum valid satoshi value to avoid arithmetic panics.
+const MAX_SATS: u64 = 21_000_000 * 100_000_000;
+
+#[derive(Arbitrary, Debug)]
+struct FuzzedUpdate {
+    txs: Vec<FuzzedTx>,
+    /// Each entry: (tx index byte, block height) — index is taken mod txs.len().
+    anchors: Vec<(u8, u32)>,
+    /// Each entry: (tx index byte, unix timestamp).
+    seen_ats: Vec<(u8, u64)>,
+    last_active_ext: Option<u16>,
+    last_active_int: Option<u16>,
+    /// Sorted, deduplicated heights used to build a chain checkpoint.
+    chain_heights: Vec<u32>,
+}
+
+#[derive(Arbitrary, Debug)]
+struct FuzzedTx {
+    version: bool, // false → version 1, true → version 2
+    locktime: u32,
+    /// (txid bytes, output index, sequence)
+    inputs: Vec<([u8; 32], u32, u32)>,
+    /// (satoshi value, 20-byte script hash)
+    outputs: Vec<(u64, [u8; 20])>,
+}
+
+impl FuzzedTx {
+    fn into_transaction(self) -> Transaction {
+        let input = self
+            .inputs
+            .into_iter()
+            .map(|(txid_bytes, vout, seq)| TxIn {
+                previous_output: OutPoint {
+                    txid: Txid::from_byte_array(txid_bytes),
+                    vout,
+                },
+                sequence: Sequence(seq),
+                ..Default::default()
+            })
+            .collect();
+
+        let output: Vec<TxOut> = self
+            .outputs
+            .into_iter()
+            .filter_map(|(sats, hash)| {
+                // Clamp to valid range; skip zero-value outputs.
+                if sats == 0 || sats > MAX_SATS {
+                    return None;
+                }
+                Some(TxOut {
+                    value: Amount::from_sat(sats),
+                    script_pubkey: p2wpkh_script(hash),
+                })
+            })
+            .collect();
+
+        Transaction {
+            version: Version(if self.version { 2 } else { 1 }),
+            lock_time: LockTime::from_consensus(self.locktime),
+            input,
+            output,
+        }
+    }
+}
+
+fuzz_target!(|input: FuzzedUpdate| {
+    let mut wallet = create_wallet();
+
+    if input.txs.is_empty() {
+        return;
+    }
+
+    let genesis_hash = wallet.latest_checkpoint().hash();
+
+    let txs: Vec<Arc<Transaction>> = input
+        .txs
+        .into_iter()
+        .map(|t| Arc::new(t.into_transaction()))
+        .collect();
+
+    let mut tx_update = TxUpdate::<ConfirmationBlockTime>::default();
+    tx_update.txs = txs.clone();
+
+    for (idx_byte, height) in input.anchors {
+        let idx = idx_byte as usize % txs.len();
+        let txid = txs[idx].compute_txid();
+        tx_update.anchors.insert((
+            ConfirmationBlockTime {
+                block_id: BlockId {
+                    height,
+                    hash: BlockHash::all_zeros(),
+                },
+                confirmation_time: 1_600_000_000,
+            },
+            txid,
+        ));
+    }
+
+    for (idx_byte, ts) in input.seen_ats {
+        let idx = idx_byte as usize % txs.len();
+        let txid = txs[idx].compute_txid();
+        tx_update.seen_ats.insert((txid, ts));
+    }
+
+    let chain = if !input.chain_heights.is_empty() {
+        let mut heights = input.chain_heights;
+        heights.sort_unstable();
+        heights.dedup();
+
+        let mut block_ids = vec![BlockId {
+            height: 0,
+            hash: genesis_hash,
+        }];
+        block_ids.extend(heights.into_iter().map(|h| BlockId {
+            height: h,
+            hash: BlockHash::all_zeros(),
+        }));
+
+        CheckPoint::from_block_ids(block_ids).ok()
+    } else {
+        None
+    };
+
+    let mut last_active_indices = BTreeMap::new();
+    if let Some(idx) = input.last_active_ext {
+        last_active_indices.insert(KeychainKind::External, idx as u32);
+    }
+    if let Some(idx) = input.last_active_int {
+        last_active_indices.insert(KeychainKind::Internal, idx as u32);
+    }
+
+    let update = Update {
+        tx_update,
+        chain,
+        last_active_indices,
+    };
+
+    let _ = wallet.apply_update(update);
+
+    // Invariant: total confirmed balance never exceeds the 21M BTC supply cap.
+    assert!(wallet.balance().total().to_sat() <= MAX_SATS);
+});

--- a/fuzz/fuzz_targets/create_tx.rs
+++ b/fuzz/fuzz_targets/create_tx.rs
@@ -1,0 +1,91 @@
+//! Fuzz target: build transactions from a funded wallet with arbitrary parameters.
+//!
+//! The wallet is pre-funded with a deterministic UTXO. The fuzzer then drives
+//! `build_tx` with arbitrary fee rates, recipient amounts, drain options and
+//! sign options. `CreateTxError` and similar errors are expected; panics are not.
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bdk_wallet_fuzz::{create_wallet, funding_update};
+use libfuzzer_sys::fuzz_target;
+
+use bdk_wallet::{
+    bitcoin::{Amount, FeeRate, Sequence},
+    KeychainKind, SignOptions,
+};
+
+/// Bounded fee rate: 1 – 100_000 sat/kwu (~400 sat/vb max).
+const MAX_FEE_SAT_KWU: u64 = 100_000;
+/// Funding UTXO value.
+const FUND_SATS: u64 = 100_000;
+
+#[derive(Arbitrary, Debug)]
+struct FuzzedTxParams {
+    /// Satoshi amount to send to the recipient (before clamping).
+    send_sats: u64,
+    /// Fee rate in sat/kwu. Zero means "use default".
+    fee_sat_kwu: u64,
+    /// Use drain-wallet mode instead of a specific recipient amount.
+    drain_wallet: bool,
+    /// Enable RBF signalling.
+    enable_rbf: bool,
+    /// Try to sign the resulting PSBT.
+    sign: bool,
+    /// Recipient keychain index (0–9) so we can derive distinct addresses.
+    recipient_index: u8,
+    /// Use absolute fee instead of fee rate.
+    use_absolute_fee: bool,
+    /// Absolute fee in satoshis (only used when `use_absolute_fee` is true).
+    absolute_fee_sats: u64,
+}
+
+fuzz_target!(|params: FuzzedTxParams| {
+    let mut wallet = create_wallet();
+
+    let update = funding_update(&wallet, FUND_SATS, 1);
+    if wallet.apply_update(update).is_err() {
+        return;
+    }
+
+    // Derive recipient and drain addresses from fixed indices to avoid borrow conflicts.
+    let recipient_idx = params.recipient_index as u32 % 10 + 1; // indices 1–10
+    let recipient_script = wallet
+        .peek_address(KeychainKind::External, recipient_idx)
+        .script_pubkey();
+    let drain_script = wallet
+        .peek_address(KeychainKind::External, recipient_idx + 10)
+        .script_pubkey();
+
+    let send_sats = params.send_sats.clamp(1, FUND_SATS);
+
+    let mut builder = wallet.build_tx();
+
+    if params.drain_wallet {
+        builder.drain_wallet().drain_to(drain_script);
+    } else {
+        builder.add_recipient(recipient_script, Amount::from_sat(send_sats));
+    }
+
+    if params.enable_rbf {
+        // RBF is signalled by setting nSequence <= 0xFFFFFFFD.
+        builder.set_exact_sequence(Sequence::ENABLE_RBF_NO_LOCKTIME);
+    }
+
+    if params.use_absolute_fee {
+        let abs_fee = params.absolute_fee_sats.min(FUND_SATS);
+        builder.fee_absolute(Amount::from_sat(abs_fee));
+    } else {
+        let rate = params.fee_sat_kwu.clamp(1, MAX_FEE_SAT_KWU);
+        builder.fee_rate(FeeRate::from_sat_per_kwu(rate));
+    }
+
+    let mut psbt = match builder.finish() {
+        Ok(psbt) => psbt,
+        Err(_) => return, // CreateTxError variants are expected
+    };
+
+    if params.sign {
+        // Errors from sign are also expected (e.g. missing key, missing UTXO).
+        let _ = wallet.sign(&mut psbt, SignOptions::default());
+    }
+});

--- a/fuzz/fuzz_targets/descriptor_parse.rs
+++ b/fuzz/fuzz_targets/descriptor_parse.rs
@@ -1,0 +1,26 @@
+//! Fuzz target: parse arbitrary byte strings as Bitcoin output descriptors.
+//!
+//! Exercises BDK's descriptor parsing and validation pipeline — including
+//! miniscript type-checking, key derivation path validation, and checksum
+//! verification — for both mainnet and testnet network kinds.
+//! Any panic is a bug; parse errors are expected and ignored.
+#![no_main]
+
+use bdk_wallet::{
+    bitcoin::{secp256k1::Secp256k1, NetworkKind},
+    descriptor::IntoWalletDescriptor,
+};
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(s) = std::str::from_utf8(data) else {
+        return;
+    };
+
+    // IntoWalletDescriptor requires Secp256k1<All> for signing-capable context.
+    let secp = Secp256k1::new();
+
+    // Try both network kinds so we exercise both mainnet and testnet key parsing.
+    let _ = s.into_wallet_descriptor(&secp, NetworkKind::Main);
+    let _ = s.into_wallet_descriptor(&secp, NetworkKind::Test);
+});

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -1,0 +1,75 @@
+use bdk_wallet::{
+    bitcoin::{absolute::LockTime, hashes::Hash, transaction::Version, Amount, BlockHash, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid},
+    chain::{BlockId, CheckPoint, ConfirmationBlockTime, TxUpdate},
+    KeychainKind, Update, Wallet,
+};
+use std::{collections::BTreeMap, sync::Arc};
+
+pub const EXTERNAL_DESC: &str = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/1'/0'/0/*)";
+pub const INTERNAL_DESC: &str = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/1'/0'/1/*)";
+pub const NETWORK: bdk_wallet::bitcoin::Network = bdk_wallet::bitcoin::Network::Regtest;
+
+/// Creates a fresh wallet (no persistence) using deterministic test descriptors.
+pub fn create_wallet() -> Wallet {
+    Wallet::create(EXTERNAL_DESC, INTERNAL_DESC)
+        .network(NETWORK)
+        .create_wallet_no_persist()
+        .expect("valid descriptors")
+}
+
+/// Builds a minimal valid P2WPKH output script from a 20-byte hash.
+pub fn p2wpkh_script(hash: [u8; 20]) -> ScriptBuf {
+    let mut v = vec![0x00u8, 0x14u8]; // OP_0 PUSH20
+    v.extend_from_slice(&hash);
+    ScriptBuf::from_bytes(v)
+}
+
+/// Builds an `Update` that funds the wallet at external index 0 with `value` sats,
+/// confirmed at height `height`. Used by `create_tx` to seed UTXOs.
+pub fn funding_update(wallet: &Wallet, value: u64, height: u32) -> Update {
+    let receive_script = wallet
+        .peek_address(KeychainKind::External, 0)
+        .script_pubkey();
+
+    let tx = Transaction {
+        version: Version::ONE,
+        lock_time: LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: OutPoint {
+                txid: Txid::from_byte_array([0xab; 32]),
+                vout: 0,
+            },
+            sequence: Sequence::MAX,
+            ..Default::default()
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(value),
+            script_pubkey: receive_script,
+        }],
+    };
+
+    let txid = tx.compute_txid();
+    let genesis_hash = wallet.latest_checkpoint().hash();
+
+    let mut tx_update = TxUpdate::<ConfirmationBlockTime>::default();
+    tx_update.txs = vec![Arc::new(tx)];
+    tx_update.anchors.insert((
+        ConfirmationBlockTime {
+            block_id: BlockId { height, hash: BlockHash::all_zeros() },
+            confirmation_time: 1_600_000_000,
+        },
+        txid,
+    ));
+
+    let chain = CheckPoint::from_block_ids([
+        BlockId { height: 0, hash: genesis_hash },
+        BlockId { height, hash: BlockHash::all_zeros() },
+    ])
+    .ok();
+
+    Update {
+        tx_update,
+        chain,
+        last_active_indices: BTreeMap::from([(KeychainKind::External, 0)]),
+    }
+}


### PR DESCRIPTION
### Description

Adds initial fuzz testing infrastructure to address #61. Built around `cargo-fuzz` (LibFuzzer), with three focused targets and CI integration.

**New `fuzz/` crate with three targets:**

`apply_update` — structure-aware fuzzing of `Wallet::apply_update`. Generates arbitrary transactions, confirmation anchors, mempool timestamps, and chain checkpoints using the `Arbitrary` derive macro. After each run, asserts that the total wallet balance doesn't exceed 21M BTC.

`create_tx` — seeds the wallet with a known 100k-sat UTXO, then drives `build_tx` with arbitrary fee rates, amounts, drain mode, RBF signalling, and signing. `CreateTxError` variants are expected and swallowed — panics are bugs.

`descriptor_parse` — feeds arbitrary byte strings through `IntoWalletDescriptor` for both `NetworkKind::Main` and `NetworkKind::Test`. Exercises the full descriptor parsing pipeline: miniscript type-checking, key path validation, checksum verification.

Shared helpers (`create_wallet`, `funding_update`, `p2wpkh_script`) live in `fuzz/src/lib.rs` to keep new targets clean.

**CI:**

- `fuzz/` is a workspace member but excluded from all normal `cargo build/test/clippy/doc` runs so MSRV and no-std checks aren't affected.
- New `fuzz.yml` workflow builds all targets on every PR (catches compile regressions) and runs each for 60 seconds on a weekly schedule, uploading crash artifacts on failure.

**Running locally:**

```bash
cargo install cargo-fuzz
cargo +nightly fuzz run apply_update
cargo +nightly fuzz run create_tx
cargo +nightly fuzz run descriptor_parse