### PR TITLE
Fix API docs for `LoadParams::two_path_descriptor` method

### DIFF
--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -147,9 +147,14 @@ pub fn get_test_wpkh_and_change_desc() -> (&'static str, &'static str) {
     "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/1'/0'/1/*)")
 }
 
-/// `wpkh` two-path descriptor
+/// `wpkh` public two-path descriptor
 pub fn get_test_two_path_wpkh() -> &'static str {
     "wpkh(tpubDDks68wKK1xKaVVVbNmXUAx68K1K817M6KwjvjEyCrjdU7xMvjKnfYAtZjfZcrfPfGFzqmibuVqMzKJGbBnK7mo7WSJri8Y9QgM7aNQ3fCp/<0;1>/*)"
+}
+
+/// `wpkh` private two-path descriptor
+pub fn get_test_two_path_private_wpkh() -> &'static str {
+    "tr(tprv8ZgxMBicQKsPdfqH2fGKQkBAMXpqCpC6v6WhYnEZC7TbpcEavC1N27tHbFP16eLm9XdFDW6cqnGChit8gWXyyT1zQ3xFqUWgHTS9XBQw3j5/<0;1>/*)"
 }
 
 /// `wsh` descriptor with policy `and(pk(A),older(6))`

--- a/src/wallet/params.rs
+++ b/src/wallet/params.rs
@@ -271,12 +271,12 @@ impl LoadParams {
     }
 
     /// Checks that the provided two-path descriptor matches exactly what is loaded for both the
-    /// external and internal keychains.
+    /// external and internal keychains. Note that you can only use this method with public extended
+    /// keys (`xpub` prefix) to create watch-only wallets.
     ///
-    /// # Note
-    ///
-    /// You must also specify [`extract_keys`](Self::extract_keys) if you wish to add a signer
-    /// for an expected descriptor containing secrets.
+    /// # Errors
+    /// Returns an error if the descriptor is invalid, not a 2-path multipath descriptor, or if
+    /// the descriptor provided contains an extended private key (`xprv` prefix).
     pub fn two_path_descriptor<D>(mut self, expected_descriptor: D) -> Self
     where
         D: IntoWalletDescriptor + Send + Clone + 'static,

--- a/tests/persisted_wallet.rs
+++ b/tests/persisted_wallet.rs
@@ -8,7 +8,7 @@ use bdk_chain::{
     keychain_txout::DEFAULT_LOOKAHEAD, ChainPosition, ConfirmationBlockTime, DescriptorExt,
 };
 use bdk_wallet::coin_selection::InsufficientFunds;
-use bdk_wallet::descriptor::IntoWalletDescriptor;
+use bdk_wallet::descriptor::{DescriptorError, IntoWalletDescriptor};
 use bdk_wallet::error::CreateTxError;
 use bdk_wallet::test_utils::*;
 use bdk_wallet::{
@@ -450,6 +450,24 @@ fn two_path_descriptor_wallet_persist_and_recover() {
         .unwrap()
         .expect("wallet must exist");
     assert_eq!(loaded.derivation_index(KeychainKind::External), Some(2));
+
+    // A private multipath descriptor can't be converted to a public key, so loading fails.
+    // You get a Miniscript(Unexpected("Can't make an extended private key with multiple paths into
+    // a public key.")) error.
+    let private_two_path_descriptor = get_test_two_path_private_wpkh();
+    let err = Wallet::load()
+        .two_path_descriptor(private_two_path_descriptor)
+        .check_network(Network::Testnet4)
+        .load_wallet(&mut db);
+    assert_matches!(
+        err,
+        Err(LoadWithPersistError::InvalidChangeSet(
+            LoadError::Descriptor(DescriptorError::Miniscript(miniscript::Error::Unexpected(
+                _
+            )))
+        )),
+        "private multipath descriptor should fail with a Miniscript Unexpected error"
+    );
 }
 
 #[test]


### PR DESCRIPTION
This is a follow up PR to #418 and the sister PR to #306.

Read #306 for more information on this, but the gist is that miniscript cannot parse multipath descriptors that use extended private keys. Our constructors to create/load from two_path_descriptors() fail if users provide private keys there.

This PR adds a test for this failure case, and adjusts the API docs to warn users of this constraint.

cc @yukibtc

### Changelog notice

None.

### Before submitting

- [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk_wallet/blob/master/CONTRIBUTING.md)
- [ ] This PR breaks the existing API
