### PR TITLE
fix(wallet): validate network and genesis hash consistency

### DIFF
--- a/src/descriptor/error.rs
+++ b/src/descriptor/error.rs
@@ -10,6 +10,7 @@
 // licenses.
 
 //! Descriptor errors
+use bitcoin::{BlockHash, Network};
 use core::fmt;
 
 /// Errors related to the parsing and usage of descriptors
@@ -44,6 +45,13 @@ pub enum Error {
     Hex(bitcoin::hex::HexToBytesError),
     /// The provided wallet descriptors are identical
     ExternalAndInternalAreTheSame,
+    /// The provided genesis hash does not match the expected mainnet genesis hash
+    GenesisHashMismatch {
+        /// The configured network
+        network: Network,
+        /// The genesis hash that was provided
+        genesis_hash: BlockHash,
+    },
 }
 
 impl From<crate::keys::KeyError> for Error {
@@ -84,6 +92,13 @@ impl fmt::Display for Error {
             Self::ExternalAndInternalAreTheSame => {
                 write!(f, "External and internal descriptors are the same")
             }
+            Self::GenesisHashMismatch {
+                network,
+                genesis_hash,
+            } => write!(
+                f,
+                "Genesis hash {genesis_hash} does not match expected genesis hash for network {network}"
+            ),
         }
     }
 }

--- a/src/wallet/error.rs
+++ b/src/wallet/error.rs
@@ -38,6 +38,13 @@ pub enum LoadError {
     MissingGenesis,
     /// Data loaded from persistence is missing descriptor.
     MissingDescriptor(KeychainKind),
+    /// The network's mainnet genesis hash does not match the loaded genesis hash.
+    GenesisNetworkMismatch {
+        /// The loaded network.
+        network: Network,
+        /// The loaded genesis hash.
+        genesis_hash: BlockHash,
+    },
     /// Data loaded is unexpected.
     Mismatch(LoadMismatch),
 }
@@ -51,6 +58,13 @@ impl fmt::Display for LoadError {
             LoadError::MissingDescriptor(k) => {
                 write!(f, "loaded data is missing descriptor for {k} keychain")
             }
+            LoadError::GenesisNetworkMismatch {
+                network,
+                genesis_hash,
+            } => write!(
+                f,
+                "network {network} is mainnet but loaded genesis hash {genesis_hash} does not match"
+            ),
             LoadError::Mismatch(e) => write!(f, "{e}"),
         }
     }

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -37,7 +37,7 @@ use bitcoin::{
     Address, Amount, Block, FeeRate, Network, NetworkKind, OutPoint, Psbt, ScriptBuf, Sequence,
     SignedAmount, Transaction, TxOut, Txid, Weight, Witness, absolute,
     consensus::encode::serialize,
-    constants::genesis_block,
+    constants::{ChainHash, genesis_block},
     psbt,
     secp256k1::Secp256k1,
     sighash::{EcdsaSighashType, TapSighashType},
@@ -339,9 +339,20 @@ impl Wallet {
         let secp = SecpCtx::new();
         let network = params.network;
         let network_kind = NetworkKind::from(network);
-        let genesis_hash = params
-            .genesis_hash
-            .unwrap_or(genesis_block(network).block_hash());
+        let genesis_hash = match params.genesis_hash {
+            Some(hash) => {
+                if network_kind.is_mainnet()
+                    && ChainHash::from_genesis_block_hash(hash) != ChainHash::BITCOIN
+                {
+                    return Err(DescriptorError::GenesisHashMismatch {
+                        network,
+                        genesis_hash: hash,
+                    });
+                }
+                hash
+            }
+            None => genesis_block(network).block_hash(),
+        };
         let (chain, chain_changeset) = LocalChain::from_genesis_hash(genesis_hash);
 
         let (descriptor, mut descriptor_keymap) = (params.descriptor)(&secp, network_kind)?;
@@ -474,6 +485,14 @@ impl Wallet {
                     expected: exp_network,
                 }));
             }
+        }
+        if network_kind.is_mainnet()
+            && ChainHash::from_genesis_block_hash(chain.genesis_hash()) != ChainHash::BITCOIN
+        {
+            return Err(LoadError::GenesisNetworkMismatch {
+                network,
+                genesis_hash: chain.genesis_hash(),
+            });
         }
         if let Some(exp_genesis_hash) = params.check_genesis_hash {
             if chain.genesis_hash() != exp_genesis_hash {

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use assert_matches::assert_matches;
-use bdk_chain::{BlockId, CanonicalizationParams, ConfirmationBlockTime};
+use bdk_chain::{BlockId, CanonicalizationParams, ConfirmationBlockTime, local_chain};
 use bdk_wallet::KeychainKind;
 use bdk_wallet::coin_selection;
 use bdk_wallet::coin_selection::InsufficientFunds;
@@ -12,8 +12,8 @@ use bdk_wallet::psbt::PsbtUtils;
 use bdk_wallet::signer::{SignOptions, SignerError, SignersContainer};
 use bdk_wallet::test_utils::*;
 use bdk_wallet::{
-    AddressInfo, Balance, FinalizeInputOutcome, IndexOutOfBoundsError, PersistedWallet, Update,
-    Wallet, WalletTx,
+    AddressInfo, Balance, ChangeSet, FinalizeInputOutcome, IndexOutOfBoundsError, LoadError,
+    LoadParams, PersistedWallet, Update, Wallet, WalletTx,
 };
 use bitcoin::constants::COINBASE_MATURITY;
 use bitcoin::hashes::Hash;
@@ -50,6 +50,55 @@ fn test_error_external_and_internal_are_the_same() {
     assert!(
         matches!(err, Err(DescriptorError::ExternalAndInternalAreTheSame)),
         "expected same descriptors error, got {err:?}",
+    );
+}
+
+#[test]
+fn test_error_create_mainnet_network_with_non_mainnet_genesis_hash() {
+    let external_desc = "tr(8aee2b8120a5f157f1223f72b5e62b825831a27a9fdf427db7cc697494d4a642)";
+    let internal_desc = "tr(b511bd5771e47ee27558b1765e87b541668304ec567721c7b880edc0a010da55)";
+    let testnet_genesis_hash = bitcoin::constants::genesis_block(Network::Testnet).block_hash();
+
+    let err = Wallet::create(external_desc, internal_desc)
+        .network(Network::Bitcoin)
+        .genesis_hash(testnet_genesis_hash)
+        .create_wallet_no_persist();
+
+    assert!(
+        matches!(
+            err,
+            Err(DescriptorError::GenesisHashMismatch {
+                network: Network::Bitcoin,
+                genesis_hash,
+            }) if genesis_hash == testnet_genesis_hash
+        ),
+        "expected wallet creation to reject a mismatched mainnet network and genesis hash, got {err:?}",
+    );
+}
+
+#[test]
+fn test_error_load_mainnet_network_with_non_mainnet_genesis_hash() {
+    let testnet_genesis_hash = bitcoin::constants::genesis_block(Network::Testnet).block_hash();
+
+    let changeset = ChangeSet {
+        network: Some(Network::Bitcoin),
+        local_chain: local_chain::ChangeSet {
+            blocks: [(0, Some(testnet_genesis_hash))].into(),
+        },
+        ..Default::default()
+    };
+
+    let err = Wallet::load_with_params(changeset, LoadParams::default());
+
+    assert!(
+        matches!(
+            err,
+            Err(LoadError::GenesisNetworkMismatch {
+                network: Network::Bitcoin,
+                genesis_hash,
+            }) if genesis_hash == testnet_genesis_hash
+        ),
+        "expected wallet loading to reject a mismatched mainnet network and genesis hash, got {err:?}"
     );
 }
 


### PR DESCRIPTION
Fixes #46

### Description

Previously, `Wallet::create_with_params` and `Wallet::load_with_params` allowed `Network::Bitcoin` to be paired with a non-mainnet genesis hash, creating an internally inconsistent wallet configuration.

This PR adds validation to both entry points:

- `Wallet::create_with_params` returns `DescriptorError::GenesisHashMismatch` when a mainnet wallet is configured with a non-mainnet genesis hash.
- `Wallet::load_with_params` returns  `LoadError::GenesisNetworkMismatch` when persisted wallet metadata contains the same inconsistency.

Regression tests have been added for both code paths.

### Notes to the reviewers

This PR revisits the earlier implementation attempt ([#1777](https://github.com/bitcoindevkit/bdk/pull/1777)) and implements the approach that emerged from the review discussion:
- reject only custom genesis hashes for `Network::Bitcoin`;
- preserve support for custom genesis hashes on Testnet, Signet, and Regtest;
- apply the same validation during both wallet creation and wallet loading.

To report these validation failures without changing the existing API signatures, this PR introduces `DescriptorError::GenesisHashMismatch` and `LoadError::GenesisNetworkMismatch`.

Neither `DescriptorError` nor `LoadError` is `#[non_exhaustive]`, so adding these variants is a semver-breaking change for any downstream code with an exhaustive `match` on either enum.

### Changelog notice

```text
Validate that `Network::Bitcoin` is paired with the Bitcoin genesis hash during wallet creation and loading.
```

### Checklists

#### All Submissions

- [x] I've signed all my commits
- [x] I followed the contribution guidelines
- [x] I ran `just p` before pushing

#### Bugfixes

- [ ] This pull request breaks the existing API
- [x] I've added tests to reproduce the issue which are now passing
- [x] I'm linking the issue being fixed by this PR
