### PR TITLE
fix(signer): respect allow_all_sighashes in SignerWrapper::sign_input

### DIFF
--- a/src/wallet/signer.rs
+++ b/src/wallet/signer.rs
@@ -91,6 +91,7 @@ use core::ops::{Bound::Included, Deref};
 
 use bitcoin::bip32::{ChildNumber, DerivationPath, Fingerprint, Xpriv};
 use bitcoin::hashes::hash160;
+use bitcoin::psbt::PsbtSighashType;
 use bitcoin::secp256k1::Message;
 use bitcoin::sighash::{EcdsaSighashType, TapSighash, TapSighashType};
 use bitcoin::{ecdsa, psbt, sighash, taproot};
@@ -154,10 +155,10 @@ pub enum SignerError {
     MissingWitnessScript,
     /// The fingerprint and derivation path are missing from the psbt input
     MissingHdKeypath,
-    /// The psbt contains a non-`SIGHASH_ALL` sighash in one of its input and the user hasn't
+    /// The PSBT contains a non-`SIGHASH_ALL` sighash in one of its inputs and the user hasn't
     /// explicitly allowed them
     ///
-    /// To enable signing transactions with non-standard sighashes set
+    /// To enable signing transactions with non-`SIGHASH_ALL` set
     /// [`SignOptions::allow_all_sighashes`] to `true`.
     NonStandardSighash,
     /// Invalid SIGHASH for the signing context in use
@@ -462,6 +463,28 @@ impl InputSigner for SignerWrapper<PrivateKey> {
             || psbt.inputs[input_index].final_script_witness.is_some()
         {
             return Ok(());
+        }
+
+        fn is_sighash_all(ctx: SignerContext, sighash_type: PsbtSighashType) -> bool {
+            match ctx {
+                SignerContext::Legacy | SignerContext::Segwitv0 => {
+                    matches!(sighash_type.ecdsa_hash_ty(), Ok(EcdsaSighashType::All))
+                }
+                SignerContext::Tap { .. } => {
+                    matches!(
+                        sighash_type.taproot_hash_ty(),
+                        Ok(TapSighashType::All) | Ok(TapSighashType::Default)
+                    )
+                }
+            }
+        }
+
+        if !sign_options.allow_all_sighashes {
+            if let Some(sht) = psbt.inputs[input_index].sighash_type {
+                if !is_sighash_all(self.ctx, sht) {
+                    return Err(SignerError::NonStandardSighash);
+                }
+            }
         }
 
         let pubkey = PublicKey::from_private_key(secp, self);
@@ -1008,6 +1031,100 @@ mod signers_container_tests {
 
         // Can't find anything with ID that doesn't exist
         assert_matches!(signers.find(id_nonexistent), None);
+    }
+
+    #[test]
+    fn sign_input_rejects_non_standard_sighash() {
+        use bitcoin::{
+            absolute, psbt::Input, sighash::TapSighashType, transaction, Amount, OutPoint,
+            PrivateKey, ScriptBuf, Sequence, TxIn, TxOut, Witness,
+        };
+
+        let secp = Secp256k1::new();
+
+        // Build a private key and derive its x-only pubkey for taproot
+        let tprv = bip32::Xpriv::from_str(TPRV0_STR).unwrap();
+        let priv_key = PrivateKey::new(tprv.private_key, bitcoin::NetworkKind::Test);
+        let pubkey = priv_key.public_key(&secp);
+        let x_only = bitcoin::key::XOnlyPublicKey::from(pubkey.inner);
+
+        // Wrap as a taproot signer treating this key as the internal key
+        let signer = SignerWrapper::new(
+            priv_key,
+            SignerContext::Tap {
+                is_internal_key: true,
+            },
+        );
+
+        // Build a minimal unsigned transaction with one input
+        let unsigned_tx = bitcoin::Transaction {
+            version: transaction::Version::TWO,
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint::null(),
+                script_sig: ScriptBuf::default(),
+                sequence: Sequence::MAX,
+                witness: Witness::default(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(90_000),
+                script_pubkey: ScriptBuf::default(),
+            }],
+        };
+
+        // Build a base PSBT from the unsigned transaction to be cloned for each assertion
+        let mut base_psbt = bitcoin::Psbt::from_unsigned_tx(unsigned_tx).unwrap();
+        base_psbt.inputs[0] = Input {
+            tap_internal_key: Some(x_only),
+            witness_utxo: Some(TxOut {
+                value: Amount::from_sat(100_000),
+                script_pubkey: ScriptBuf::default(),
+            }),
+            ..Default::default()
+        };
+
+        let opts_reject = SignOptions {
+            allow_all_sighashes: false,
+            ..Default::default()
+        };
+
+        let opts_allow = SignOptions {
+            allow_all_sighashes: true,
+            ..Default::default()
+        };
+
+        // SIGHASH_NONE + allow_all_sighashes: false -> must reject
+        let mut psbt = base_psbt.clone();
+        psbt.inputs[0].sighash_type = Some(TapSighashType::None.into());
+        assert_matches!(
+            signer.sign_input(&mut psbt, 0, &opts_reject, &secp),
+            Err(SignerError::NonStandardSighash),
+            "expected NonStandardSighash when allow_all_sighashes is false"
+        );
+
+        // SIGHASH_ALL + allow_all_sighashes: false -> must pass guard
+        let mut psbt = base_psbt.clone();
+        psbt.inputs[0].sighash_type = Some(TapSighashType::All.into());
+        assert!(
+            signer.sign_input(&mut psbt, 0, &opts_reject, &secp).is_ok(),
+            "SIGHASH_ALL should not be rejected when allow_all_sighashes is false"
+        );
+
+        // SIGHASH_DEFAULT + allow_all_sighashes: false -> must pass guard
+        let mut psbt = base_psbt.clone();
+        psbt.inputs[0].sighash_type = Some(TapSighashType::Default.into());
+        assert!(
+            signer.sign_input(&mut psbt, 0, &opts_reject, &secp).is_ok(),
+            "SIGHASH_DEFAULT should not be rejected when allow_all_sighashes is false"
+        );
+
+        // SIGHASH_NONE + allow_all_sighashes: true -> guard must not reject
+        let mut psbt = base_psbt.clone();
+        psbt.inputs[0].sighash_type = Some(TapSighashType::None.into());
+        assert!(
+            signer.sign_input(&mut psbt, 0, &opts_allow, &secp).is_ok(),
+            "expected guard to pass when allow_all_sighashes is true"
+        );
     }
 
     #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description
`SignOptions::allow_all_sighashes` is documented as controlling whether the signer will accept non-`SIGHASH_ALL`    sighash types. However, the check only existed inside `Wallet::sign` as a PSBT-wide pre-flight guard. The underlying `SignerWrapper<PrivateKey>::sign_input` never consulted it, meaning callers using `InputSigner` or `TransactionSigner` directly could bypass the check entirely.

Added a sighash guard in `SignerWrapper<PrivateKey>::sign_input` before the `match self.ctx` dispatch. This ensures the check covers all signing contexts (Legacy, Segwitv0, Taproot) and all delegating implementations in a single place.

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Tests Added

- Taproot input with `SIGHASH_NONE` and `allow_all_sighashes: false` returns `NonStandardSighash`
- Same setup with `allow_all_sighashes: true` passes the guard successfully

Fixes #469 

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `just p` before pushing

#### New Features:

* N/A

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
