### PR TITLE
fix(wallet): add support for bip-431 rule 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ test-utils = ["std", "anyhow", "tempfile"]
 [dev-dependencies]
 anyhow = "1"
 assert_matches = "1.5.0"
+bdk_testenv = { version = "0.13.1" }
 bdk_bitcoind_rpc = { version = "0.22.0" }
 bdk_electrum = { version = "0.23.2" }
 bdk_esplora = { version = "0.22.1", features = ["async-https", "blocking-https", "tokio"] }
@@ -77,3 +78,7 @@ name = "esplora_blocking"
 
 [[example]]
 name = "bitcoind_rpc"
+
+# override `bdk_testenv` to the latest one, as it's the one that have `bitcoind v0.28`
+[patch.crates-io]
+bdk_testenv = { git = "https://github.com/bitcoindevkit/bdk.git", branch = "master", package = "bdk_testenv" }

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -41,8 +41,9 @@ use bitcoin::{
     psbt,
     secp256k1::Secp256k1,
     sighash::{EcdsaSighashType, TapSighashType},
-    transaction, Address, Amount, Block, FeeRate, Network, NetworkKind, OutPoint, Psbt, ScriptBuf,
-    Sequence, SignedAmount, Transaction, TxOut, Txid, Weight, Witness,
+    transaction::{self, Version},
+    Address, Amount, Block, FeeRate, Network, NetworkKind, OutPoint, Psbt, ScriptBuf, Sequence,
+    SignedAmount, Transaction, TxOut, Txid, Weight, Witness,
 };
 use miniscript::{
     descriptor::KeyMap,
@@ -1429,7 +1430,7 @@ impl Wallet {
         let (required_utxos, optional_utxos) = {
             // NOTE: manual selection overrides unspendable
             let mut required: Vec<WeightedUtxo> = params.utxos.clone();
-            let optional = self.filter_utxos(&params, current_height.to_consensus_u32());
+            let optional = self.filter_utxos(&params, current_height.to_consensus_u32(), version);
 
             // If `drain_wallet` is true, all UTxOs are required.
             if params.drain_wallet {
@@ -1978,7 +1979,12 @@ impl Wallet {
 
     /// Given the options returns the list of utxos that must be used to form the
     /// transaction and any further that may be used if needed.
-    fn filter_utxos(&self, params: &TxParams, current_height: u32) -> Vec<WeightedUtxo> {
+    fn filter_utxos(
+        &self,
+        params: &TxParams,
+        current_height: u32,
+        version: Version,
+    ) -> Vec<WeightedUtxo> {
         if params.manually_selected_only {
             vec![]
         // Only process optional UTxOs if manually_selected_only is false.
@@ -1988,6 +1994,7 @@ impl Wallet {
                 .iter()
                 .map(|wutxo| wutxo.utxo.outpoint())
                 .collect::<HashSet<OutPoint>>();
+
             self.tx_graph
                 .graph()
                 // Get all unspent UTxOs from wallet.
@@ -2006,6 +2013,29 @@ impl Wallet {
                     full_txo
                         .is_mature(current_height)
                         .then(|| new_local_utxo(k, i, full_txo))
+                })
+                // only add to optional UTXOs those that follows BIP-431 (TRUC) specification.
+                // see https://github.com/bitcoin/bips/blob/master/bip-0431.mediawiki#specification
+                .filter(|local_output| {
+                    local_output.chain_position.is_confirmed()
+                        || match self.tx_graph().get_tx(local_output.outpoint.txid) {
+                            Some(ancestor_tx) => match is_truc(version) {
+                                // if building TRUC; filter out all unconfirmed non-TRUC.
+                                true => {
+                                    is_truc(ancestor_tx.version)
+                                        && local_output.chain_position.is_unconfirmed()
+                                }
+                                // if building non-TRUC; filter out all unconfirmed TRUC.
+                                false => {
+                                    !is_truc(ancestor_tx.version)
+                                        && local_output.chain_position.is_unconfirmed()
+                                }
+                            },
+                            // if we don't have the full tx available we can't assure the ancestor
+                            // tx version it assumes it's a valid
+                            // candidate.
+                            None => true,
+                        }
                 })
                 // only process UTXOs not selected manually, they will be considered later in the
                 // chain
@@ -2885,6 +2915,12 @@ fn make_indexed_graph(
     Ok(indexed_graph)
 }
 
+/// Check if the given [`transaction::Version`] is TRUC (Topologically Restricted Until
+/// Confirmation)s.
+fn is_truc(version: transaction::Version) -> bool {
+    version.eq(&Version(3))
+}
+
 /// Transforms a [`FeeRate`] to `f64` with unit as sat/vb.
 #[macro_export]
 #[doc(hidden)]
@@ -2981,8 +3017,13 @@ mod test {
         let mut builder = wallet.build_tx();
         builder.add_utxo(outpoint).expect("should add local utxo");
         let params = builder.params.clone();
+        let version = params.version.unwrap_or(Version::TWO);
         // enforce selection of first output in transaction
-        let received = wallet.filter_utxos(&params, wallet.latest_checkpoint().block_id().height);
+        let received = wallet.filter_utxos(
+            &params,
+            wallet.latest_checkpoint().block_id().height,
+            version,
+        );
         // Notice expected doesn't include the first output from two_output_tx as it should be
         // filtered out.
         let expected = vec![wallet

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -41,8 +41,9 @@ use bitcoin::{
     psbt,
     secp256k1::Secp256k1,
     sighash::{EcdsaSighashType, TapSighashType},
-    transaction, Address, Amount, Block, FeeRate, Network, NetworkKind, OutPoint, Psbt, ScriptBuf,
-    Sequence, SignedAmount, Transaction, TxOut, Txid, Weight, Witness,
+    transaction::{self, Version},
+    Address, Amount, Block, FeeRate, Network, NetworkKind, OutPoint, Psbt, ScriptBuf, Sequence,
+    SignedAmount, Transaction, TxOut, Txid, Weight, Witness,
 };
 use miniscript::{
     descriptor::KeyMap,
@@ -1429,7 +1430,7 @@ impl Wallet {
         let (required_utxos, optional_utxos) = {
             // NOTE: manual selection overrides unspendable
             let mut required: Vec<WeightedUtxo> = params.utxos.clone();
-            let optional = self.filter_utxos(&params, current_height.to_consensus_u32());
+            let optional = self.filter_utxos(&params, current_height.to_consensus_u32(), version);
 
             // If `drain_wallet` is true, all UTxOs are required.
             if params.drain_wallet {
@@ -2095,7 +2096,12 @@ impl Wallet {
 
     /// Given the options returns the list of utxos that must be used to form the
     /// transaction and any further that may be used if needed.
-    fn filter_utxos(&self, params: &TxParams, current_height: u32) -> Vec<WeightedUtxo> {
+    fn filter_utxos(
+        &self,
+        params: &TxParams,
+        current_height: u32,
+        version: Version,
+    ) -> Vec<WeightedUtxo> {
         if params.manually_selected_only {
             vec![]
         // Only process optional UTxOs if manually_selected_only is false.
@@ -2105,6 +2111,7 @@ impl Wallet {
                 .iter()
                 .map(|wutxo| wutxo.utxo.outpoint())
                 .collect::<HashSet<OutPoint>>();
+
             self.tx_graph
                 .graph()
                 // Get all unspent UTxOs from wallet.
@@ -2123,6 +2130,21 @@ impl Wallet {
                     full_txo
                         .is_mature(current_height)
                         .then(|| new_local_utxo(k, i, full_txo))
+                })
+                // Only add to optional UTXOs those that follows BIP-431 (TRUC) specification.
+                // see https://github.com/bitcoin/bips/blob/master/bip-0431.mediawiki#specification
+                .filter(|local_output| {
+                    // If the output is confirmed, it can be spent by either non-TRUC/TRUC
+                    // transactions.
+                    if local_output.chain_position.is_confirmed() {
+                        return true;
+                    }
+
+                    // If building TRUC (V3), the unconfirmed outputs MUST be TRUC (V3). Otherwise,
+                    // if building a non-TRUC, the unconfirmed outputs MUST be non-TRUC.
+                    self.tx_graph()
+                        .get_tx(local_output.outpoint.txid)
+                        .is_some_and(|tx| (tx.version == Version(3)) == (version == Version(3)))
                 })
                 // only process UTXOs not selected manually, they will be considered later in the
                 // chain
@@ -3104,8 +3126,13 @@ mod test {
         let mut builder = wallet.build_tx();
         builder.add_utxo(outpoint).expect("should add local utxo");
         let params = builder.params.clone();
+        let version = params.version.unwrap_or(Version::TWO);
         // enforce selection of first output in transaction
-        let received = wallet.filter_utxos(&params, wallet.latest_checkpoint().block_id().height);
+        let received = wallet.filter_utxos(
+            &params,
+            wallet.latest_checkpoint().block_id().height,
+            version,
+        );
         // Notice expected doesn't include the first output from two_output_tx as it should be
         // filtered out.
         let expected = vec![wallet

--- a/src/wallet/tx_builder.rs
+++ b/src/wallet/tx_builder.rs
@@ -322,6 +322,10 @@ impl<'a, Cs> TxBuilder<'a, Cs> {
     ///
     /// These have priority over the "unspendable" UTXOs, meaning that if a UTXO is present both in
     /// the "UTXOs" and the "unspendable" list, it will be spent.
+    ///
+    /// Manually selected UTXOs bypass optional-UTXO filtering (for example TRUC version
+    /// compatibility checks). Callers must ensure any manually selected unconfirmed UTXO is valid
+    /// for the transaction version being built.
     pub fn add_utxo(&mut self, outpoint: OutPoint) -> Result<&mut Self, AddUtxoError> {
         self.add_utxos(&[outpoint])
     }
@@ -338,6 +342,10 @@ impl<'a, Cs> TxBuilder<'a, Cs> {
     /// UTXOs through the [`TxBuilder::add_utxo`] method.
     /// A manually added local UTXO will always have greater precedence than a foreign UTXO. No
     /// matter if it was added before or after the foreign UTXO.
+    ///
+    /// Manually selected UTXOs bypass optional-UTXO filtering (for example TRUC version
+    /// compatibility checks). Callers must ensure any manually selected unconfirmed UTXO is valid
+    /// for the transaction version being built.
     ///
     /// At a minimum to add a foreign UTXO we need:
     ///

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -1,8 +1,10 @@
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use assert_matches::assert_matches;
 use bdk_chain::{BlockId, CanonicalizationParams, ConfirmationBlockTime};
+use bdk_testenv::TestEnv;
 use bdk_wallet::coin_selection;
 use bdk_wallet::descriptor::{calc_checksum, DescriptorError};
 use bdk_wallet::error::CreateTxError;
@@ -16,6 +18,7 @@ use bitcoin::hashes::Hash;
 use bitcoin::script::PushBytesBuf;
 use bitcoin::sighash::{EcdsaSighashType, TapSighashType};
 use bitcoin::taproot::TapNodeHash;
+use bitcoin::transaction::Version;
 use bitcoin::{
     absolute, transaction, Address, Amount, BlockHash, FeeRate, Network, OutPoint, ScriptBuf,
     Sequence, SignedAmount, Transaction, TxIn, TxOut, Txid,
@@ -3006,4 +3009,174 @@ fn test_tx_ordering_untouched_preserves_insertion_ordering_bnb_success() {
         vec![outpoint_0, outpoint_1],
         "UTXOs should be ordered with required first, then selected"
     );
+}
+
+#[test]
+fn test_create_and_spend_from_truc_tx() -> anyhow::Result<()> {
+    let env = TestEnv::new().expect("should create `TestEnv` successfully!");
+
+    let _ = env
+        .mine_blocks(101, None)
+        .expect("should mine blocks successfully!");
+
+    let (descriptor, change_descriptor) = get_test_wpkh_and_change_desc();
+    let mut wallet = Wallet::create(descriptor, change_descriptor)
+        .network(Network::Regtest)
+        .create_wallet_no_persist()
+        .expect("should create wallet successfully!");
+
+    let recv_addr = wallet.next_unused_address(KeychainKind::External);
+
+    // add funds to the wallet (two 250k sats UTXOs)
+    let _ = env
+        .send(&recv_addr, Amount::from_sat(250_000))
+        .expect("should fund wallet successfully!");
+    let _ = env
+        .send(&recv_addr, Amount::from_sat(250_000))
+        .expect("should fund wallet successfully!");
+
+    // mine block that confirms tx
+    let _ = env.mine_blocks(6, None)?;
+    env.wait_until_electrum_sees_block(Duration::from_secs(6))?;
+
+    let balance = wallet.balance();
+    assert_eq!(
+        balance.total(),
+        Amount::ZERO,
+        "wallet balance SHOULD be zero before any scan/sync"
+    );
+
+    // wallet full scan
+    let electrum_client = bdk_electrum::BdkElectrumClient::new(env.electrum_client());
+
+    let request = wallet.start_full_scan();
+    let response = electrum_client
+        .full_scan(request, 50, 5, true)
+        .expect("should execute full scan successfully!");
+
+    wallet.apply_update(response)?;
+
+    let balance = wallet.balance();
+    assert_eq!(
+        balance.total(),
+        Amount::from_sat(500_000),
+        "wallet balance SHOULD be 500K after initial full scan"
+    );
+
+    // should be able to create/broadcast TRUC (v3) transactions.
+
+    // create txA (TRUC)
+    let recv_addr = wallet.next_unused_address(KeychainKind::External);
+
+    let mut builder = wallet.build_tx();
+    builder.add_recipient(recv_addr.script_pubkey(), Amount::from_sat(50_000));
+    builder.version(3);
+
+    let mut psbt = builder.finish().expect("should create txA (TRUC) successfully! as per BIP-431 it can spend confirmed outputs from non-TRUC txs.");
+
+    let _ = wallet.sign(&mut psbt, SignOptions::default())?;
+    let tx_a = psbt.extract_tx()?;
+
+    // broadcast txA (TRUC)
+    let txid_a = electrum_client
+        .transaction_broadcast(&tx_a)
+        .expect("should broadcast txA (TRUC) successfully!");
+    let _ = env.wait_until_electrum_sees_txid(txid_a, Duration::from_secs(6));
+
+    // wallet sync
+    let request = wallet.start_sync_with_revealed_spks();
+    let response = electrum_client
+        .sync(request, 5, true)
+        .expect("should execute sync successfully!");
+
+    wallet.apply_update(response)?;
+
+    let balance = wallet.balance();
+    assert_eq!(
+        balance.untrusted_pending,
+        Amount::from_sat(50_000),
+        "wallet balance SHOULD have 50K unconfirmed UTXO after sync!"
+    );
+
+    // create txB (non-TRUC)
+    let recv_addr = wallet.next_unused_address(KeychainKind::External);
+
+    let mut builder = wallet.build_tx();
+    builder.add_recipient(recv_addr.script_pubkey(), Amount::from_sat(50_000));
+
+    let mut psbt = builder
+        .finish()
+        .expect("SHOULD create txB (non-TRUC) successfully! However, a non-TRUC transaction can only spend confirmed outputs from TRUC transactions");
+
+    let _ = wallet.sign(&mut psbt, SignOptions::default());
+    let tx_b = psbt.extract_tx()?;
+
+    // broadcast txB (non-TRUC)
+    let txid_b = electrum_client.transaction_broadcast(&tx_b);
+    assert!(
+        matches!(
+            txid_b,
+            Err(e) if e.to_string().contains("TRUC-violation")
+                && e.to_string().contains("non-version=3 tx")
+                && e.to_string().contains("cannot spend from version=3 tx")
+        ),
+        "SHOULD fail if it's trying to spend an unconfirmed TRUC output in a non-TRUC tx!"
+    );
+
+    // create txB filtering out unconfirmed TRUC
+
+    // all unconfirmed-TRUC UTXOs
+    let tx_graph = wallet.tx_graph();
+    let chain = wallet.local_chain();
+    let chain_tip = chain.tip().block_id();
+    let params = CanonicalizationParams::default();
+    let txouts = wallet.spk_index().outpoints().iter().cloned();
+
+    let utxos = tx_graph
+        .filter_chain_unspents(chain, chain_tip, params, txouts)
+        .filter(|(_, ftxo)| ftxo.chain_position.is_unconfirmed())
+        .filter(|(_, ftxo)| {
+            tx_graph
+                .get_tx(ftxo.outpoint.txid)
+                .map(|tx| tx.version.eq(&Version(3)))
+                .unwrap_or(false)
+        })
+        .map(|(_, ftxo)| ftxo.outpoint)
+        .collect::<Vec<_>>();
+
+    let mut builder = wallet.build_tx();
+    builder.add_recipient(recv_addr.script_pubkey(), Amount::from_sat(50_000));
+    utxos.iter().for_each(|utxo| {
+        builder.add_unspendable(*utxo);
+    });
+
+    let mut psbt = builder
+        .finish()
+        .expect("SHOULD create txB (non-TRUC) successfully! However, a non-TRUC transaction can only spend confirmed outputs from TRUC transactions");
+
+    let _ = wallet.sign(&mut psbt, SignOptions::default());
+    let tx_b = psbt.extract_tx()?;
+
+    // broadcast txB (non-TRUC)
+    let txid_b = electrum_client
+        .transaction_broadcast(&tx_b)
+        .expect("should broadcast txB (non-TRUC) successfully!");
+    let _ = env.wait_until_electrum_sees_txid(txid_b, Duration::from_secs(6));
+
+    // wallet sync
+    let request = wallet.start_sync_with_revealed_spks();
+    let response = electrum_client
+        .sync(request, 5, true)
+        .expect("should execute sync successfully!");
+
+    wallet.apply_update(response)?;
+
+    let balance = wallet.balance();
+    assert_eq!(
+        balance.untrusted_pending,
+        Amount::from_sat(100_000),
+        "wallet balance SHOULD have 100K unconfirmed UTXO after sync!"
+    );
+
+    Ok(())
 }

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use assert_matches::assert_matches;
 use bdk_chain::{BlockId, CanonicalizationParams, ConfirmationBlockTime};
 use bdk_testenv::TestEnv;
-use bdk_wallet::coin_selection;
+use bdk_wallet::coin_selection::{self, InsufficientFunds};
 use bdk_wallet::descriptor::{calc_checksum, DescriptorError};
 use bdk_wallet::error::CreateTxError;
 use bdk_wallet::psbt::PsbtUtils;
@@ -18,7 +18,6 @@ use bitcoin::hashes::Hash;
 use bitcoin::script::PushBytesBuf;
 use bitcoin::sighash::{EcdsaSighashType, TapSighashType};
 use bitcoin::taproot::TapNodeHash;
-use bitcoin::transaction::Version;
 use bitcoin::{
     absolute, transaction, Address, Amount, BlockHash, FeeRate, Network, OutPoint, ScriptBuf,
     Sequence, SignedAmount, Transaction, TxIn, TxOut, Txid,
@@ -3063,13 +3062,15 @@ fn test_create_and_spend_from_truc_tx() -> anyhow::Result<()> {
         "wallet balance SHOULD be 500K after initial full scan"
     );
 
-    // should be able to create/broadcast TRUC (v3) transactions.
+    // Should be able to create/broadcast TRUC (v3) transactions.
+    // NOTE: "A TRUC transaction can spend outputs from confirmed non-TRUC transactions. A non-TRUC
+    // transaction can spend outputs from confirmed TRUC transactions" See, rule #2: https://github.com/bitcoin/bips/blob/master/bip-0431.mediawiki#specification
 
     // create txA (TRUC)
     let recv_addr = wallet.next_unused_address(KeychainKind::External);
 
     let mut builder = wallet.build_tx();
-    builder.add_recipient(recv_addr.script_pubkey(), Amount::from_sat(50_000));
+    builder.add_recipient(recv_addr.script_pubkey(), Amount::from_sat(125_000));
     builder.version(3);
 
     let mut psbt = builder.finish().expect("should create txA (TRUC) successfully! as per BIP-431 it can spend confirmed outputs from non-TRUC txs.");
@@ -3094,15 +3095,15 @@ fn test_create_and_spend_from_truc_tx() -> anyhow::Result<()> {
     let balance = wallet.balance();
     assert_eq!(
         balance.untrusted_pending,
-        Amount::from_sat(50_000),
-        "wallet balance SHOULD have 50K unconfirmed UTXO after sync!"
+        Amount::from_sat(125_000),
+        "wallet balance SHOULD have 125K unconfirmed (TRUC) UTXO after txA sync!"
     );
 
     // create txB (non-TRUC)
     let recv_addr = wallet.next_unused_address(KeychainKind::External);
 
     let mut builder = wallet.build_tx();
-    builder.add_recipient(recv_addr.script_pubkey(), Amount::from_sat(50_000));
+    builder.add_recipient(recv_addr.script_pubkey(), Amount::from_sat(125_000));
 
     let mut psbt = builder
         .finish()
@@ -3111,57 +3112,18 @@ fn test_create_and_spend_from_truc_tx() -> anyhow::Result<()> {
     let _ = wallet.sign(&mut psbt, SignOptions::default());
     let tx_b = psbt.extract_tx()?;
 
-    // broadcast txB (non-TRUC)
-    let txid_b = electrum_client.transaction_broadcast(&tx_b);
+    // txB MUST NOT use the available unconfirmed TRUC UTXO.
     assert!(
-        matches!(
-            txid_b,
-            Err(e) if e.to_string().contains("TRUC-violation")
-                && e.to_string().contains("non-version=3 tx")
-                && e.to_string().contains("cannot spend from version=3 tx")
-        ),
-        "SHOULD fail if it's trying to spend an unconfirmed TRUC output in a non-TRUC tx!"
+        tx_b.input
+            .iter()
+            .all(|txin| txin.previous_output.txid.ne(&txid_a)),
+        "SHOULD NOT try to spend an unconfirmed TRUC output in a non-TRUC tx!"
     );
-
-    // create txB filtering out unconfirmed TRUC
-
-    // all unconfirmed-TRUC UTXOs
-    let tx_graph = wallet.tx_graph();
-    let chain = wallet.local_chain();
-    let chain_tip = chain.tip().block_id();
-    let params = CanonicalizationParams::default();
-    let txouts = wallet.spk_index().outpoints().iter().cloned();
-
-    let utxos = tx_graph
-        .filter_chain_unspents(chain, chain_tip, params, txouts)
-        .filter(|(_, ftxo)| ftxo.chain_position.is_unconfirmed())
-        .filter(|(_, ftxo)| {
-            tx_graph
-                .get_tx(ftxo.outpoint.txid)
-                .map(|tx| tx.version.eq(&Version(3)))
-                .unwrap_or(false)
-        })
-        .map(|(_, ftxo)| ftxo.outpoint)
-        .collect::<Vec<_>>();
-
-    let mut builder = wallet.build_tx();
-    builder.add_recipient(recv_addr.script_pubkey(), Amount::from_sat(50_000));
-    utxos.iter().for_each(|utxo| {
-        builder.add_unspendable(*utxo);
-    });
-
-    let mut psbt = builder
-        .finish()
-        .expect("SHOULD create txB (non-TRUC) successfully! However, a non-TRUC transaction can only spend confirmed outputs from TRUC transactions");
-
-    let _ = wallet.sign(&mut psbt, SignOptions::default());
-    let tx_b = psbt.extract_tx()?;
 
     // broadcast txB (non-TRUC)
     let txid_b = electrum_client
         .transaction_broadcast(&tx_b)
         .expect("should broadcast txB (non-TRUC) successfully!");
-    let _ = env.wait_until_electrum_sees_txid(txid_b, Duration::from_secs(6));
 
     // wallet sync
     let request = wallet.start_sync_with_revealed_spks();
@@ -3174,8 +3136,66 @@ fn test_create_and_spend_from_truc_tx() -> anyhow::Result<()> {
     let balance = wallet.balance();
     assert_eq!(
         balance.untrusted_pending,
-        Amount::from_sat(100_000),
-        "wallet balance SHOULD have 100K unconfirmed UTXO after sync!"
+        Amount::from_sat(250_000),
+        "wallet balance SHOULD have 250K unconfirmed, both non-TRUC (txB) and TRUC (txA) UTXOs after txB sync!"
+    );
+
+    // create txC (TRUC)
+    let recv_addr = wallet.next_unused_address(KeychainKind::External);
+
+    let mut builder = wallet.build_tx();
+    builder.add_recipient(recv_addr.script_pubkey(), Amount::from_sat(200_000));
+    builder.version(3);
+
+    let mut psbt = builder.finish().expect("should create txB (TRUC) successfully! as per BIP-431 it can spend unconfirmed outputs from TRUC txs.");
+
+    let _ = wallet.sign(&mut psbt, SignOptions::default())?;
+    let tx_c = psbt.extract_tx()?;
+
+    // txC MUST ONLY use the available confirmed UTXOs AND/OR unconfirmed TRUC UTXOs.
+    assert!(
+        tx_c.input
+            .iter()
+            .all(|txin| txin.previous_output.txid.ne(&txid_b)),
+        "SHOULD NOT try to spend an unconfirmed non-TRUC output in a TRUC tx!"
+    );
+
+    // broadcast txC (TRUC)
+    let txid_c = electrum_client
+        .transaction_broadcast(&tx_c)
+        .expect("should broadcast txC (TRUC) successfully!");
+    let _ = env.wait_until_electrum_sees_txid(txid_c, Duration::from_secs(6));
+
+    // wallet sync
+    let request = wallet.start_sync_with_revealed_spks();
+    let response = electrum_client
+        .sync(request, 5, true)
+        .expect("should execute sync successfully!");
+
+    wallet.apply_update(response)?;
+
+    let balance = wallet.balance();
+    assert_eq!(
+        balance.untrusted_pending,
+        Amount::from_sat(325_000),
+        "wallet balance SHOULD have 325K unconfirmed UTXOs after sync!"
+    );
+
+    // create txD (non-TRUC)
+    let recv_addr = wallet.next_unused_address(KeychainKind::External);
+
+    let mut builder = wallet.build_tx();
+    builder.add_recipient(recv_addr.script_pubkey(), Amount::from_sat(400_000));
+    builder.version(3);
+
+    let psbt = builder.finish();
+
+    assert!(
+        matches!(
+            psbt,
+            Err(CreateTxError::CoinSelection(InsufficientFunds { .. }))
+        ),
+        "SHOULD fail if it's trying to spend an unconfirmed TRUC output in a non-TRUC tx!"
     );
 
     Ok(())

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use assert_matches::assert_matches;
 use bdk_chain::{BlockId, CanonicalizationParams, ConfirmationBlockTime};
 use bdk_wallet::coin_selection;
+use bdk_wallet::coin_selection::InsufficientFunds;
 use bdk_wallet::descriptor::{calc_checksum, DescriptorError, IntoWalletDescriptor};
 use bdk_wallet::error::CreateTxError;
 use bdk_wallet::psbt::PsbtUtils;
@@ -3330,4 +3331,142 @@ fn test_tx_ordering_untouched_preserves_insertion_ordering_bnb_success() {
         vec![outpoint_0, outpoint_1],
         "UTXOs should be ordered with required first, then selected"
     );
+}
+
+#[test]
+fn test_create_and_spend_from_truc_tx() -> anyhow::Result<()> {
+    let (descriptor, change_descriptor) = get_test_wpkh_and_change_desc();
+    let mut wallet = Wallet::create(descriptor, change_descriptor)
+        .network(Network::Regtest)
+        .create_wallet_no_persist()
+        .expect("should create wallet successfully!");
+
+    // establish a chain tip so confirmed funds can be anchored to a block in the active chain.
+    let block = BlockId {
+        height: 1_000,
+        hash: BlockHash::all_zeros(),
+    };
+    insert_checkpoint(&mut wallet, block);
+    let anchor = ConfirmationBlockTime {
+        block_id: block,
+        confirmation_time: 0,
+    };
+
+    // add funds to the wallet (two 250k sats confirmed UTXOs)
+    receive_output(&mut wallet, Amount::from_sat(250_000), anchor);
+    receive_output(&mut wallet, Amount::from_sat(250_000), anchor);
+
+    let balance = wallet.balance();
+    assert_eq!(
+        balance.total(),
+        Amount::from_sat(500_000),
+        "wallet balance SHOULD be 500K after funding"
+    );
+
+    // Should be able to create TRUC (v3) transactions.
+    // NOTE: "A TRUC transaction can spend outputs from confirmed non-TRUC transactions. A non-TRUC
+    // transaction can spend outputs from confirmed TRUC transactions" See, rule #2: https://github.com/bitcoin/bips/blob/master/bip-0431.mediawiki#specification
+
+    // create txA (TRUC)
+    let recv_addr = wallet.next_unused_address(KeychainKind::External);
+
+    let mut builder = wallet.build_tx();
+    builder.add_recipient(recv_addr.script_pubkey(), Amount::from_sat(125_000));
+    builder.version(3);
+
+    let mut psbt = builder.finish().expect("should create txA (TRUC) successfully! as per BIP-431 it can spend confirmed outputs from non-TRUC txs.");
+
+    let _ = wallet.sign(&mut psbt, SignOptions::default())?;
+    let tx_a = psbt.extract_tx()?;
+    let txid_a = tx_a.compute_txid();
+
+    // "broadcast" txA (TRUC): insert it into the wallet's local view as an unconfirmed tx.
+    insert_tx(&mut wallet, tx_a);
+
+    let balance = wallet.balance();
+    assert_eq!(
+        balance.untrusted_pending,
+        Amount::from_sat(125_000),
+        "wallet balance SHOULD have 125K unconfirmed (TRUC) UTXO after txA!"
+    );
+
+    // create txB (non-TRUC)
+    let recv_addr = wallet.next_unused_address(KeychainKind::External);
+
+    let mut builder = wallet.build_tx();
+    builder.add_recipient(recv_addr.script_pubkey(), Amount::from_sat(125_000));
+
+    let mut psbt = builder
+        .finish()
+        .expect("SHOULD create txB (non-TRUC) successfully! However, a non-TRUC transaction can only spend confirmed outputs from TRUC transactions");
+
+    let _ = wallet.sign(&mut psbt, SignOptions::default());
+    let tx_b = psbt.extract_tx()?;
+
+    // txB MUST NOT use the available unconfirmed TRUC UTXO.
+    assert!(
+        tx_b.input
+            .iter()
+            .all(|txin| txin.previous_output.txid.ne(&txid_a)),
+        "SHOULD NOT try to spend an unconfirmed TRUC output in a non-TRUC tx!"
+    );
+
+    // "broadcast" txB (non-TRUC)
+    let txid_b = tx_b.compute_txid();
+    insert_tx(&mut wallet, tx_b);
+
+    let balance = wallet.balance();
+    assert_eq!(
+        balance.untrusted_pending,
+        Amount::from_sat(250_000),
+        "wallet balance SHOULD have 250K unconfirmed, both non-TRUC (txB) and TRUC (txA) UTXOs after txB!"
+    );
+
+    // create txC (TRUC)
+    let recv_addr = wallet.next_unused_address(KeychainKind::External);
+
+    let mut builder = wallet.build_tx();
+    builder.add_recipient(recv_addr.script_pubkey(), Amount::from_sat(200_000));
+    builder.version(3);
+
+    let mut psbt = builder.finish().expect("should create txC (TRUC) successfully! as per BIP-431 it can spend unconfirmed outputs from TRUC txs.");
+
+    let _ = wallet.sign(&mut psbt, SignOptions::default())?;
+    let tx_c = psbt.extract_tx()?;
+
+    // txC MUST ONLY use the available confirmed UTXOs AND/OR unconfirmed TRUC UTXOs.
+    assert!(
+        tx_c.input
+            .iter()
+            .all(|txin| txin.previous_output.txid.ne(&txid_b)),
+        "SHOULD NOT try to spend an unconfirmed non-TRUC output in a TRUC tx!"
+    );
+
+    // "broadcast" txC (TRUC)
+    insert_tx(&mut wallet, tx_c);
+
+    let balance = wallet.balance();
+    assert_eq!(
+        balance.untrusted_pending,
+        Amount::from_sat(325_000),
+        "wallet balance SHOULD have 325K unconfirmed UTXOs after txC!"
+    );
+
+    // create txD (non-TRUC)
+    let recv_addr = wallet.next_unused_address(KeychainKind::External);
+
+    let mut builder = wallet.build_tx();
+    builder.add_recipient(recv_addr.script_pubkey(), Amount::from_sat(400_000));
+
+    let psbt = builder.finish();
+
+    assert!(
+        matches!(
+            psbt,
+            Err(CreateTxError::CoinSelection(InsufficientFunds { .. }))
+        ),
+        "SHOULD fail if it's trying to spend an unconfirmed TRUC output in a non-TRUC tx!"
+    );
+
+    Ok(())
 }


### PR DESCRIPTION
partially addresses #477
supersedes #442

### Description

Adds support for BIP-431 (TRUC) rule 2 in filter_utxos. When building a transaction, unconfirmed UTXOs are filtered based on version compatibility with the transaction being constructed:

* If building a TRUC (v3) transaction, only unconfirmed outputs from TRUC transactions are eligible as optional UTXOs.
* If building a non-TRUC transaction, only unconfirmed outputs from non-TRUC transactions are eligible as optional UTXOs.
* Confirmed outputs may be spent by either TRUC or non-TRUC transactions regardless of the source transaction's version.

The filter is implemented inline in filter_utxos, which now takes a `version` parameter passed down from the transaction builder. The version compatibility check uses an equality comparison on the `== Version(3)` predicate, ensuring the unconfirmed output's transaction version matches the version class (TRUC or non-TRUC) of the transaction being built.

Note that manually selected UTXOs bypass this filter — callers are responsible for ensuring any manually selected unconfirmed UTXO is compatible with the transaction version being built.

### Changelog notice

```
### Fixed

- fix(wallet): filter unconfirmed UTXOs by BIP-431 (TRUC) rule-2
```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `just p` before pushing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature

#### Bugfixes:

* [x] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
