### PR TITLE
fix(ci): pin nightly toolchain for rustfmt

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -124,13 +124,15 @@ jobs:
         uses: actions/checkout@v7
         with:
           persist-credentials: false
-      # This action automatically reads and applies rust-toolchain.toml
+      # Pin nightly for rustfmt — rustfmt.toml uses nightly-only options
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          toolchain: nightly-2026-08-01
+          components: rustfmt
           cache: true
       - name: Check fmt
-        run: cargo fmt --all --check
+        run: cargo +nightly-2026-08-01 fmt --all --check
 
   clippy_check:
     name: Rust clippy

--- a/justfile
+++ b/justfile
@@ -19,14 +19,14 @@ build:
 
 # Check formatting, compilation, linting
 _check:
-   cargo +nightly fmt --all -- --check
+   cargo +nightly-2026-08-01 fmt --all -- --check
    RUSTFLAGS="" cargo check --all-targets --no-default-features --features miniscript/no-std,bdk_chain/hashbrown
    RUSTFLAGS="" cargo check --all-targets --features {{FEATURES}}
    RUSTFLAGS="-D warnings" cargo clippy --all-targets --features {{FEATURES}}
 
 # Check formatting, compilation, linting of the unstable API surface
 _check-unstable:
-   cargo +nightly fmt --all -- --check
+   cargo +nightly-2026-08-01 fmt --all -- --check
    RUSTFLAGS="--cfg bdk_wallet_unstable" cargo check --all-targets --no-default-features --features miniscript/no-std,bdk_chain/hashbrown
    RUSTFLAGS="--cfg bdk_wallet_unstable" cargo check --all-targets --all-features
    RUSTFLAGS="--cfg bdk_wallet_unstable -D warnings" cargo clippy --all-targets --all-features
@@ -39,7 +39,7 @@ check: _check _check-unstable
 
 # Format all code
 fmt:
-   cargo +nightly fmt
+   cargo +nightly-2026-08-01 fmt
 
 # Run tests on the stable API surface
 _test:


### PR DESCRIPTION
Fixes #535

### Description

The CI fmt job ran cargo fmt on the stable toolchain resolved from rust-toolchain.toml, so the nightly-only options in rustfmt.toml (wrap_comments, comment_width, format_code_in_doc_comments) were silently ignored and never enforced. PRs could pass CI with formatting that `just p` would reject locally.

Point the fmt job at a pinned nightly (nightly-2026-08-01) with the rustfmt component, and pin the same version in the justfile recipes so CI and local just runs produce identical formatting output.

### Before submitting

- [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk_wallet/blob/master/CONTRIBUTING.md)
- [ ] This PR breaks the existing API
