### PR TITLE
Add maintainers section to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,22 @@ well as test out the patch set and opine on the technical merits of the patch.
 PR should be reviewed first on the conceptual level before focusing on code
 style or grammar fixes.
 
-To merge a PR we require all CI tests to pass, the PR has at least one approving review by a maintainer with write access, and reasonable criticisms have been addressed.
+Repository maintainers
+----------------------
+
+Like all open source projects our maintainers are busy. Please take it easy on
+them and only ping them if you get no response for a week or two. Maintainers must ensure
+that there is "rough consenus" that a PR is needed and correctly implemented.
+Maintainers are not required to review and test your PR. A maintainer may ACK and
+merge (or NACK and close) a PR based on the reviews of any competent project contributors.
+
+Minimum pull request merge requirements:
+
+- all CI tests pass.
+- at least two "accepts"/ACK from a repository maintainer (other than the author).
+- no reasonable "rejects"/NACK from anybody who reviewed the code.
+
+See the [CODEOWNERS](.github/CODEOWNERS) file for a current list of the project maintainers.
 
 Coding Conventions
 ------------------


### PR DESCRIPTION
### Description

I borrowed from the [rust-bitcoin CONTRIBUTING.md](https://github.com/rust-bitcoin/rust-bitcoin/blob/master/CONTRIBUTING.md) file to add a maintainers section to our CONTRIBUTING.md file. The main points I wanted to clarify are:

1. a maintainer can merge a PR based on the reviews of other project contributors they trust to competently review and test changes. They do not need to do a detailed review and test each and every PR themselves.
2. a maintainer must ensure "rough consensus" is reached on the need for and correctness of a PR.
3. at least ~~one~~ two maintainers must ACK a PR who is not the original author.

### Notes to the reviewers

If these changes work for `bdk_wallet` I'll propose the same change on our other repos. I will also reach out to current maintainers to suggest additional people who they would like to add (and are willing to be) maintainers. Having only two per repo does seem to be enough, the rust-bitcoin team has eight people with maintainer rights. 

### Changelog notice

* Add maintainers section to CONTRIBUTING.md file.

### Before submitting

- [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk_wallet/blob/master/CONTRIBUTING.md)
- [ ] This PR breaks the existing API
