### PR TITLE
feat: Add lock_utxos option to prevent double-spending unbroadcasted txs

### DIFF
--- a/src/psbt/params.rs
+++ b/src/psbt/params.rs
@@ -75,6 +75,8 @@ pub struct PsbtParams<C> {
     pub(crate) fallback_sequence: Option<Sequence>,
     /// The context in which the params are used.
     pub(crate) marker: core::marker::PhantomData<C>,
+    /// Set whether to automatically lock the selected UTXOs (inputs) of the created transaction.
+    pub(crate) lock_utxos: bool,
 }
 
 impl Default for PsbtParams<CreateTx> {
@@ -101,6 +103,7 @@ impl Default for PsbtParams<CreateTx> {
             sequence_overrides: Default::default(),
             fallback_sequence: Default::default(),
             marker: core::marker::PhantomData,
+            lock_utxos: false,
         }
     }
 }
@@ -273,6 +276,12 @@ impl<C> PsbtParams<C> {
     /// [`add_planned_input`]: PsbtParams::add_planned_input
     pub fn manually_selected_only(&mut self) -> &mut Self {
         self.manually_selected_only = true;
+        self
+    }
+
+    /// Set whether to automatically lock the selected UTXOs (inputs) of the created transaction in the wallet.
+    pub fn lock_utxos(&mut self, lock: bool) -> &mut Self {
+        self.lock_utxos = lock;
         self
     }
 

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -1572,6 +1572,7 @@ impl Wallet {
         // Sort inputs/outputs according to the chosen algorithm.
         params.ordering.sort_tx_with_aux_rand(&mut tx, rng);
 
+        let lock_utxos = params.lock_utxos;
         let psbt = self.complete_transaction(tx, coin_selection.selected, params)?;
 
         // Recording changes to the change keychain.
@@ -1581,6 +1582,12 @@ impl Wallet {
             {
                 self.stage.merge(index_changeset.into());
                 self.mark_used(keychain, index);
+            }
+        }
+
+        if lock_utxos {
+            for input in &psbt.unsigned_tx.input {
+                self.lock_outpoint(input.previous_output);
             }
         }
 
@@ -3267,6 +3274,12 @@ impl Wallet {
                 {
                     self.stage.merge(index_changeset.into());
                 }
+            }
+        }
+
+        if params.lock_utxos {
+            for input in &psbt.unsigned_tx.input {
+                self.lock_outpoint(input.previous_output);
             }
         }
 

--- a/src/wallet/tx_builder.rs
+++ b/src/wallet/tx_builder.rs
@@ -140,6 +140,7 @@ pub(crate) struct TxParams {
     pub(crate) bumping_fee: Option<PreviousFee>,
     pub(crate) current_height: Option<absolute::LockTime>,
     pub(crate) allow_dust: bool,
+    pub(crate) lock_utxos: bool,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -665,6 +666,12 @@ impl<'a, Cs> TxBuilder<'a, Cs> {
     /// non-standard.
     pub fn allow_dust(&mut self, allow_dust: bool) -> &mut Self {
         self.params.allow_dust = allow_dust;
+        self
+    }
+
+    /// Set whether to automatically lock the selected UTXOs (inputs) of the created transaction in the wallet.
+    pub fn lock_utxos(&mut self, lock: bool) -> &mut Self {
+        self.params.lock_utxos = lock;
         self
     }
 

--- a/tests/create_psbt.rs
+++ b/tests/create_psbt.rs
@@ -1211,3 +1211,33 @@ fn test_add_planned_psbt_input() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_create_psbt_lock_utxos() {
+    let (mut wallet, _) = get_funded_wallet_wpkh();
+
+    // Check that we have a spendable UTXO and it's not locked.
+    let utxo = wallet.list_unspent().next().unwrap().outpoint;
+    assert!(!wallet.is_outpoint_locked(utxo));
+
+    // Create a PSBT with lock_utxos(true)
+    let send_to = wallet.reveal_next_address(KeychainKind::External).address;
+    let mut params = PsbtParams::default();
+    params
+        .add_recipients([(send_to.script_pubkey(), Amount::from_sat(20_000))])
+        .lock_utxos(true);
+    let (psbt, _) = wallet.create_psbt(params).unwrap();
+
+    // Verify that the UTXO spent by this PSBT is now locked
+    let input_op = psbt.unsigned_tx.input[0].previous_output;
+    assert!(wallet.is_outpoint_locked(input_op));
+
+    // Creating a second PSBT should fail with InsufficientFunds because the only UTXO is locked
+    let send_to2 = wallet.reveal_next_address(KeychainKind::External).address;
+    let mut params2 = PsbtParams::default();
+    params2
+        .add_recipients([(send_to2.script_pubkey(), Amount::from_sat(20_000))]);
+    let result = wallet.create_psbt(params2);
+    assert!(result.is_err());
+}
+

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -3506,3 +3506,30 @@ fn test_create_and_spend_from_truc_tx() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_tx_builder_lock_utxos() {
+    let (mut wallet, _) = get_funded_wallet_wpkh();
+
+    let utxo = wallet.list_unspent().next().unwrap().outpoint;
+    assert!(!wallet.is_outpoint_locked(utxo));
+
+    let send_to = wallet.reveal_next_address(KeychainKind::External).address;
+    let mut builder = wallet.build_tx();
+    builder
+        .add_recipient(send_to.script_pubkey(), Amount::from_sat(20_000))
+        .lock_utxos(true);
+    let psbt = builder.finish().unwrap();
+
+    let input_op = psbt.unsigned_tx.input[0].previous_output;
+    assert!(wallet.is_outpoint_locked(input_op));
+
+    // Subsequent build should fail with InsufficientFunds
+    let send_to2 = wallet.reveal_next_address(KeychainKind::External).address;
+    let mut builder2 = wallet.build_tx();
+    builder2
+        .add_recipient(send_to2.script_pubkey(), Amount::from_sat(20_000));
+    let result = builder2.finish();
+    assert!(result.is_err());
+}
+


### PR DESCRIPTION
### Description

Title: feat: Add lock_utxos option to prevent double-spending created transactions

Description: This PR addresses #40 by introducing an option to automatically lock the selected UTXOs (inputs) of a transaction when it is created.

Added lock_utxos option (disabled by default) to TxParams and PsbtParams.
Implemented lock_utxos(bool) builder methods on TxBuilder and PsbtParams.
Updated Wallet::create_tx and Wallet::create_psbt_with_rng to call lock_outpoint on the transaction inputs if lock_utxos is enabled.
Verification: Added the following integration tests to verify that locked UTXOs are excluded from subsequent transaction creations:

test_tx_builder_lock_utxos in tests/wallet.rs
test_create_psbt_lock_utxos in tests/create_psbt.rs
Run tests with: RUSTFLAGS="--cfg bdk_wallet_unstable" cargo test