### PR TITLE
docs(wallet,params): Fix doc for LoadParams::two_path_descriptor

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.96.0"
 components = ["clippy", "rustfmt"]

--- a/src/wallet/params.rs
+++ b/src/wallet/params.rs
@@ -275,8 +275,8 @@ impl LoadParams {
     ///
     /// # Note
     ///
-    /// You must also specify [`extract_keys`](Self::extract_keys) if you wish to add a signer
-    /// for an expected descriptor containing secrets.
+    /// The provided descriptor may only contain extended public keys (`xpub`) with exactly 2 paths,
+    /// or an error will occur at load time.
     pub fn two_path_descriptor<D>(mut self, expected_descriptor: D) -> Self
     where
         D: IntoWalletDescriptor + Send + Clone + 'static,


### PR DESCRIPTION
### Description

Fix incorrect documentation on `LoadParams::two_path_descriptor` that described behavior from `LoadParams::descriptor` rather than the actual constraints of the `two_path_descriptor` method. The note now correctly states that the provided descriptor must contain only extended public keys (`xpub`) with exactly two derivation paths.

Bump the rust toolchain channel to 1.96.0.

### Changelog notice

Fixed
- docs: Fix doc for LoadParams::two_path_descriptor

### Before submitting

- [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk_wallet/blob/master/CONTRIBUTING.md)