### PR TITLE
chore(ci): add signed commits check to integration

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -169,3 +169,16 @@ jobs:
         env: 
           RUSTDOCFLAGS: "-D warnings --cfg bdk_wallet_unstable"
         run: cargo doc --workspace --all-features --no-deps
+
+  check-signed-commits:
+    name: Check signed commits
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Verify all commits are GPG signed
+        run: ./ci/check-signed-commits.sh "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}"

--- a/ci/check-signed-commits.sh
+++ b/ci/check-signed-commits.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -euo pipefail
+
+BASE_SHA="${1:-}"
+HEAD_SHA="${2:-}"
+
+if [ -z "$BASE_SHA" ] || [ -z "$HEAD_SHA" ]; then
+    echo "Usage: $0 <base_sha> <head_sha>"
+    exit 1
+fi
+
+UNSIGNED=0
+while IFS=' ' read -r commit status; do
+    if [ "$status" = "N" ]; then
+        echo "Commit $commit is not GPG signed."
+        UNSIGNED=$((UNSIGNED + 1))
+    fi
+done < <(git log --format="%H %G?" "${BASE_SHA}..${HEAD_SHA}")
+
+if [ "$UNSIGNED" -gt 0 ]; then
+    echo "Error: $UNSIGNED commit(s) are not GPG signed. See CONTRIBUTING.md."
+    exit 1
+fi
+
+echo "All commits are GPG signed."


### PR DESCRIPTION
### Description

Part of #410 

A new check-signed-commits job is added to the integration workflow. It runs only on pull requests and calls `ci/check-signed-commits.sh`, which iterates over every commit between the PR base and head, checks the signature status via `git log --format="%H %G?"`, and fails the job if any commit is unsigned (status = N). The check is implemented as a standalone bash script in ci/ consistent with the existing bash scripts, making it easy to run independently of CI.
  
### Notes to the reviewers

The signature check uses git's built-in %G? format specifier, which returns N specifically for commits with no signature at all distinct from E (signature present but key not in local keyring) or U(unknown key validity). This means the check correctly identifies unsigned commits without needing any GPG keys loaded in the CI environment.

The job only runs on pull_request events (guarded by if:` github.event_name == 'pull_request'`) so it doesn't affect push-triggered runs on protected branches.

### Changelog notice

ci: enforce GPG signed commits on pull requests

### Before submitting
- [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk_wallet/blob/master/CONTRIBUTING.md)
