### PR TITLE
fix(wallet): map keychain in mark_used and unmark_used

### DIFF
--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -729,7 +729,9 @@ impl Wallet {
     ///
     /// Returns whether the given index was present and then removed from the unused set.
     pub fn mark_used(&mut self, keychain: KeychainKind, index: u32) -> bool {
-        self.tx_graph.index.mark_used(keychain, index)
+        self.tx_graph
+            .index
+            .mark_used(self.map_keychain(keychain), index)
     }
 
     /// Undoes the effect of [`mark_used`] and returns whether the `index` was inserted
@@ -741,7 +743,9 @@ impl Wallet {
     ///
     /// [`mark_used`]: Self::mark_used
     pub fn unmark_used(&mut self, keychain: KeychainKind, index: u32) -> bool {
-        self.tx_graph.index.unmark_used(keychain, index)
+        self.tx_graph
+            .index
+            .unmark_used(self.map_keychain(keychain), index)
     }
 
     /// List addresses that are revealed but unused.


### PR DESCRIPTION
### Description

The bug that is fixed: `Wallet::mark_used` and `Wallet::unmark_used` passed the caller-supplied `KeychainKind` straight through to the underlying index. For single-descriptor wallets, this meant marking or unmarking an index on `KeychainKind::Internal` was a silent no-op.

### Changelog notice

```rust
- Fixed `Wallet::mark_used` and `Wallet::unmark_used` being a no-op on single-descriptor wallets when passed `KeychainKind::Internal`.
```

### Before submitting

- [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk_wallet/blob/master/CONTRIBUTING.md)
~- [ ] This PR breaks the existing API~
