### PR TITLE
Add GH security advisory link on SECURITY.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ println!("Next receive address: {}", address_info.address);
 Ok::<_, anyhow::Error>(())
 ```
 
+## Security Policy
+
+To report a security issue, please refer to the [security policy](SECURITY.md).
+
 ## Minimum Supported Rust Version (MSRV)
 
 The libraries in this repository maintain a MSRV of 1.85.0.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,12 @@
 # Security Policy
 
-To report security issues send an email to `security AT bitcoindevkit DOT org` (not for support).
+To report security issues, either
 
-The following key may be used to communicate sensitive information to developers:
+- send an email to `security AT bitcoindevkit DOT org` (not for support), or
+- open a security advisory on GitHub at
+[`https://github.com/bitcoindevkit/bdk_wallet/security/advisories`](https://github.com/bitcoindevkit/bdk_wallet/security/advisories).
+
+The following key may be used to communicate sensitive information to BDK via email:
 
 | Name | Fingerprint |
 | ---- | ----------- |


### PR DESCRIPTION
Link to GitHub's security advisory page on `SECURITY.md`