### PR TITLE
feat(wallet): add Wallet::sign_with_signers

### DIFF
--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -1729,11 +1729,6 @@ impl Wallet {
     /// [`SignerOrdering`]. This function returns the `Result` type with an encapsulated `bool` that
     /// has the value true if the PSBT was finalized, or false otherwise.
     ///
-    /// The [`SignOptions`] can be used to tweak the behavior of the software signers, and the way
-    /// the transaction is finalized at the end. Note that it can't be guaranteed that *every*
-    /// signers will follow the options, but the "software signers" (WIF keys and `xprv`) defined
-    /// in this library will.
-    ///
     /// ## Example
     ///
     /// ```
@@ -1753,7 +1748,68 @@ impl Wallet {
     /// let finalized = wallet.sign(&mut psbt, SignOptions::default())?;
     /// assert!(finalized, "we should have signed all the inputs");
     /// # Ok::<(),anyhow::Error>(())
+    /// ```
     pub fn sign(&self, psbt: &mut Psbt, sign_options: SignOptions) -> Result<bool, SignerError> {
+        self.sign_with_signers(
+            psbt,
+            &[self.signers.as_ref(), self.change_signers.as_ref()],
+            sign_options,
+        )
+    }
+
+    /// Sign a transaction with the provided signer containers.
+    ///
+    /// Signer containers are processed in the order provided. Signers inside each container are
+    /// processed according to their [`SignerOrdering`].
+    ///
+    /// The [`SignOptions`] can be used to tweak the behavior of the software signers, and the way
+    /// the transaction is finalized at the end. Note that it can't be guaranteed that *every*
+    /// signer will follow the options, but the "software signers" (WIF keys and `xprv`) defined
+    /// in this library will.
+    ///
+    /// Returns true if the PSBT was finalized, or false otherwise.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// # use bdk_wallet::*;
+    /// # use bdk_wallet::bitcoin::*;
+    /// # use bdk_wallet::bitcoin::{NetworkKind, secp256k1::Secp256k1};
+    /// # use bdk_wallet::descriptor::IntoWalletDescriptor;
+    /// # use bdk_wallet::signer::SignersContainer;
+    /// # let mut wallet = doctest_wallet!();
+    /// let signer_descriptor = "tr([73c5da0a/86'/0'/0']tprv8fMn4hSKPRC1oaCPqxDb1JWtgkpeiQvZhsr8W2xuy3GEMkzoArcAWTfJxYb6Wj8XNNDWEjfYKK4wGQXh3ZUXhDF2NcnsALpWTeSwarJt7Vc/0/*)";
+    /// let secp = Secp256k1::new();
+    /// let (_, keymap) = signer_descriptor
+    ///     .into_wallet_descriptor(&secp, NetworkKind::Test)
+    ///     .unwrap();
+    /// let external_signers = SignersContainer::build(
+    ///     keymap,
+    ///     wallet.public_descriptor(KeychainKind::External),
+    ///     wallet.secp_ctx(),
+    /// );
+    ///
+    /// let to_address = wallet.next_unused_address(KeychainKind::External).address;
+    /// let mut psbt = {
+    ///     let mut builder = wallet.build_tx();
+    ///     builder.drain_to(to_address.script_pubkey()).drain_wallet();
+    ///     builder.finish()?
+    /// };
+    ///
+    /// let finalized = wallet.sign_with_signers(
+    ///     &mut psbt,
+    ///     &[&external_signers],
+    ///     SignOptions::default(),
+    /// )?;
+    /// assert!(finalized);
+    /// # Ok::<(), anyhow::Error>(())
+    /// ```
+    pub fn sign_with_signers(
+        &self,
+        psbt: &mut Psbt,
+        signers: &[&SignersContainer],
+        sign_options: SignOptions,
+    ) -> Result<bool, SignerError> {
         // This adds all the PSBT metadata for the inputs, which will help us later figure out how
         // to derive our keys.
         self.update_psbt_with_descriptor(psbt)
@@ -1785,12 +1841,7 @@ impl Wallet {
             return Err(SignerError::NonStandardSighash);
         }
 
-        for signer in self
-            .signers
-            .signers()
-            .iter()
-            .chain(self.change_signers.signers().iter())
-        {
+        for signer in signers.iter().flat_map(|container| container.signers()) {
             signer.sign_transaction(psbt, &sign_options, &self.secp)?;
         }
 

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -4,10 +4,10 @@ use std::sync::Arc;
 use assert_matches::assert_matches;
 use bdk_chain::{BlockId, CanonicalizationParams, ConfirmationBlockTime};
 use bdk_wallet::coin_selection;
-use bdk_wallet::descriptor::{calc_checksum, DescriptorError};
+use bdk_wallet::descriptor::{calc_checksum, DescriptorError, IntoWalletDescriptor};
 use bdk_wallet::error::CreateTxError;
 use bdk_wallet::psbt::PsbtUtils;
-use bdk_wallet::signer::{SignOptions, SignerError};
+use bdk_wallet::signer::{SignOptions, SignerError, SignersContainer};
 use bdk_wallet::test_utils::*;
 use bdk_wallet::KeychainKind;
 use bdk_wallet::{AddressInfo, Balance, PersistedWallet, Update, Wallet, WalletTx};
@@ -17,8 +17,8 @@ use bitcoin::script::PushBytesBuf;
 use bitcoin::sighash::{EcdsaSighashType, TapSighashType};
 use bitcoin::taproot::TapNodeHash;
 use bitcoin::{
-    absolute, transaction, Address, Amount, BlockHash, FeeRate, Network, OutPoint, ScriptBuf,
-    Sequence, SignedAmount, Transaction, TxIn, TxOut, Txid,
+    absolute, transaction, Address, Amount, BlockHash, FeeRate, Network, NetworkKind, OutPoint,
+    ScriptBuf, Sequence, SignedAmount, Transaction, TxIn, TxOut, Txid,
 };
 use rand::rngs::StdRng;
 use rand::SeedableRng;
@@ -1366,6 +1366,58 @@ fn test_sign_single_xprv() {
 
     let extracted = psbt.extract_tx().expect("failed to extract tx");
     assert_eq!(extracted.input[0].witness.len(), 2);
+}
+
+#[test]
+fn test_sign_with_signers() {
+    let (descriptor, change_descriptor) = get_test_wpkh_and_change_desc();
+    let (mut wallet, _) = get_funded_wallet(descriptor, change_descriptor);
+    let (_, external_keymap) = descriptor
+        .into_wallet_descriptor(wallet.secp_ctx(), NetworkKind::Test)
+        .unwrap();
+    let external_signers = SignersContainer::build(
+        external_keymap,
+        wallet.public_descriptor(KeychainKind::External),
+        wallet.secp_ctx(),
+    );
+    let (_, internal_keymap) = change_descriptor
+        .into_wallet_descriptor(wallet.secp_ctx(), NetworkKind::Test)
+        .unwrap();
+    let internal_signers = SignersContainer::build(
+        internal_keymap,
+        wallet.public_descriptor(KeychainKind::Internal),
+        wallet.secp_ctx(),
+    );
+
+    let latest_block = wallet.latest_checkpoint().block_id();
+    let internal_addr = wallet.next_unused_address(KeychainKind::Internal);
+    receive_output_to_address(
+        &mut wallet,
+        internal_addr.address,
+        Amount::from_sat(25_000),
+        ConfirmationBlockTime {
+            block_id: latest_block,
+            confirmation_time: 0,
+        },
+    );
+    let addr = wallet.next_unused_address(KeychainKind::External);
+    let mut builder = wallet.build_tx();
+    builder.drain_to(addr.script_pubkey()).drain_wallet();
+    let mut psbt = builder.finish().unwrap();
+    assert_eq!(psbt.inputs.len(), 2);
+
+    let finalized = wallet
+        .sign_with_signers(
+            &mut psbt,
+            &[&external_signers, &internal_signers],
+            Default::default(),
+        )
+        .unwrap();
+    assert!(finalized);
+
+    let extracted = psbt.extract_tx().expect("failed to extract tx");
+    assert_eq!(extracted.input.len(), 2);
+    assert!(extracted.input.iter().all(|input| input.witness.len() == 2));
 }
 
 #[test]


### PR DESCRIPTION
### Description

Adds `Wallet::sign_with_signers`, allowing callers to pass signer containers. `Wallet::sign` now delegates to this new method, so the existing API remains unchanged.

This is a small step toward removing signer ownership from `Wallet` and improving separation of concerns. In the future we can deprecate `Wallet::sign` and remove the wallet signer fields.

### Changelog notice
```
- Added `Wallet::sign_with_signers`.
```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `just p` before pushing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature