### PR TITLE
fix(coin_selection): avoid per-utxo fee rounding

### DIFF
--- a/src/wallet/coin_selection.rs
+++ b/src/wallet/coin_selection.rs
@@ -326,17 +326,16 @@ fn select_sorted_utxos(
     drain_script: &Script,
 ) -> Result<CoinSelectionResult, InsufficientFunds> {
     let mut selected_amount = Amount::ZERO;
-    let mut fee_amount = Amount::ZERO;
+    let mut total_weight = Weight::ZERO;
     let selected = utxos
         .scan(
-            (&mut selected_amount, &mut fee_amount),
-            |(selected_amount, fee_amount), (must_use, weighted_utxo)| {
-                if must_use || **selected_amount < target_amount + **fee_amount {
-                    **fee_amount += fee_rate
-                        * TxIn::default()
-                            .segwit_weight()
-                            .checked_add(weighted_utxo.satisfaction_weight)
-                            .expect("`Weight` addition should not cause an integer overflow");
+            (&mut selected_amount, &mut total_weight),
+            |(selected_amount, total_weight), (must_use, weighted_utxo)| {
+                if must_use || **selected_amount < target_amount + fee_rate * **total_weight {
+                    **total_weight += TxIn::default()
+                        .segwit_weight()
+                        .checked_add(weighted_utxo.satisfaction_weight)
+                        .expect("`Weight` addition should not cause an integer overflow");
                     **selected_amount += weighted_utxo.utxo.txout().value;
                     Some(weighted_utxo.utxo)
                 } else {
@@ -346,6 +345,7 @@ fn select_sorted_utxos(
         )
         .collect::<Vec<_>>();
 
+    let fee_amount = fee_rate * total_weight;
     let amount_needed_with_fees = target_amount + fee_amount;
     if selected_amount < amount_needed_with_fees {
         return Err(InsufficientFunds {
@@ -994,6 +994,46 @@ mod test {
         assert_eq!(result.selected.len(), 1);
         assert_eq!(result.selected_amount(), Amount::from_sat(200_000));
         assert_eq!(result.fee_amount, Amount::from_sat(68));
+    }
+
+    #[test]
+    fn test_select_sorted_utxos_accumulates_weight_before_fee() {
+        // Per-input weight of 271 wu makes (1 sat/vb) * weight = 67.75 sat,
+        // so rounding per-utxo gains 0.25 sat each. Selecting 4 such inputs
+        // and summing the floors error 272 sat; computing the fee once on
+        // the accumulated weight yields 271 sat.
+        let satisfaction_weight = Weight::from_wu(106);
+        let input_weight = TxIn::default().segwit_weight() + satisfaction_weight;
+        assert_eq!(input_weight.to_wu(), 271);
+
+        let utxos: Vec<WeightedUtxo> = (0..4)
+            .map(|i| {
+                let mut wu = unconfirmed_utxo(Amount::from_sat(50_000), i, 0);
+                wu.satisfaction_weight = satisfaction_weight;
+                wu
+            })
+            .collect();
+
+        let fee_rate = FeeRate::from_sat_per_vb_u32(1);
+        let drain_script = ScriptBuf::default();
+        let target_amount = Amount::from_sat(190_000);
+
+        let result = LargestFirstCoinSelection
+            .coin_select(
+                utxos,
+                vec![],
+                fee_rate,
+                target_amount,
+                &drain_script,
+                &mut thread_rng(),
+            )
+            .unwrap();
+
+        assert_eq!(result.selected.len(), 4);
+        let expected_fee = fee_rate * (input_weight * 4);
+        let buggy_fee = (fee_rate * input_weight) * 4;
+        assert!(buggy_fee > expected_fee, "test setup must induce rounding");
+        assert_eq!(result.fee_amount, expected_fee);
     }
 
     #[test]


### PR DESCRIPTION
select_sorted_utxos computed fee_rate * weight per utxo and summed
the results. Because FeeRate * Weight ceils to whole sats, each
input added up to 0.999 sats of fractional fee. The error grew
linearly with the input count: at 1 sat/vb on 271-wu inputs
(67.75 sat each), four inputs overpay by 1 sat; ten overpay by
2 sats; large selections drift further.

Accumulate input weight during selection and compute the fee once
on the total. Ceiling now happens at most once for the whole tx,
so the result equals the fee a sender would compute by weighing
the finished transaction and never exceeds the requested fee rate
by more than one sat over the whole transaction.

This was found when comparing fee calculation differences between LDK
and BDK.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `just p` before pushing

#### Bugfixes:

* [x] I've added tests to reproduce the issue which are now passing
