### PR TITLE
feat(wallet)!: include non-canonical txs in wallet history

### DIFF
--- a/examples/bitcoind_rpc.rs
+++ b/examples/bitcoind_rpc.rs
@@ -5,7 +5,8 @@ use bdk_bitcoind_rpc::{
 use bdk_wallet::rusqlite::Connection;
 use bdk_wallet::{
     bitcoin::{Block, Network},
-    KeychainKind, Wallet,
+    chain::ChainPosition,
+    KeychainKind, TxCanonicality, Wallet,
 };
 use clap::{self, Parser};
 use std::{
@@ -144,7 +145,13 @@ fn main() -> anyhow::Result<()> {
         args.start_height,
         wallet
             .transactions()
-            .filter(|tx| tx.chain_position.is_unconfirmed()),
+            .filter(|tx| {
+                matches!(
+                    tx.details.canonicality,
+                    TxCanonicality::Canonical(ChainPosition::Unconfirmed { .. })
+                )
+            })
+            .map(|tx| tx.tx_node.tx),
     );
     spawn(move || -> Result<(), anyhow::Error> {
         while let Some(emission) = emitter.next_block()? {

--- a/examples/bitcoind_rpc.rs
+++ b/examples/bitcoind_rpc.rs
@@ -5,6 +5,7 @@ use bdk_bitcoind_rpc::{
 use bdk_wallet::rusqlite::Connection;
 use bdk_wallet::{
     bitcoin::{Block, Network},
+    chain::ChainPosition,
     KeychainKind, Wallet,
 };
 use clap::{self, Parser};
@@ -144,7 +145,13 @@ fn main() -> anyhow::Result<()> {
         args.start_height,
         wallet
             .transactions()
-            .filter(|tx| tx.chain_position.is_unconfirmed()),
+            .filter(|tx| {
+                matches!(
+                    tx.details.chain_position,
+                    Some(ChainPosition::Unconfirmed { .. })
+                )
+            })
+            .map(|tx| tx.details.tx),
     );
     spawn(move || -> Result<(), anyhow::Error> {
         while let Some(emission) = emitter.next_block()? {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -361,3 +361,15 @@ pub fn insert_seen_at(wallet: &mut Wallet, txid: Txid, seen_at: u64) {
         })
         .expect("failed to apply update");
 }
+
+/// Marks the given `txid` evicted from the mempool at `evicted_at`
+pub fn insert_evicted_at(wallet: &mut Wallet, txid: Txid, evicted_at: u64) {
+    let mut tx_update = TxUpdate::default();
+    tx_update.evicted_ats = [(txid, evicted_at)].into();
+    wallet
+        .apply_update(Update {
+            tx_update,
+            ..Default::default()
+        })
+        .expect("failed to apply update");
+}

--- a/src/wallet/error.rs
+++ b/src/wallet/error.rs
@@ -365,3 +365,15 @@ impl fmt::Display for BuildFeeBumpError {
 }
 
 impl core::error::Error for BuildFeeBumpError {}
+
+/// The transaction is unknown or not relevant to this wallet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UnknownTransaction;
+
+impl fmt::Display for UnknownTransaction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "transaction is unknown or not wallet-relevant")
+    }
+}
+
+impl core::error::Error for UnknownTransaction {}

--- a/src/wallet/export.rs
+++ b/src/wallet/export.rs
@@ -137,6 +137,7 @@
 use alloc::string::String;
 use alloc::string::ToString;
 use alloc::vec::Vec;
+use bdk_chain::{CanonicalizationParams, Indexer};
 use bitcoin::bip32::{DerivationPath, Fingerprint, Xpub};
 use core::fmt;
 use core::str::FromStr;
@@ -210,12 +211,17 @@ impl FullyNodedExport {
         Self::is_compatible_with_core(&descriptor)?;
 
         let blockheight = if include_blockheight {
-            wallet.transactions().next().map_or(0, |canonical_tx| {
-                canonical_tx
-                    .chain_position
-                    .confirmation_height_upper_bound()
-                    .unwrap_or(0)
-            })
+            wallet
+                .tx_graph()
+                .list_canonical_txs(
+                    wallet.local_chain(),
+                    wallet.local_chain().tip().block_id(),
+                    CanonicalizationParams::default(),
+                )
+                .filter(|tx| wallet.spk_index().is_tx_relevant(&tx.tx_node.tx))
+                .filter_map(|tx| tx.chain_position.confirmation_height_upper_bound())
+                .min()
+                .unwrap_or(0)
         } else {
             0
         };

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -30,7 +30,7 @@ use bdk_chain::{
         FullScanRequest, FullScanRequestBuilder, FullScanResponse, SyncRequest, SyncRequestBuilder,
         SyncResponse,
     },
-    tx_graph::{CalculateFeeError, CanonicalTx, TxGraph, TxUpdate},
+    tx_graph::{CalculateFeeError, TxGraph, TxNode, TxUpdate},
     BlockId, CanonicalizationParams, ChainPosition, ConfirmationBlockTime, DescriptorExt,
     FullTxOut, Indexed, IndexedTxGraph, Indexer, Merge,
 };
@@ -42,7 +42,7 @@ use bitcoin::{
     secp256k1::Secp256k1,
     sighash::{EcdsaSighashType, TapSighashType},
     transaction, Address, Amount, Block, FeeRate, Network, NetworkKind, OutPoint, Psbt, ScriptBuf,
-    Sequence, SignedAmount, Transaction, TxOut, Txid, Weight, Witness,
+    Sequence, Transaction, TxOut, Txid, Weight, Witness,
 };
 use miniscript::{
     descriptor::KeyMap,
@@ -64,7 +64,7 @@ pub mod signer;
 pub mod tx_builder;
 pub(crate) mod utils;
 
-use crate::collections::{BTreeMap, HashMap, HashSet};
+use crate::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use crate::descriptor::{
     check_wallet_descriptor, error::Error as DescriptorError, policy::BuildSatisfaction,
     DerivedDescriptor, DescriptorMeta, ExtendedDescriptor, ExtractPolicy, IntoWalletDescriptor,
@@ -181,8 +181,49 @@ impl fmt::Display for AddressInfo {
     }
 }
 
-/// A `CanonicalTx` managed by a `Wallet`.
-pub type WalletTx<'a> = CanonicalTx<'a, Arc<Transaction>, ConfirmationBlockTime>;
+/// A wallet-relevant transaction and its metadata.
+#[derive(Clone, Debug)]
+pub struct TransactionInfo<'a> {
+    /// Wallet-specific amounts, fees, and canonicality.
+    pub details: TxDetails,
+    /// Graph metadata such as anchors, first_seen, and last_seen.
+    pub tx_node: TxNode<'a, Arc<Transaction>, ConfirmationBlockTime>,
+    /// Latest backend observation that this tx was absent from the mempool.
+    pub last_evicted: Option<u64>,
+    /// Direct conflicts spending the same inputs.
+    ///
+    /// See [`Wallet::canonical_blockers`] to get canonical blockers, including those via
+    /// ancestors.
+    pub conflicts: Vec<Txid>,
+}
+
+/// The canonicality of a wallet-relevant transaction.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TxCanonicality {
+    /// The transaction is currently canonical.
+    Canonical(ChainPosition<ConfirmationBlockTime>),
+    /// The transaction is currently not canonical.
+    NonCanonical,
+}
+
+impl From<Option<ChainPosition<ConfirmationBlockTime>>> for TxCanonicality {
+    fn from(chain_position: Option<ChainPosition<ConfirmationBlockTime>>) -> Self {
+        match chain_position {
+            Some(chain_position) => Self::Canonical(chain_position),
+            None => Self::NonCanonical,
+        }
+    }
+}
+
+impl TransactionInfo<'_> {
+    /// Returns the chain position if the transaction is currently canonical.
+    pub fn chain_position(&self) -> Option<&ChainPosition<ConfirmationBlockTime>> {
+        match &self.details.canonicality {
+            TxCanonicality::Canonical(chain_position) => Some(chain_position),
+            TxCanonicality::NonCanonical => None,
+        }
+    }
+}
 
 impl Wallet {
     /// Build a new single descriptor [`Wallet`].
@@ -789,33 +830,6 @@ impl Wallet {
             .map(|((k, i), full_txo)| new_local_utxo(k, i, full_txo))
     }
 
-    /// Get the [`TxDetails`] of a wallet transaction.
-    ///
-    /// If the transaction with txid [`Txid`] cannot be found in the wallet's transactions, `None`
-    /// is returned.
-    pub fn tx_details(&self, txid: Txid) -> Option<TxDetails> {
-        let tx: WalletTx = self.transactions().find(|c| c.tx_node.txid == txid)?;
-
-        let (sent, received) = self.sent_and_received(&tx.tx_node.tx);
-        let fee: Option<Amount> = self.calculate_fee(&tx.tx_node.tx).ok();
-        let fee_rate: Option<FeeRate> = self.calculate_fee_rate(&tx.tx_node.tx).ok();
-        let balance_delta: SignedAmount = self.tx_graph.index.net_value(&tx.tx_node.tx, ..);
-        let chain_position = tx.chain_position;
-
-        let tx_details: TxDetails = TxDetails {
-            txid,
-            received,
-            sent,
-            fee,
-            fee_rate,
-            balance_delta,
-            chain_position,
-            tx: tx.tx_node.tx,
-        };
-
-        Some(tx_details)
-    }
-
     /// List all relevant outputs (includes both spent and unspent, confirmed and unconfirmed).
     ///
     /// To list only unspent outputs (UTXOs), use [`Wallet::list_unspent`] instead.
@@ -1000,95 +1014,217 @@ impl Wallet {
         self.tx_graph.index.sent_and_received(tx, ..)
     }
 
-    /// Get a single transaction from the wallet as a [`WalletTx`] (if the transaction exists).
+    /// Create transaction info metadata.
+    fn build_transaction_info<'a>(
+        &self,
+        tx_node: TxNode<'a, Arc<Transaction>, ConfirmationBlockTime>,
+        chain_position: Option<ChainPosition<ConfirmationBlockTime>>,
+    ) -> TransactionInfo<'a> {
+        let txid = tx_node.txid;
+        let (sent, received) = self.sent_and_received(&tx_node.tx);
+        let fee = self.calculate_fee(&tx_node.tx).ok();
+        let fee_rate = self.calculate_fee_rate(&tx_node.tx).ok();
+        let balance_delta = self.tx_graph.index.net_value(&tx_node.tx, ..);
+        let canonicality = chain_position.into();
+        let conflicts = self
+            .tx_graph
+            .graph()
+            .direct_conflicts(&tx_node.tx)
+            .map(|(_, conflict_txid)| conflict_txid)
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect();
+        let last_evicted = self.tx_graph.graph().get_last_evicted(txid);
+
+        TransactionInfo {
+            details: TxDetails {
+                txid,
+                received,
+                sent,
+                fee,
+                fee_rate,
+                balance_delta,
+                canonicality,
+                tx: tx_node.tx.clone(),
+            },
+            tx_node,
+            last_evicted,
+            conflicts,
+        }
+    }
+
+    /// Get a single wallet-relevant transaction as [`TransactionInfo`] if it is known.
     ///
-    /// `WalletTx` contains the full transaction alongside meta-data such as:
+    /// [`TransactionInfo`] contains the full transaction alongside metadata such as:
     /// * Blocks that the transaction is [`Anchor`]ed in. These may or may not be blocks that exist
     ///   in the best chain.
-    /// * The [`ChainPosition`] of the transaction in the best chain - whether the transaction is
-    ///   confirmed or unconfirmed. If the transaction is confirmed, the anchor which proves the
-    ///   confirmation is provided. If the transaction is unconfirmed, the unix timestamp of when
-    ///   the transaction was last seen in the mempool is provided.
+    /// * Wallet-specific amounts, fees, and canonicality.
+    /// * Direct conflicts spending the same inputs.
     ///
     /// ```rust, no_run
     /// use bdk_chain::Anchor;
-    /// use bdk_wallet::{chain::ChainPosition, Wallet};
+    /// use bdk_wallet::{chain::ChainPosition, TxCanonicality, Wallet};
     /// # let wallet: Wallet = todo!();
     /// # let my_txid: bitcoin::Txid = todo!();
     ///
-    /// let wallet_tx = wallet.get_tx(my_txid).expect("panic if tx does not exist");
+    /// let tx_info = wallet.get_tx(my_txid).expect("panic if tx does not exist");
     ///
     /// // get reference to full transaction
-    /// println!("my tx: {:#?}", wallet_tx.tx_node.tx);
+    /// println!("my tx: {:#?}", tx_info.tx_node.tx);
     ///
     /// // list all transaction anchors
-    /// for anchor in wallet_tx.tx_node.anchors {
+    /// for anchor in tx_info.tx_node.anchors {
     ///     println!(
     ///         "tx is anchored by block of hash {}",
     ///         anchor.anchor_block().hash
     ///     );
     /// }
     ///
-    /// // get confirmation status of transaction
-    /// match wallet_tx.chain_position {
-    ///     ChainPosition::Confirmed {
+    /// // get canonicality of transaction
+    /// match tx_info.details.canonicality {
+    ///     TxCanonicality::Canonical(ChainPosition::Confirmed {
     ///         anchor,
     ///         transitively: None,
-    ///     } => println!(
+    ///     }) => println!(
     ///         "tx is confirmed at height {}, we know this since {}:{} is in the best chain",
     ///         anchor.block_id.height, anchor.block_id.height, anchor.block_id.hash,
     ///     ),
-    ///     ChainPosition::Confirmed {
+    ///     TxCanonicality::Canonical(ChainPosition::Confirmed {
     ///         anchor,
     ///         transitively: Some(_),
-    ///     } => println!(
+    ///     }) => println!(
     ///         "tx is an ancestor of a tx anchored in {}:{}",
     ///         anchor.block_id.height, anchor.block_id.hash,
     ///     ),
-    ///     ChainPosition::Unconfirmed { first_seen, last_seen } => println!(
+    ///     TxCanonicality::Canonical(ChainPosition::Unconfirmed { first_seen, last_seen }) => println!(
     ///         "tx is first seen at {:?}, last seen at {:?}, it is unconfirmed as it is not anchored in the best chain",
     ///         first_seen, last_seen
+    ///     ),
+    ///     TxCanonicality::NonCanonical => println!(
+    ///         "tx is not canonical, last evicted at {:?}",
+    ///         tx_info.last_evicted
     ///     ),
     /// }
     /// ```
     ///
     /// [`Anchor`]: bdk_chain::Anchor
-    pub fn get_tx(&self, txid: Txid) -> Option<WalletTx<'_>> {
+    pub fn get_tx(&self, txid: Txid) -> Option<TransactionInfo<'_>> {
         let graph = self.tx_graph.graph();
-        graph
+        let tx_node = graph.get_tx_node(txid)?;
+
+        if !self.tx_graph.index.is_tx_relevant(&tx_node.tx) {
+            return None;
+        }
+
+        let maybe_chain_position = graph
             .list_canonical_txs(
                 &self.chain,
                 self.chain.tip().block_id(),
                 CanonicalizationParams::default(),
             )
-            .find(|tx| tx.tx_node.txid == txid)
+            .find(|canonical_tx| canonical_tx.tx_node.txid == txid)
+            .map(|canonical_tx| canonical_tx.chain_position);
+
+        Some(self.build_transaction_info(tx_node, maybe_chain_position))
     }
 
-    /// Iterate over relevant and canonical transactions in the wallet.
+    /// Return canonical transactions that block a wallet transaction from being canonical.
+    ///
+    /// This includes canonical transactions that directly conflict with `txid`, and canonical
+    /// transactions that directly conflict with a non-canonical ancestor of `txid`. Ancestors are
+    /// checked because a transaction is also blocked if one of its ancestors was replaced.
+    ///
+    /// Returns `None` if `txid` is unknown or not wallet-relevant; returns `Some(empty)` if `txid`
+    /// is canonical or no canonical blockers are known.
+    pub fn canonical_blockers(&self, txid: Txid) -> Option<Vec<Txid>> {
+        let graph = self.tx_graph.graph();
+        let tx_node = graph.get_tx_node(txid)?;
+
+        if !self.tx_graph.index.is_tx_relevant(&tx_node.tx) {
+            return None;
+        }
+
+        let canonical_txids: HashSet<Txid> = graph
+            .list_canonical_txs(
+                &self.chain,
+                self.chain.tip().block_id(),
+                CanonicalizationParams::default(),
+            )
+            .map(|canonical_tx| canonical_tx.tx_node.txid)
+            .collect();
+
+        if canonical_txids.contains(&txid) {
+            return Some(Vec::new());
+        }
+
+        let tx = tx_node.tx.clone();
+        let candidates = core::iter::once(tx.clone())
+            .chain(graph.walk_ancestors(tx, |_, ancestor| Some(ancestor)))
+            .filter(|tx| !canonical_txids.contains(&tx.compute_txid()));
+
+        let blockers = candidates
+            .flat_map(|blocked_tx| {
+                graph
+                    .direct_conflicts(&blocked_tx)
+                    .map(|(_, blocker)| blocker)
+                    .collect::<Vec<_>>()
+            })
+            .filter(|blocker| canonical_txids.contains(blocker))
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect();
+
+        Some(blockers)
+    }
+
+    /// Iterate over relevant transactions in the wallet.
     ///
     /// A transaction is relevant when it spends from or spends to at least one tracked output. A
     /// transaction is canonical when it is confirmed in the best chain, or does not conflict
-    /// with any transaction confirmed in the best chain.
+    /// with any transaction confirmed in the best chain. Non-canonical transactions are included
+    /// too if they remain wallet-relevant.
     ///
-    /// To iterate over all transactions, including those that are irrelevant and not canonical, use
+    /// To iterate over all transactions, including those that are irrelevant, use
     /// [`TxGraph::full_txs`].
     ///
     /// To iterate over all canonical transactions, including those that are irrelevant, use
     /// [`TxGraph::list_canonical_txs`].
-    pub fn transactions(&self) -> impl Iterator<Item = WalletTx<'_>> + '_ {
+    pub fn transactions(&self) -> impl Iterator<Item = TransactionInfo<'_>> + '_ {
         let tx_graph = self.tx_graph.graph();
         let tx_index = &self.tx_graph.index;
-        tx_graph
+
+        let canonical_txs: Vec<_> = tx_graph
             .list_canonical_txs(
                 &self.chain,
                 self.chain.tip().block_id(),
                 CanonicalizationParams::default(),
             )
+            .collect();
+
+        let canonical_txids: HashSet<_> = canonical_txs
+            .iter()
+            .map(|canonical_tx| canonical_tx.tx_node.txid)
+            .collect();
+
+        let mut wallet_txs = canonical_txs
+            .into_iter()
             .filter(|c_tx| tx_index.is_tx_relevant(&c_tx.tx_node.tx))
+            .map(|c_tx| self.build_transaction_info(c_tx.tx_node, Some(c_tx.chain_position)))
+            .collect::<Vec<_>>();
+
+        let mut non_canonical_txs = tx_graph
+            .full_txs()
+            .filter(|tx_node| !canonical_txids.contains(&tx_node.txid))
+            .filter(|tx_node| tx_index.is_tx_relevant(&tx_node.tx))
+            .map(|tx_node| self.build_transaction_info(tx_node, None))
+            .collect::<Vec<_>>();
+        non_canonical_txs.sort_unstable_by_key(|tx_info| tx_info.tx_node.txid);
+        wallet_txs.extend(non_canonical_txs);
+
+        wallet_txs.into_iter()
     }
 
-    /// Array of relevant and canonical transactions in the wallet sorted with a comparator
-    /// function.
+    /// Array of relevant transactions in the wallet sorted with a comparator function.
     ///
     /// This is a helper method equivalent to collecting the result of [`Wallet::transactions`]
     /// into a [`Vec`] and then sorting it.
@@ -1096,18 +1232,18 @@ impl Wallet {
     /// # Example
     ///
     /// ```rust,no_run
-    /// # use bdk_wallet::{LoadParams, Wallet, WalletTx};
+    /// # use bdk_wallet::{LoadParams, TransactionInfo, Wallet};
     /// # let mut wallet:Wallet = todo!();
     /// // Transactions by chain position: first unconfirmed then descending by confirmed height.
-    /// let sorted_txs: Vec<WalletTx> =
-    ///     wallet.transactions_sort_by(|tx1, tx2| tx2.chain_position.cmp(&tx1.chain_position));
+    /// let sorted_txs: Vec<TransactionInfo> =
+    ///     wallet.transactions_sort_by(|tx1, tx2| tx2.chain_position().cmp(&tx1.chain_position()));
     /// # Ok::<(), anyhow::Error>(())
     /// ```
-    pub fn transactions_sort_by<F>(&self, compare: F) -> Vec<WalletTx<'_>>
+    pub fn transactions_sort_by<F>(&self, compare: F) -> Vec<TransactionInfo<'_>>
     where
-        F: FnMut(&WalletTx, &WalletTx) -> Ordering,
+        F: FnMut(&TransactionInfo, &TransactionInfo) -> Ordering,
     {
-        let mut txs: Vec<WalletTx> = self.transactions().collect();
+        let mut txs: Vec<TransactionInfo> = self.transactions().collect();
         txs.sort_unstable_by(compare);
         txs
     }
@@ -2535,10 +2671,9 @@ impl Wallet {
     /// Apply evictions of the given transaction IDs with their associated timestamps.
     ///
     /// This function is used to mark specific unconfirmed transactions as evicted from the mempool.
-    /// Eviction means that these transactions are not considered canonical by default, and will
-    /// no longer be part of the wallet's [`transactions`] set. This can happen for example when
-    /// a transaction is dropped from the mempool due to low fees or conflicts with another
-    /// transaction.
+    /// Eviction means that these transactions are not considered canonical by default. This can
+    /// happen for example when a transaction is dropped from the mempool due to low fees or
+    /// conflicts with another transaction.
     ///
     /// Only transactions that are currently unconfirmed and canonical are considered for eviction.
     /// Transactions that are not relevant to the wallet are ignored. Note that an evicted
@@ -2656,14 +2791,14 @@ impl Wallet {
     {
         // Snapshot of chain tip and transactions before
         let chain_tip1 = self.chain.tip().block_id();
-        let wallet_txs1 = self.map_transactions();
+        let wallet_txs1 = self.map_canonical_transactions();
 
         // Call `f` on self
         f(self)?;
 
         // Chain tip and transactions after
         let chain_tip2 = self.chain.tip().block_id();
-        let wallet_txs2 = self.map_transactions();
+        let wallet_txs2 = self.map_canonical_transactions();
 
         Ok(wallet_events(
             self,
@@ -2689,14 +2824,21 @@ impl Wallet {
     /// Returns a map of canonical transactions keyed by txid.
     ///
     /// This is used internally to help generate [`WalletEvent`]s.
-    fn map_transactions(
+    fn map_canonical_transactions(
         &self,
     ) -> BTreeMap<Txid, (Arc<Transaction>, ChainPosition<ConfirmationBlockTime>)> {
-        self.transactions()
-            .map(|wtx| {
+        self.tx_graph
+            .graph()
+            .list_canonical_txs(
+                &self.chain,
+                self.chain.tip().block_id(),
+                CanonicalizationParams::default(),
+            )
+            .filter(|c_tx| self.tx_graph.index.is_tx_relevant(&c_tx.tx_node.tx))
+            .map(|c_tx| {
                 (
-                    wtx.tx_node.txid,
-                    (wtx.tx_node.tx.clone(), wtx.chain_position),
+                    c_tx.tx_node.txid,
+                    (c_tx.tx_node.tx.clone(), c_tx.chain_position),
                 )
             })
             .collect()

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -30,7 +30,7 @@ use bdk_chain::{
         FullScanRequest, FullScanRequestBuilder, FullScanResponse, SyncRequest, SyncRequestBuilder,
         SyncResponse,
     },
-    tx_graph::{CalculateFeeError, CanonicalTx, TxGraph, TxUpdate},
+    tx_graph::{CalculateFeeError, TxGraph, TxNode, TxUpdate},
     BlockId, CanonicalizationParams, ChainPosition, ConfirmationBlockTime, DescriptorExt,
     FullTxOut, Indexed, IndexedTxGraph, Indexer, Merge,
 };
@@ -42,7 +42,7 @@ use bitcoin::{
     secp256k1::Secp256k1,
     sighash::{EcdsaSighashType, TapSighashType},
     transaction, Address, Amount, Block, FeeRate, Network, NetworkKind, OutPoint, Psbt, ScriptBuf,
-    Sequence, SignedAmount, Transaction, TxOut, Txid, Weight, Witness,
+    Sequence, Transaction, TxOut, Txid, Weight, Witness,
 };
 use miniscript::{
     descriptor::KeyMap,
@@ -64,7 +64,7 @@ pub mod signer;
 pub mod tx_builder;
 pub(crate) mod utils;
 
-use crate::collections::{BTreeMap, HashMap, HashSet};
+use crate::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use crate::descriptor::{
     check_wallet_descriptor, checksum::calc_checksum, error::Error as DescriptorError,
     policy::BuildSatisfaction, DerivedDescriptor, DescriptorMeta, ExtendedDescriptor,
@@ -83,7 +83,7 @@ use crate::wallet::{
 // re-exports
 pub use bdk_chain::Balance;
 pub use changeset::ChangeSet;
-pub use error::{LoadError, LoadMismatch};
+pub use error::{LoadError, LoadMismatch, UnknownTransaction};
 pub use event::*;
 pub use params::*;
 pub use persisted::*;
@@ -181,8 +181,24 @@ impl fmt::Display for AddressInfo {
     }
 }
 
-/// A `CanonicalTx` managed by a `Wallet`.
-pub type WalletTx<'a> = CanonicalTx<'a, Arc<Transaction>, ConfirmationBlockTime>;
+/// A wallet-relevant transaction and its metadata.
+#[derive(Clone, Debug)]
+pub struct TransactionInfo {
+    /// Wallet-specific amounts, fees, and chain position.
+    pub details: TxDetails,
+    /// Blocks that the transaction is anchored in.
+    pub anchors: BTreeSet<ConfirmationBlockTime>,
+    /// The first-seen unix timestamp of the transaction as unconfirmed.
+    pub first_seen: Option<u64>,
+    /// The last-seen unix timestamp of the transaction as unconfirmed.
+    pub last_seen: Option<u64>,
+    /// Latest backend observation that this tx was absent from the mempool.
+    pub evicted_at: Option<u64>,
+    /// Direct conflicts spending the same inputs.
+    ///
+    /// See [`Wallet::conflicts`] for ancestor-aware conflicts with chain positions.
+    pub conflicts: Vec<Txid>,
+}
 
 impl Wallet {
     /// Build a new single descriptor [`Wallet`].
@@ -789,33 +805,6 @@ impl Wallet {
             .map(|((k, i), full_txo)| new_local_utxo(k, i, full_txo))
     }
 
-    /// Get the [`TxDetails`] of a wallet transaction.
-    ///
-    /// If the transaction with txid [`Txid`] cannot be found in the wallet's transactions, `None`
-    /// is returned.
-    pub fn tx_details(&self, txid: Txid) -> Option<TxDetails> {
-        let tx: WalletTx = self.transactions().find(|c| c.tx_node.txid == txid)?;
-
-        let (sent, received) = self.sent_and_received(&tx.tx_node.tx);
-        let fee: Option<Amount> = self.calculate_fee(&tx.tx_node.tx).ok();
-        let fee_rate: Option<FeeRate> = self.calculate_fee_rate(&tx.tx_node.tx).ok();
-        let balance_delta: SignedAmount = self.tx_graph.index.net_value(&tx.tx_node.tx, ..);
-        let chain_position = tx.chain_position;
-
-        let tx_details: TxDetails = TxDetails {
-            txid,
-            received,
-            sent,
-            fee,
-            fee_rate,
-            balance_delta,
-            chain_position,
-            tx: tx.tx_node.tx,
-        };
-
-        Some(tx_details)
-    }
-
     /// List all relevant outputs (includes both spent and unspent, confirmed and unconfirmed).
     ///
     /// To list only unspent outputs (UTXOs), use [`Wallet::list_unspent`] instead.
@@ -923,7 +912,7 @@ impl Wallet {
     /// # use bdk_wallet::Wallet;
     /// # let mut wallet: Wallet = todo!();
     /// # let txid:Txid = todo!();
-    /// let tx = wallet.get_tx(txid).expect("transaction").tx_node.tx;
+    /// let tx = wallet.get_tx(txid).expect("transaction").details.tx;
     /// let fee = wallet.calculate_fee(&tx).expect("fee");
     /// ```
     ///
@@ -954,7 +943,7 @@ impl Wallet {
     /// # use bdk_wallet::Wallet;
     /// # let mut wallet: Wallet = todo!();
     /// # let txid:Txid = todo!();
-    /// let tx = wallet.get_tx(txid).expect("transaction").tx_node.tx;
+    /// let tx = wallet.get_tx(txid).expect("transaction").details.tx;
     /// let fee_rate = wallet.calculate_fee_rate(&tx).expect("fee rate");
     /// ```
     ///
@@ -984,7 +973,7 @@ impl Wallet {
     /// # use bdk_wallet::Wallet;
     /// # let mut wallet: Wallet = todo!();
     /// # let txid:Txid = todo!();
-    /// let tx = wallet.get_tx(txid).expect("tx exists").tx_node.tx;
+    /// let tx = wallet.get_tx(txid).expect("tx exists").details.tx;
     /// let (sent, received) = wallet.sent_and_received(&tx);
     /// ```
     ///
@@ -1000,95 +989,208 @@ impl Wallet {
         self.tx_graph.index.sent_and_received(tx, ..)
     }
 
-    /// Get a single transaction from the wallet as a [`WalletTx`] (if the transaction exists).
+    /// Create transaction info metadata.
+    fn build_transaction_info(
+        &self,
+        tx_node: TxNode<'_, Arc<Transaction>, ConfirmationBlockTime>,
+        chain_position: Option<ChainPosition<ConfirmationBlockTime>>,
+    ) -> TransactionInfo {
+        let txid = tx_node.txid;
+        let (sent, received) = self.sent_and_received(&tx_node.tx);
+        let fee = self.calculate_fee(&tx_node.tx).ok();
+        let fee_rate = self.calculate_fee_rate(&tx_node.tx).ok();
+        let balance_delta = self.tx_graph.index.net_value(&tx_node.tx, ..);
+        let conflicts = self
+            .tx_graph
+            .graph()
+            .direct_conflicts(&tx_node.tx)
+            .map(|(_, conflict_txid)| conflict_txid)
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect();
+        let evicted_at = self.tx_graph.graph().get_last_evicted(txid);
+
+        TransactionInfo {
+            details: TxDetails {
+                txid,
+                received,
+                sent,
+                fee,
+                fee_rate,
+                balance_delta,
+                chain_position,
+                tx: tx_node.tx.clone(),
+            },
+            anchors: tx_node.anchors.clone(),
+            first_seen: tx_node.first_seen,
+            last_seen: tx_node.last_seen,
+            evicted_at,
+            conflicts,
+        }
+    }
+
+    /// Get a single wallet-relevant transaction as [`TransactionInfo`] if it is known.
     ///
-    /// `WalletTx` contains the full transaction alongside meta-data such as:
+    /// [`TransactionInfo`] contains the full transaction alongside metadata such as:
     /// * Blocks that the transaction is [`Anchor`]ed in. These may or may not be blocks that exist
     ///   in the best chain.
-    /// * The [`ChainPosition`] of the transaction in the best chain - whether the transaction is
-    ///   confirmed or unconfirmed. If the transaction is confirmed, the anchor which proves the
-    ///   confirmation is provided. If the transaction is unconfirmed, the unix timestamp of when
-    ///   the transaction was last seen in the mempool is provided.
+    /// * Wallet-specific amounts, fees, and chain position.
+    /// * Direct conflicts spending the same inputs.
     ///
     /// ```rust, no_run
     /// use bdk_chain::Anchor;
-    /// use bdk_wallet::{chain::ChainPosition, Wallet};
+    /// use bdk_wallet::Wallet;
     /// # let wallet: Wallet = todo!();
     /// # let my_txid: bitcoin::Txid = todo!();
     ///
-    /// let wallet_tx = wallet.get_tx(my_txid).expect("panic if tx does not exist");
+    /// let tx_info = wallet.get_tx(my_txid).expect("panic if tx does not exist");
     ///
     /// // get reference to full transaction
-    /// println!("my tx: {:#?}", wallet_tx.tx_node.tx);
+    /// println!("my tx: {:#?}", tx_info.details.tx);
     ///
     /// // list all transaction anchors
-    /// for anchor in wallet_tx.tx_node.anchors {
+    /// for anchor in &tx_info.anchors {
     ///     println!(
     ///         "tx is anchored by block of hash {}",
     ///         anchor.anchor_block().hash
     ///     );
     /// }
-    ///
-    /// // get confirmation status of transaction
-    /// match wallet_tx.chain_position {
-    ///     ChainPosition::Confirmed {
-    ///         anchor,
-    ///         transitively: None,
-    ///     } => println!(
-    ///         "tx is confirmed at height {}, we know this since {}:{} is in the best chain",
-    ///         anchor.block_id.height, anchor.block_id.height, anchor.block_id.hash,
-    ///     ),
-    ///     ChainPosition::Confirmed {
-    ///         anchor,
-    ///         transitively: Some(_),
-    ///     } => println!(
-    ///         "tx is an ancestor of a tx anchored in {}:{}",
-    ///         anchor.block_id.height, anchor.block_id.hash,
-    ///     ),
-    ///     ChainPosition::Unconfirmed { first_seen, last_seen } => println!(
-    ///         "tx is first seen at {:?}, last seen at {:?}, it is unconfirmed as it is not anchored in the best chain",
-    ///         first_seen, last_seen
-    ///     ),
-    /// }
     /// ```
     ///
     /// [`Anchor`]: bdk_chain::Anchor
-    pub fn get_tx(&self, txid: Txid) -> Option<WalletTx<'_>> {
+    pub fn get_tx(&self, txid: Txid) -> Option<TransactionInfo> {
         let graph = self.tx_graph.graph();
-        graph
+        let tx_node = graph.get_tx_node(txid)?;
+
+        if !self.tx_graph.index.is_tx_relevant(&tx_node.tx) {
+            return None;
+        }
+
+        let maybe_chain_position = graph
             .list_canonical_txs(
                 &self.chain,
                 self.chain.tip().block_id(),
                 CanonicalizationParams::default(),
             )
-            .find(|tx| tx.tx_node.txid == txid)
+            .find(|canonical_tx| canonical_tx.tx_node.txid == txid)
+            .map(|canonical_tx| canonical_tx.chain_position);
+
+        Some(self.build_transaction_info(tx_node, maybe_chain_position))
     }
 
-    /// Iterate over relevant and canonical transactions in the wallet.
+    /// Get the [`TxDetails`] of a wallet transaction.
+    ///
+    /// If the transaction with txid [`Txid`] cannot be found in the wallet's transactions, `None`
+    /// is returned.
+    ///
+    /// Convenience for [`Wallet::get_tx`]'s `details` field.
+    pub fn tx_details(&self, txid: Txid) -> Option<TxDetails> {
+        self.get_tx(txid).map(|info| info.details)
+    }
+
+    /// Return conflicts of a wallet-relevant transaction, including conflicts of its non-canonical
+    /// ancestors.
+    ///
+    /// Direct conflicts of `txid` are included, as well as direct conflicts of any non-canonical
+    /// ancestor of `txid`. Ancestors are checked because a transaction can be non-canonical when
+    /// one of its ancestors was replaced.
+    ///
+    /// Returns [`UnknownTransaction`] if `txid` is unknown or not wallet-relevant. Returns
+    /// an empty list if `txid` is canonical or no conflicts are known.
+    #[allow(clippy::type_complexity)]
+    pub fn conflicts(
+        &self,
+        txid: Txid,
+    ) -> Result<Vec<(Txid, Option<ChainPosition<ConfirmationBlockTime>>)>, UnknownTransaction> {
+        let graph = self.tx_graph.graph();
+        let tx_node = graph.get_tx_node(txid).ok_or(UnknownTransaction)?;
+
+        if !self.tx_graph.index.is_tx_relevant(&tx_node.tx) {
+            return Err(UnknownTransaction);
+        }
+
+        let canonical_positions: HashMap<Txid, ChainPosition<ConfirmationBlockTime>> = graph
+            .list_canonical_txs(
+                &self.chain,
+                self.chain.tip().block_id(),
+                CanonicalizationParams::default(),
+            )
+            .map(|canonical_tx| (canonical_tx.tx_node.txid, canonical_tx.chain_position))
+            .collect();
+
+        if canonical_positions.contains_key(&txid) {
+            return Ok(Vec::new());
+        }
+
+        let tx = tx_node.tx.clone();
+        let candidates = core::iter::once(tx.clone())
+            .chain(graph.walk_ancestors(tx, |_, ancestor| Some(ancestor)))
+            .filter(|tx| !canonical_positions.contains_key(&tx.compute_txid()));
+
+        let conflicts = candidates
+            .flat_map(|candidate_tx| {
+                graph
+                    .direct_conflicts(&candidate_tx)
+                    .map(|(_, conflict_txid)| conflict_txid)
+                    .collect::<Vec<_>>()
+            })
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .map(|conflict_txid| {
+                (
+                    conflict_txid,
+                    canonical_positions.get(&conflict_txid).cloned(),
+                )
+            })
+            .collect();
+
+        Ok(conflicts)
+    }
+
+    /// Iterate over relevant transactions in the wallet.
     ///
     /// A transaction is relevant when it spends from or spends to at least one tracked output. A
     /// transaction is canonical when it is confirmed in the best chain, or does not conflict
-    /// with any transaction confirmed in the best chain.
+    /// with any transaction confirmed in the best chain. Non-canonical transactions are included
+    /// too if they remain wallet-relevant.
     ///
-    /// To iterate over all transactions, including those that are irrelevant and not canonical, use
+    /// To iterate over all transactions, including those that are irrelevant, use
     /// [`TxGraph::full_txs`].
     ///
     /// To iterate over all canonical transactions, including those that are irrelevant, use
     /// [`TxGraph::list_canonical_txs`].
-    pub fn transactions(&self) -> impl Iterator<Item = WalletTx<'_>> + '_ {
+    pub fn transactions(&self) -> impl Iterator<Item = TransactionInfo> + '_ {
         let tx_graph = self.tx_graph.graph();
         let tx_index = &self.tx_graph.index;
-        tx_graph
+
+        let canonical_txs: Vec<_> = tx_graph
             .list_canonical_txs(
                 &self.chain,
                 self.chain.tip().block_id(),
                 CanonicalizationParams::default(),
             )
+            .collect();
+
+        let canonical_txids: HashSet<_> = canonical_txs
+            .iter()
+            .map(|canonical_tx| canonical_tx.tx_node.txid)
+            .collect();
+
+        let canonical = canonical_txs
+            .into_iter()
             .filter(|c_tx| tx_index.is_tx_relevant(&c_tx.tx_node.tx))
+            .map(|c_tx| self.build_transaction_info(c_tx.tx_node, Some(c_tx.chain_position)));
+
+        let non_canonical = tx_graph
+            .full_txs()
+            .filter(move |tx_node| !canonical_txids.contains(&tx_node.txid))
+            .filter(|tx_node| tx_index.is_tx_relevant(&tx_node.tx))
+            .map(|tx_node| self.build_transaction_info(tx_node, None));
+
+        canonical.chain(non_canonical)
     }
 
-    /// Array of relevant and canonical transactions in the wallet sorted with a comparator
-    /// function.
+    /// Array of relevant transactions in the wallet sorted with a comparator function.
     ///
     /// This is a helper method equivalent to collecting the result of [`Wallet::transactions`]
     /// into a [`Vec`] and then sorting it.
@@ -1096,18 +1198,19 @@ impl Wallet {
     /// # Example
     ///
     /// ```rust,no_run
-    /// # use bdk_wallet::{LoadParams, Wallet, WalletTx};
+    /// # use bdk_wallet::{LoadParams, TransactionInfo, Wallet};
     /// # let mut wallet:Wallet = todo!();
     /// // Transactions by chain position: first unconfirmed then descending by confirmed height.
-    /// let sorted_txs: Vec<WalletTx> =
-    ///     wallet.transactions_sort_by(|tx1, tx2| tx2.chain_position.cmp(&tx1.chain_position));
+    /// let sorted_txs: Vec<TransactionInfo> = wallet.transactions_sort_by(|tx1, tx2| {
+    ///     tx2.details.chain_position.cmp(&tx1.details.chain_position)
+    /// });
     /// # Ok::<(), anyhow::Error>(())
     /// ```
-    pub fn transactions_sort_by<F>(&self, compare: F) -> Vec<WalletTx<'_>>
+    pub fn transactions_sort_by<F>(&self, compare: F) -> Vec<TransactionInfo>
     where
-        F: FnMut(&WalletTx, &WalletTx) -> Ordering,
+        F: FnMut(&TransactionInfo, &TransactionInfo) -> Ordering,
     {
-        let mut txs: Vec<WalletTx> = self.transactions().collect();
+        let mut txs: Vec<TransactionInfo> = self.transactions().collect();
         txs.sort_unstable_by(compare);
         txs
     }
@@ -2652,10 +2755,9 @@ impl Wallet {
     /// Apply evictions of the given transaction IDs with their associated timestamps.
     ///
     /// This function is used to mark specific unconfirmed transactions as evicted from the mempool.
-    /// Eviction means that these transactions are not considered canonical by default, and will
-    /// no longer be part of the wallet's [`transactions`] set. This can happen for example when
-    /// a transaction is dropped from the mempool due to low fees or conflicts with another
-    /// transaction.
+    /// Eviction means that these transactions are not considered canonical by default. This can
+    /// happen for example when a transaction is dropped from the mempool due to low fees or
+    /// conflicts with another transaction.
     ///
     /// Only transactions that are currently unconfirmed and canonical are considered for eviction.
     /// Transactions that are not relevant to the wallet are ignored. Note that an evicted
@@ -2773,14 +2875,14 @@ impl Wallet {
     {
         // Snapshot of chain tip and transactions before
         let chain_tip1 = self.chain.tip().block_id();
-        let wallet_txs1 = self.map_transactions();
+        let wallet_txs1 = self.map_canonical_transactions();
 
         // Call `f` on self
         f(self)?;
 
         // Chain tip and transactions after
         let chain_tip2 = self.chain.tip().block_id();
-        let wallet_txs2 = self.map_transactions();
+        let wallet_txs2 = self.map_canonical_transactions();
 
         Ok(wallet_events(
             self,
@@ -2806,14 +2908,21 @@ impl Wallet {
     /// Returns a map of canonical transactions keyed by txid.
     ///
     /// This is used internally to help generate [`WalletEvent`]s.
-    fn map_transactions(
+    fn map_canonical_transactions(
         &self,
     ) -> BTreeMap<Txid, (Arc<Transaction>, ChainPosition<ConfirmationBlockTime>)> {
-        self.transactions()
-            .map(|wtx| {
+        self.tx_graph
+            .graph()
+            .list_canonical_txs(
+                &self.chain,
+                self.chain.tip().block_id(),
+                CanonicalizationParams::default(),
+            )
+            .filter(|c_tx| self.tx_graph.index.is_tx_relevant(&c_tx.tx_node.tx))
+            .map(|c_tx| {
                 (
-                    wtx.tx_node.txid,
-                    (wtx.tx_node.tx.clone(), wtx.chain_position),
+                    c_tx.tx_node.txid,
+                    (c_tx.tx_node.tx.clone(), c_tx.chain_position),
                 )
             })
             .collect()

--- a/src/wallet/tx_builder.rs
+++ b/src/wallet/tx_builder.rs
@@ -1369,7 +1369,7 @@ mod test {
         assert_ne!(txid1, txid2);
 
         let utxo1 = wallet1.list_unspent().next().unwrap();
-        let tx1 = wallet1.get_tx(txid1).unwrap().tx_node.tx.clone();
+        let tx1 = wallet1.get_tx(txid1).unwrap().details.tx.clone();
 
         let satisfaction_weight = wallet1
             .public_descriptor(KeychainKind::External)

--- a/src/wallet/utils.rs
+++ b/src/wallet/utils.rs
@@ -14,8 +14,9 @@ use bitcoin::secp256k1::{All, Secp256k1};
 use bitcoin::{
     absolute, relative, Amount, FeeRate, Script, Sequence, SignedAmount, Transaction, Txid,
 };
-use chain::{ChainPosition, ConfirmationBlockTime};
 use miniscript::{MiniscriptKey, Satisfier, ToPublicKey};
+
+use super::TxCanonicality;
 
 use rand_core::RngCore;
 
@@ -136,8 +137,8 @@ pub(crate) fn shuffle_slice<T>(list: &mut [T], rng: &mut impl RngCore) {
 
 pub(crate) type SecpCtx = Secp256k1<All>;
 
-/// Details about a transaction affecting the wallet (relevant and canonical).
-#[derive(Debug)]
+/// Details about a transaction affecting the wallet.
+#[derive(Clone, Debug)]
 pub struct TxDetails {
     /// The transaction id.
     pub txid: Txid,
@@ -157,8 +158,8 @@ pub struct TxDetails {
     pub fee_rate: Option<FeeRate>,
     /// The net effect of the transaction on the balance of the wallet.
     pub balance_delta: SignedAmount,
-    /// The position of the transaction in the chain.
-    pub chain_position: ChainPosition<ConfirmationBlockTime>,
+    /// The canonicality of the transaction.
+    pub canonicality: TxCanonicality,
     /// The complete [`Transaction`].
     pub tx: Arc<Transaction>,
 }

--- a/src/wallet/utils.rs
+++ b/src/wallet/utils.rs
@@ -14,8 +14,9 @@ use bitcoin::secp256k1::{All, Secp256k1};
 use bitcoin::{
     absolute, relative, Amount, FeeRate, Script, Sequence, SignedAmount, Transaction, Txid,
 };
-use chain::{ChainPosition, ConfirmationBlockTime};
 use miniscript::{MiniscriptKey, Satisfier, ToPublicKey};
+
+use bdk_chain::{ChainPosition, ConfirmationBlockTime};
 
 use rand_core::RngCore;
 
@@ -136,8 +137,8 @@ pub(crate) fn shuffle_slice<T>(list: &mut [T], rng: &mut impl RngCore) {
 
 pub(crate) type SecpCtx = Secp256k1<All>;
 
-/// Details about a transaction affecting the wallet (relevant and canonical).
-#[derive(Debug)]
+/// Details about a transaction affecting the wallet.
+#[derive(Clone, Debug)]
 pub struct TxDetails {
     /// The transaction id.
     pub txid: Txid,
@@ -157,8 +158,8 @@ pub struct TxDetails {
     pub fee_rate: Option<FeeRate>,
     /// The net effect of the transaction on the balance of the wallet.
     pub balance_delta: SignedAmount,
-    /// The position of the transaction in the chain.
-    pub chain_position: ChainPosition<ConfirmationBlockTime>,
+    /// Chain position of the transaction, if currently canonical.
+    pub chain_position: Option<ChainPosition<ConfirmationBlockTime>>,
     /// The complete [`Transaction`].
     pub tx: Arc<Transaction>,
 }

--- a/tests/add_foreign_utxo.rs
+++ b/tests/add_foreign_utxo.rs
@@ -139,8 +139,8 @@ fn test_add_foreign_utxo_where_outpoint_doesnt_match_psbt_input() {
         get_funded_wallet_single("wpkh(cVbZ8ovhye9AoAHFsqobCf7LxbXDAECy9Kb8TZdfsDYMZGBUyCnm)");
 
     let utxo2 = wallet2.list_unspent().next().unwrap();
-    let tx1 = wallet1.get_tx(txid1).unwrap().tx_node.tx.clone();
-    let tx2 = wallet2.get_tx(txid2).unwrap().tx_node.tx.clone();
+    let tx1 = wallet1.get_tx(txid1).unwrap().details.tx.clone();
+    let tx2 = wallet2.get_tx(txid2).unwrap().details.tx.clone();
 
     let satisfaction_weight = wallet2
         .public_descriptor(KeychainKind::External)
@@ -230,7 +230,7 @@ fn test_add_foreign_utxo_only_witness_utxo() {
         let mut builder = wallet1.build_tx();
         builder.add_recipient(addr.script_pubkey(), Amount::from_sat(60_000));
 
-        let tx2 = wallet2.get_tx(txid2).unwrap().tx_node.tx;
+        let tx2 = wallet2.get_tx(txid2).unwrap().details.tx;
         let psbt_input = psbt::Input {
             non_witness_utxo: Some(tx2.as_ref().clone()),
             ..Default::default()
@@ -298,7 +298,7 @@ fn test_add_foreign_utxo_rejects_wrong_non_witness_utxo_even_with_witness_utxo()
         get_funded_wallet_single("wpkh(cVbZ8ovhye9AoAHFsqobCf7LxbXDAECy9Kb8TZdfsDYMZGBUyCnm)");
 
     let utxo2 = wallet2.list_unspent().next().unwrap();
-    let tx1 = wallet1.get_tx(txid1).unwrap().tx_node.tx.clone();
+    let tx1 = wallet1.get_tx(txid1).unwrap().details.tx.clone();
 
     let satisfaction_weight = wallet2
         .public_descriptor(KeychainKind::External)

--- a/tests/build_fee_bump.rs
+++ b/tests/build_fee_bump.rs
@@ -358,8 +358,13 @@ fn test_bump_fee_remove_output_manually_selected_only() {
         }],
     };
 
-    let position: ChainPosition<ConfirmationBlockTime> =
-        wallet.transactions().last().unwrap().chain_position;
+    let position: ChainPosition<ConfirmationBlockTime> = wallet
+        .transactions()
+        .last()
+        .unwrap()
+        .chain_position()
+        .cloned()
+        .unwrap();
     insert_tx(&mut wallet, init_tx.clone());
     match position {
         ChainPosition::Confirmed { anchor, .. } => {
@@ -410,8 +415,13 @@ fn test_bump_fee_add_input() {
         }],
     };
     let txid = init_tx.compute_txid();
-    let pos: ChainPosition<ConfirmationBlockTime> =
-        wallet.transactions().last().unwrap().chain_position;
+    let pos: ChainPosition<ConfirmationBlockTime> = wallet
+        .transactions()
+        .last()
+        .unwrap()
+        .chain_position()
+        .cloned()
+        .unwrap();
     insert_tx(&mut wallet, init_tx);
     match pos {
         ChainPosition::Confirmed { anchor, .. } => insert_anchor(&mut wallet, txid, anchor),
@@ -846,8 +856,13 @@ fn test_legacy_bump_fee_add_input() {
         }],
     };
     let txid = init_tx.compute_txid();
-    let pos: ChainPosition<ConfirmationBlockTime> =
-        wallet.transactions().last().unwrap().chain_position;
+    let pos: ChainPosition<ConfirmationBlockTime> = wallet
+        .transactions()
+        .last()
+        .unwrap()
+        .chain_position()
+        .cloned()
+        .unwrap();
     insert_tx(&mut wallet, init_tx);
     match pos {
         ChainPosition::Confirmed { anchor, .. } => insert_anchor(&mut wallet, txid, anchor),

--- a/tests/build_fee_bump.rs
+++ b/tests/build_fee_bump.rs
@@ -358,8 +358,13 @@ fn test_bump_fee_remove_output_manually_selected_only() {
         }],
     };
 
-    let position: ChainPosition<ConfirmationBlockTime> =
-        wallet.transactions().last().unwrap().chain_position;
+    let position: ChainPosition<ConfirmationBlockTime> = wallet
+        .transactions()
+        .last()
+        .unwrap()
+        .details
+        .chain_position
+        .unwrap();
     insert_tx(&mut wallet, init_tx.clone());
     match position {
         ChainPosition::Confirmed { anchor, .. } => {
@@ -410,8 +415,13 @@ fn test_bump_fee_add_input() {
         }],
     };
     let txid = init_tx.compute_txid();
-    let pos: ChainPosition<ConfirmationBlockTime> =
-        wallet.transactions().last().unwrap().chain_position;
+    let pos: ChainPosition<ConfirmationBlockTime> = wallet
+        .transactions()
+        .last()
+        .unwrap()
+        .details
+        .chain_position
+        .unwrap();
     insert_tx(&mut wallet, init_tx);
     match pos {
         ChainPosition::Confirmed { anchor, .. } => insert_anchor(&mut wallet, txid, anchor),
@@ -846,8 +856,13 @@ fn test_legacy_bump_fee_add_input() {
         }],
     };
     let txid = init_tx.compute_txid();
-    let pos: ChainPosition<ConfirmationBlockTime> =
-        wallet.transactions().last().unwrap().chain_position;
+    let pos: ChainPosition<ConfirmationBlockTime> = wallet
+        .transactions()
+        .last()
+        .unwrap()
+        .details
+        .chain_position
+        .unwrap();
     insert_tx(&mut wallet, init_tx);
     match pos {
         ChainPosition::Confirmed { anchor, .. } => insert_anchor(&mut wallet, txid, anchor),

--- a/tests/persisted_wallet.rs
+++ b/tests/persisted_wallet.rs
@@ -370,9 +370,10 @@ fn wallet_should_persist_anchors_and_recover() {
     } = wallet
         .get_tx(txid)
         .expect("should retrieve stored tx")
-        .chain_position
+        .chain_position()
+        .expect("stored tx should be canonical")
     {
-        assert_eq!(obtained_anchor, expected_anchor)
+        assert_eq!(obtained_anchor, &expected_anchor)
     } else {
         panic!("Should have got ChainPosition::Confirmed)");
     }

--- a/tests/persisted_wallet.rs
+++ b/tests/persisted_wallet.rs
@@ -370,9 +370,12 @@ fn wallet_should_persist_anchors_and_recover() {
     } = wallet
         .get_tx(txid)
         .expect("should retrieve stored tx")
+        .details
         .chain_position
+        .as_ref()
+        .expect("stored tx should be canonical")
     {
-        assert_eq!(obtained_anchor, expected_anchor)
+        assert_eq!(obtained_anchor, &expected_anchor)
     } else {
         panic!("Should have got ChainPosition::Confirmed)");
     }

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -10,7 +10,7 @@ use bdk_wallet::psbt::PsbtUtils;
 use bdk_wallet::signer::{SignOptions, SignerError};
 use bdk_wallet::test_utils::*;
 use bdk_wallet::KeychainKind;
-use bdk_wallet::{AddressInfo, Balance, PersistedWallet, Update, Wallet, WalletTx};
+use bdk_wallet::{AddressInfo, Balance, PersistedWallet, TransactionInfo, Update, Wallet};
 use bitcoin::constants::COINBASE_MATURITY;
 use bitcoin::hashes::Hash;
 use bitcoin::script::PushBytesBuf;
@@ -2807,11 +2807,14 @@ fn test_transactions_sort_by() {
     receive_output(&mut wallet, Amount::from_sat(25_000), ReceiveTo::Mempool(0));
 
     // sort by chain position, unconfirmed then confirmed by descending block height
-    let sorted_txs: Vec<WalletTx> =
-        wallet.transactions_sort_by(|t1, t2| t2.chain_position.cmp(&t1.chain_position));
+    let sorted_txs: Vec<TransactionInfo> =
+        wallet.transactions_sort_by(|t1, t2| t2.chain_position().cmp(&t1.chain_position()));
     let conf_heights: Vec<Option<u32>> = sorted_txs
         .iter()
-        .map(|tx| tx.chain_position.confirmation_height_upper_bound())
+        .map(|tx| {
+            tx.chain_position()
+                .and_then(|position| position.confirmation_height_upper_bound())
+        })
         .collect();
     assert_eq!([None, Some(2000), Some(1000)], conf_heights.as_slice());
 }
@@ -2875,12 +2878,12 @@ fn test_wallet_transactions_relevant() {
 }
 
 #[test]
-fn test_tx_details_method() {
+fn test_transaction_info_details() {
     let (test_wallet, txid_1) = get_funded_wallet_wpkh();
-    let tx_details_1_option = test_wallet.tx_details(txid_1);
+    let tx_info_1_option = test_wallet.get_tx(txid_1);
 
-    assert!(tx_details_1_option.is_some());
-    let tx_details_1 = tx_details_1_option.unwrap();
+    assert!(tx_info_1_option.is_some());
+    let tx_details_1 = tx_info_1_option.unwrap().details;
 
     assert_eq!(
         tx_details_1.txid.to_string(),
@@ -2893,8 +2896,8 @@ fn test_tx_details_method() {
 
     // Transaction id not part of the TxGraph
     let txid_2 = Txid::from_raw_hash(Hash::all_zeros());
-    let tx_details_2_option = test_wallet.tx_details(txid_2);
-    assert!(tx_details_2_option.is_none());
+    let tx_info_2_option = test_wallet.get_tx(txid_2);
+    assert!(tx_info_2_option.is_none());
 }
 
 #[test]

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -10,7 +10,9 @@ use bdk_wallet::psbt::PsbtUtils;
 use bdk_wallet::signer::{SignOptions, SignerError};
 use bdk_wallet::test_utils::*;
 use bdk_wallet::KeychainKind;
-use bdk_wallet::{AddressInfo, Balance, PersistedWallet, TransactionInfo, Update, Wallet};
+use bdk_wallet::{
+    AddressInfo, Balance, PersistedWallet, TransactionInfo, TxCanonicality, Update, Wallet,
+};
 use bitcoin::constants::COINBASE_MATURITY;
 use bitcoin::hashes::Hash;
 use bitcoin::script::PushBytesBuf;
@@ -2875,29 +2877,102 @@ fn test_wallet_transactions_relevant() {
         .any(|wallet_tx| wallet_tx.tx_node.txid == other_txid));
     assert!(full_tx_count_before < full_tx_count_after);
     assert!(canonical_tx_count_before < canonical_tx_count_after);
+
+    // A wallet-relevant non-canonical tx is included.
+    let sendto = Address::from_str("bcrt1q3qtze4ys45tgdvguj66zrk4fu6hq3a3v9pfly5")
+        .unwrap()
+        .require_network(Network::Regtest)
+        .unwrap();
+    let mut builder = test_wallet.build_tx();
+    builder.add_recipient(sendto.script_pubkey(), Amount::from_sat(10_000));
+    let send_tx = builder.finish().unwrap().extract_tx().unwrap();
+    let send_txid = send_tx.compute_txid();
+    let mut update = Update::default();
+    update.tx_update.txs = vec![Arc::new(send_tx)];
+    update.tx_update.seen_ats = [(send_txid, 100)].into();
+    update.tx_update.evicted_ats = [(send_txid, 200)].into();
+    test_wallet.apply_update(update).unwrap();
+    let info = test_wallet
+        .transactions()
+        .find(|tx| tx.tx_node.txid == send_txid)
+        .expect("non-canonical send_tx should be included");
+    assert!(info.chain_position().is_none());
 }
 
 #[test]
-fn test_transaction_info_details() {
-    let (test_wallet, txid_1) = get_funded_wallet_wpkh();
-    let tx_info_1_option = test_wallet.get_tx(txid_1);
+fn test_get_tx() {
+    let (mut wallet, funding_txid) = get_funded_wallet_wpkh();
 
-    assert!(tx_info_1_option.is_some());
-    let tx_details_1 = tx_info_1_option.unwrap().details;
-
+    // Canonical case: the confirmed funding tx.
+    let info = wallet.get_tx(funding_txid).expect("funded tx should exist");
+    let details = &info.details;
     assert_eq!(
-        tx_details_1.txid.to_string(),
+        details.txid.to_string(),
         "f2a03cdfe1bb6a295b0a4bb4385ca42f95e4b2c6d9a7a59355d32911f957a5b3"
     );
-    assert_eq!(tx_details_1.received, Amount::from_sat(50000));
-    assert_eq!(tx_details_1.sent, Amount::from_sat(76000));
-    assert_eq!(tx_details_1.fee.unwrap(), Amount::from_sat(1000));
-    assert_eq!(tx_details_1.balance_delta, SignedAmount::from_sat(-26000));
+    assert_eq!(details.received, Amount::from_sat(50000));
+    assert_eq!(details.sent, Amount::from_sat(76000));
+    assert_eq!(details.fee.unwrap(), Amount::from_sat(1000));
+    assert_eq!(details.balance_delta, SignedAmount::from_sat(-26000));
+    assert!(matches!(details.canonicality, TxCanonicality::Canonical(_)));
+    assert!(info.chain_position().is_some());
+    assert!(info.last_evicted.is_none());
+    assert!(info.conflicts.is_empty());
 
-    // Transaction id not part of the TxGraph
-    let txid_2 = Txid::from_raw_hash(Hash::all_zeros());
-    let tx_info_2_option = test_wallet.get_tx(txid_2);
-    assert!(tx_info_2_option.is_none());
+    // Build an unconfirmed tx and replace it via RBF.
+    let sendto = Address::from_str("bcrt1q3qtze4ys45tgdvguj66zrk4fu6hq3a3v9pfly5")
+        .unwrap()
+        .require_network(Network::Regtest)
+        .unwrap();
+    let mut builder = wallet.build_tx();
+    builder.add_recipient(sendto.script_pubkey(), Amount::from_sat(10_000));
+    let orig_tx = builder.finish().unwrap().extract_tx().unwrap();
+    let orig_txid = orig_tx.compute_txid();
+    insert_tx(&mut wallet, orig_tx);
+
+    let mut builder = wallet.build_fee_bump(orig_txid).unwrap();
+    builder.fee_rate(FeeRate::from_sat_per_vb(10).unwrap());
+    let rbf_tx = builder.finish().unwrap().extract_tx().unwrap();
+    let rbf_txid = rbf_tx.compute_txid();
+    insert_tx(&mut wallet, rbf_tx);
+    insert_evicted_at(&mut wallet, orig_txid, 220);
+
+    // Non-canonical (evicted) side.
+    let orig_info = wallet.get_tx(orig_txid).expect("evicted tx still visible");
+    assert!(matches!(
+        orig_info.details.canonicality,
+        TxCanonicality::NonCanonical
+    ));
+    assert!(orig_info.chain_position().is_none());
+    assert_eq!(orig_info.last_evicted, Some(220));
+    assert!(orig_info.conflicts.contains(&rbf_txid));
+
+    // Canonical replacement side.
+    let rbf_info = wallet
+        .get_tx(rbf_txid)
+        .expect("replacement tx should exist");
+    assert!(matches!(
+        rbf_info.details.canonicality,
+        TxCanonicality::Canonical(_)
+    ));
+    assert!(rbf_info.chain_position().is_some());
+    assert!(rbf_info.last_evicted.is_none());
+    assert!(rbf_info.conflicts.contains(&orig_txid));
+
+    // Unknown txid returns None.
+    let unknown = Txid::from_raw_hash(Hash::all_zeros());
+    assert!(wallet.get_tx(unknown).is_none());
+
+    // Known to the tx_graph but not wallet-relevant.
+    let (other_external, other_internal) = get_test_tr_single_sig_xprv_and_change_desc();
+    let (other_wallet, other_txid) = get_funded_wallet(other_internal, other_external);
+    wallet
+        .apply_update(Update {
+            tx_update: other_wallet.tx_graph().clone().into(),
+            ..Default::default()
+        })
+        .unwrap();
+    assert!(wallet.get_tx(other_txid).is_none());
 }
 
 #[test]

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -12,7 +12,7 @@ use bdk_wallet::test_utils::*;
 use bdk_wallet::KeychainKind;
 use bdk_wallet::{
     AddressInfo, Balance, FinalizeInputOutcome, IndexOutOfBoundsError, PersistedWallet,
-    TransactionInfo, Update, Wallet,
+    TransactionInfo, UnknownTransaction, Update, Wallet,
 };
 use bitcoin::constants::COINBASE_MATURITY;
 use bitcoin::hashes::Hash;
@@ -3208,15 +3208,35 @@ fn test_wallet_transactions_relevant() {
         .any(|wallet_tx| wallet_tx.tx_node.txid == other_txid));
     assert!(full_tx_count_before < full_tx_count_after);
     assert!(canonical_tx_count_before < canonical_tx_count_after);
+
+    // A wallet-relevant non-canonical tx is included.
+    let sendto = Address::from_str("bcrt1q3qtze4ys45tgdvguj66zrk4fu6hq3a3v9pfly5")
+        .unwrap()
+        .require_network(Network::Regtest)
+        .unwrap();
+    let mut builder = test_wallet.build_tx();
+    builder.add_recipient(sendto.script_pubkey(), Amount::from_sat(10_000));
+    let send_tx = builder.finish().unwrap().extract_tx().unwrap();
+    let send_txid = send_tx.compute_txid();
+    let mut update = Update::default();
+    update.tx_update.txs = vec![Arc::new(send_tx)];
+    update.tx_update.seen_ats = [(send_txid, 100)].into();
+    update.tx_update.evicted_ats = [(send_txid, 200)].into();
+    test_wallet.apply_update(update).unwrap();
+    let info = test_wallet
+        .transactions()
+        .find(|tx| tx.details.txid == send_txid)
+        .expect("non-canonical send_tx should be included");
+    assert!(info.details.chain_position.is_none());
 }
 
 #[test]
-fn test_transaction_info_details() {
+fn test_tx_details_method() {
     let (test_wallet, txid_1) = get_funded_wallet_wpkh();
-    let tx_info_1_option = test_wallet.get_tx(txid_1);
+    let tx_details_1_option = test_wallet.tx_details(txid_1);
 
-    assert!(tx_info_1_option.is_some());
-    let tx_details_1 = tx_info_1_option.unwrap().details;
+    assert!(tx_details_1_option.is_some());
+    let tx_details_1 = tx_details_1_option.unwrap();
 
     assert_eq!(
         tx_details_1.txid.to_string(),
@@ -3229,8 +3249,153 @@ fn test_transaction_info_details() {
 
     // Transaction id not part of the TxGraph
     let txid_2 = Txid::from_raw_hash(Hash::all_zeros());
-    let tx_info_2_option = test_wallet.get_tx(txid_2);
-    assert!(tx_info_2_option.is_none());
+    let tx_details_2_option = test_wallet.tx_details(txid_2);
+    assert!(tx_details_2_option.is_none());
+}
+
+#[test]
+fn test_get_tx() {
+    let (mut wallet, funding_txid) = get_funded_wallet_wpkh();
+
+    // Canonical case: the confirmed funding tx.
+    let info = wallet.get_tx(funding_txid).expect("funded tx should exist");
+    let details = &info.details;
+    assert_eq!(
+        details.txid.to_string(),
+        "f2a03cdfe1bb6a295b0a4bb4385ca42f95e4b2c6d9a7a59355d32911f957a5b3"
+    );
+    assert_eq!(details.received, Amount::from_sat(50000));
+    assert_eq!(details.sent, Amount::from_sat(76000));
+    assert_eq!(details.fee.unwrap(), Amount::from_sat(1000));
+    assert_eq!(details.balance_delta, SignedAmount::from_sat(-26000));
+    assert!(details.chain_position.is_some());
+    assert!(info.evicted_at.is_none());
+    assert!(info.conflicts.is_empty());
+
+    // Build an unconfirmed tx and replace it via RBF.
+    let sendto = Address::from_str("bcrt1q3qtze4ys45tgdvguj66zrk4fu6hq3a3v9pfly5")
+        .unwrap()
+        .require_network(Network::Regtest)
+        .unwrap();
+    let mut builder = wallet.build_tx();
+    builder.add_recipient(sendto.script_pubkey(), Amount::from_sat(10_000));
+    let orig_tx = builder.finish().unwrap().extract_tx().unwrap();
+    let orig_txid = orig_tx.compute_txid();
+    insert_tx(&mut wallet, orig_tx);
+
+    let mut builder = wallet.build_fee_bump(orig_txid).unwrap();
+    builder.fee_rate(FeeRate::from_sat_per_vb(10).unwrap());
+    let rbf_tx = builder.finish().unwrap().extract_tx().unwrap();
+    let rbf_txid = rbf_tx.compute_txid();
+    insert_tx(&mut wallet, rbf_tx);
+    insert_evicted_at(&mut wallet, orig_txid, 220);
+
+    // Non-canonical (evicted) side.
+    let orig_info = wallet.get_tx(orig_txid).expect("evicted tx still visible");
+    assert!(orig_info.details.chain_position.is_none());
+    assert_eq!(orig_info.evicted_at, Some(220));
+    assert!(orig_info.conflicts.contains(&rbf_txid));
+
+    // Canonical replacement side.
+    let rbf_info = wallet
+        .get_tx(rbf_txid)
+        .expect("replacement tx should exist");
+    assert!(rbf_info.details.chain_position.is_some());
+    assert!(rbf_info.evicted_at.is_none());
+    assert!(rbf_info.conflicts.contains(&orig_txid));
+
+    // Unknown txid returns None.
+    let unknown = Txid::from_raw_hash(Hash::all_zeros());
+    assert!(wallet.get_tx(unknown).is_none());
+
+    // Known to the tx_graph but not wallet-relevant.
+    let (other_external, other_internal) = get_test_tr_single_sig_xprv_and_change_desc();
+    let (other_wallet, other_txid) = get_funded_wallet(other_internal, other_external);
+    wallet
+        .apply_update(Update {
+            tx_update: other_wallet.tx_graph().clone().into(),
+            ..Default::default()
+        })
+        .unwrap();
+    assert!(wallet.get_tx(other_txid).is_none());
+}
+
+#[test]
+fn test_conflicts() {
+    let (mut wallet, _funding_txid) = get_funded_wallet_wpkh();
+
+    let sendto = Address::from_str("bcrt1q3qtze4ys45tgdvguj66zrk4fu6hq3a3v9pfly5")
+        .unwrap()
+        .require_network(Network::Regtest)
+        .unwrap();
+    let mut builder = wallet.build_tx();
+    builder.add_recipient(sendto.script_pubkey(), Amount::from_sat(10_000));
+    let orig_tx = builder.finish().unwrap().extract_tx().unwrap();
+    let orig_txid = orig_tx.compute_txid();
+
+    wallet.apply_unconfirmed_txs([(orig_tx.clone(), 100)]);
+
+    // Canonical transactions have no conflicts.
+    assert_eq!(wallet.conflicts(orig_txid), Ok(Vec::new()));
+
+    let orig_change_vout = orig_tx
+        .output
+        .iter()
+        .position(|txout| wallet.is_mine(txout.script_pubkey.clone()))
+        .expect("orig tx should have wallet change") as u32;
+    let child_addr = wallet.next_unused_address(KeychainKind::External).address;
+    let child_tx = Transaction {
+        input: vec![TxIn {
+            previous_output: OutPoint {
+                txid: orig_txid,
+                vout: orig_change_vout,
+            },
+            ..Default::default()
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(1_000),
+            script_pubkey: child_addr.script_pubkey(),
+        }],
+        ..new_tx(0)
+    };
+    let child_txid = child_tx.compute_txid();
+
+    let mut builder = wallet.build_fee_bump(orig_txid).unwrap();
+    builder.fee_rate(FeeRate::from_sat_per_vb(10).unwrap());
+    let replacement_tx = builder.finish().unwrap().extract_tx().unwrap();
+    let replacement_txid = replacement_tx.compute_txid();
+
+    wallet.apply_unconfirmed_txs([(child_tx, 200), (replacement_tx, 300)]);
+
+    // canonical replacement should have no conflicts
+    assert_eq!(wallet.conflicts(replacement_txid), Ok(Vec::new()));
+
+    // check direct conflicts
+    let orig_conflicts = wallet.conflicts(orig_txid).unwrap();
+    assert_eq!(orig_conflicts.len(), 1);
+    assert_eq!(orig_conflicts[0].0, replacement_txid);
+    assert!(orig_conflicts[0].1.is_some());
+
+    // check ancestor conflicts
+    let child_conflicts = wallet.conflicts(child_txid).unwrap();
+    assert_eq!(child_conflicts.len(), 1);
+    assert_eq!(child_conflicts[0].0, replacement_txid);
+    assert!(child_conflicts[0].1.is_some());
+
+    // Unknown transactions return UnknownTransaction.
+    let unknown = Txid::from_raw_hash(Hash::all_zeros());
+    assert_eq!(wallet.conflicts(unknown), Err(UnknownTransaction));
+
+    // Known but wallet-irrelevant transactions return UnknownTransaction.
+    let (other_external, other_internal) = get_test_tr_single_sig_xprv_and_change_desc();
+    let (other_wallet, other_txid) = get_funded_wallet(other_internal, other_external);
+    wallet
+        .apply_update(Update {
+            tx_update: other_wallet.tx_graph().clone().into(),
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(wallet.conflicts(other_txid), Err(UnknownTransaction));
 }
 
 #[test]

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -11,8 +11,8 @@ use bdk_wallet::signer::{SignOptions, SignerError, SignersContainer};
 use bdk_wallet::test_utils::*;
 use bdk_wallet::KeychainKind;
 use bdk_wallet::{
-    AddressInfo, Balance, FinalizeInputOutcome, IndexOutOfBoundsError, PersistedWallet, Update,
-    Wallet, WalletTx,
+    AddressInfo, Balance, FinalizeInputOutcome, IndexOutOfBoundsError, PersistedWallet,
+    TransactionInfo, Update, Wallet,
 };
 use bitcoin::constants::COINBASE_MATURITY;
 use bitcoin::hashes::Hash;
@@ -85,7 +85,7 @@ fn test_get_funded_wallet_balance() {
 fn test_get_funded_wallet_sent_and_received() {
     let (wallet, txid) = get_funded_wallet_wpkh();
 
-    let tx = wallet.get_tx(txid).expect("transaction").tx_node.tx;
+    let tx = wallet.get_tx(txid).expect("transaction").details.tx;
     let (sent, received) = wallet.sent_and_received(&tx);
 
     // The funded wallet contains a tx with a 76_000 sats input and two outputs, one spending 25_000
@@ -99,7 +99,7 @@ fn test_get_funded_wallet_sent_and_received() {
 fn test_get_funded_wallet_tx_fees() {
     let (wallet, txid) = get_funded_wallet_wpkh();
 
-    let tx = wallet.get_tx(txid).expect("transaction").tx_node.tx;
+    let tx = wallet.get_tx(txid).expect("transaction").details.tx;
     let tx_fee = wallet.calculate_fee(&tx).expect("transaction fee");
 
     // The funded wallet contains a tx with a 76_000 sats input and two outputs, one spending 25_000
@@ -112,7 +112,7 @@ fn test_get_funded_wallet_tx_fees() {
 fn test_get_funded_wallet_tx_fee_rate() {
     let (wallet, txid) = get_funded_wallet_wpkh();
 
-    let tx = wallet.get_tx(txid).expect("transaction").tx_node.tx;
+    let tx = wallet.get_tx(txid).expect("transaction").details.tx;
     let tx_fee_rate = wallet
         .calculate_fee_rate(&tx)
         .expect("transaction fee rate");
@@ -132,7 +132,7 @@ fn test_get_funded_wallet_tx_fee_rate() {
 fn test_legacy_get_funded_wallet_tx_fee_rate() {
     let (wallet, txid) = get_funded_wallet_single(get_test_pkh());
 
-    let tx = wallet.get_tx(txid).expect("transaction").tx_node.tx;
+    let tx = wallet.get_tx(txid).expect("transaction").details.tx;
     let tx_fee_rate = wallet
         .calculate_fee_rate(&tx)
         .expect("transaction fee rate");
@@ -2463,8 +2463,15 @@ fn test_taproot_sign_using_non_witness_utxo() {
     let mut psbt = builder.finish().unwrap();
 
     psbt.inputs[0].witness_utxo = None;
-    psbt.inputs[0].non_witness_utxo =
-        Some(wallet.get_tx(prev_txid).unwrap().tx_node.as_ref().clone());
+    psbt.inputs[0].non_witness_utxo = Some(
+        wallet
+            .get_tx(prev_txid)
+            .unwrap()
+            .details
+            .tx
+            .as_ref()
+            .clone(),
+    );
     assert!(
         psbt.inputs[0].non_witness_utxo.is_some(),
         "Previous tx should be present in the database"
@@ -3131,11 +3138,16 @@ fn test_transactions_sort_by() {
     receive_output(&mut wallet, Amount::from_sat(25_000), ReceiveTo::Mempool(0));
 
     // sort by chain position, unconfirmed then confirmed by descending block height
-    let sorted_txs: Vec<WalletTx> =
-        wallet.transactions_sort_by(|t1, t2| t2.chain_position.cmp(&t1.chain_position));
+    let sorted_txs: Vec<TransactionInfo> = wallet
+        .transactions_sort_by(|t1, t2| t2.details.chain_position.cmp(&t1.details.chain_position));
     let conf_heights: Vec<Option<u32>> = sorted_txs
         .iter()
-        .map(|tx| tx.chain_position.confirmation_height_upper_bound())
+        .map(|tx| {
+            tx.details
+                .chain_position
+                .as_ref()
+                .and_then(|position| position.confirmation_height_upper_bound())
+        })
         .collect();
     assert_eq!([None, Some(2000), Some(1000)], conf_heights.as_slice());
 }
@@ -3185,7 +3197,7 @@ fn test_wallet_transactions_relevant() {
     assert_eq!(relevant_tx_count_before, relevant_tx_count_after);
     assert!(!test_wallet
         .transactions()
-        .any(|wallet_tx| wallet_tx.tx_node.txid == other_txid));
+        .any(|wallet_tx| wallet_tx.details.txid == other_txid));
     assert!(test_wallet
         .tx_graph()
         .list_canonical_txs(
@@ -3199,12 +3211,12 @@ fn test_wallet_transactions_relevant() {
 }
 
 #[test]
-fn test_tx_details_method() {
+fn test_transaction_info_details() {
     let (test_wallet, txid_1) = get_funded_wallet_wpkh();
-    let tx_details_1_option = test_wallet.tx_details(txid_1);
+    let tx_info_1_option = test_wallet.get_tx(txid_1);
 
-    assert!(tx_details_1_option.is_some());
-    let tx_details_1 = tx_details_1_option.unwrap();
+    assert!(tx_info_1_option.is_some());
+    let tx_details_1 = tx_info_1_option.unwrap().details;
 
     assert_eq!(
         tx_details_1.txid.to_string(),
@@ -3217,8 +3229,8 @@ fn test_tx_details_method() {
 
     // Transaction id not part of the TxGraph
     let txid_2 = Txid::from_raw_hash(Hash::all_zeros());
-    let tx_details_2_option = test_wallet.tx_details(txid_2);
-    assert!(tx_details_2_option.is_none());
+    let tx_info_2_option = test_wallet.get_tx(txid_2);
+    assert!(tx_info_2_option.is_none());
 }
 
 #[test]


### PR DESCRIPTION
### Description

`WalletTx` was an alias for `CanonicalTx`, so `wallet.transactions()` / `wallet.get_tx(txid)` only returned **canonical** wallet-relevant txs. Replaced/evicted txs disappeared even when still wallet-relevant.

This PR renames `WalletTx` → `TransactionInfo` and surfaces **all wallet-relevant txs**, including non-canonical ones:

```rust
pub struct TransactionInfo {
    pub details: TxDetails,              // includes chain_position: Option<…>
    pub anchors: BTreeSet<ConfirmationBlockTime>,
    pub first_seen: Option<u64>,
    pub last_seen: Option<u64>,
    pub evicted_at: Option<u64>,
    pub conflicts: Vec<Txid>,            // direct input conflicts
}
```

Fixes #295

**Supported use cases**
- Keep dropped txs visible in wallet history.
- Show whether an evicted tx has conflicts.
- Let users decide when it is safe to forget an old dropped tx.
- Give users enough information to warn before accidentally paying twice.

### Notes to the reviewers

- Performance of `transactions()` takes a small hit. Worth confirming whether it's an issue in practice.
- Still need to add tests.

### Changelog notice
```
- Changed: `WalletTx` → owned `TransactionInfo` (details, anchors/seen/evicted, direct conflicts).
- Changed: `transactions()` / `get_tx()` also return non-canonical wallet-relevant txs.
- Changed: `TxDetails::chain_position` → `Option<ChainPosition<_>>` (`None` = non-canonical).
- Added: `Wallet::conflicts(txid)` (ancestor-aware).
```

### Checklists

#### All Submissions:

- [x] I've signed all my commits
- [x] I followed the contribution guidelines
- [x] I ran `just p` before pushing

#### New Features:

- [x] I've added tests for the new feature
- [x] I've added docs for the new feature
- [x] This pull request breaks the existing API
