### PR TITLE
docs: suggest moving most PR checklist items to contributing guide

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,21 +14,7 @@ of the PR were done in a specific way -->
 <!-- Notice the release manager should include in the release tag message changelog -->
 <!-- See https://keepachangelog.com/en/1.0.0/ for examples -->
 
-### Checklists
+### Before submitting
 
-#### All Submissions:
-
-* [ ] I've signed all my commits
-* [ ] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
-* [ ] I ran `just p` before pushing
-
-#### New Features:
-
-* [ ] I've added tests for the new feature
-* [ ] I've added docs for the new feature
-
-#### Bugfixes:
-
-* [ ] This pull request breaks the existing API
-* [ ] I've added tests to reproduce the issue which are now passing
-* [ ] I'm linking the issue being fixed by this PR
+- [ ] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk_wallet/blob/master/CONTRIBUTING.md)
+- [ ] This PR breaks the existing API

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,20 @@ comment suggesting that you're working on it. If someone is already assigned,
 don't hesitate to ask if the assigned party or previous commenter are still
 working on it if it has been awhile.
 
+Pull Request Checklist
+----------------------
+
+By opening a pull request, you are confirming that:
+
+- All commits are [GPG signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
+- The PR description links to the issue it solves, if one exists.
+- `just pre-push` (alias `just p`) was run before pushing. This formats the
+  code, checks that it compiles, runs clippy, runs tests, and checks docs.
+- For new features, tests covering the new functionality have been added.
+- For new features, documentation for the new functionality has been added.
+- For bug fixes, tests reproducing the bug (and now passing) have been added.
+- Any breaking change to the existing API is clearly called out in the PR description.
+
 Deprecation policy
 ------------------
 
@@ -87,7 +101,7 @@ Coding Conventions
 ------------------
 
 This codebase uses spaces, not tabs.
-Use `cargo fmt` with the default settings to format code before committing.
+Use `cargo +nightly fmt` to format code before committing.
 This is also enforced by the CI.
 All public items must be documented. We adhere to the [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/about.html) with respect to documentation.
 


### PR DESCRIPTION
### Description

Suggests moving most pull request checklist items from the PR template into `CONTRIBUTING.md`, keeping checklist minimal.

This follows the approach we added in `bdk-tx` recently.

Also fixes the contribution guidelines link in the PR template, which previously pointed at the bdk repo instead of this repo's CONTRIBUTING.md.

### Notes to the reviewers

This is just a proposal, let me know if you like it.

### Before submitting

- [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk_wallet/blob/master/CONTRIBUTING.md)
- [ ] This PR breaks the existing API