### PR TITLE
fix(wallet): reject txs exceeding MAX_STANDARD_TX_WEIGHT

### DIFF
--- a/src/wallet/error.rs
+++ b/src/wallet/error.rs
@@ -21,7 +21,7 @@ use alloc::{
 };
 #[cfg(all(bdk_wallet_unstable, feature = "bdk-tx"))]
 use bdk_tx::bdk_coin_select;
-use bitcoin::{Amount, BlockHash, Network, OutPoint, Sequence, Txid, absolute, psbt};
+use bitcoin::{Amount, BlockHash, Network, OutPoint, Sequence, Txid, Weight, absolute, psbt};
 use core::fmt;
 
 /// The error type when loading a [`Wallet`] from a [`ChangeSet`].
@@ -199,6 +199,17 @@ pub enum CreateTxError {
     NoUtxosSelected,
     /// Output created is under the dust limit, 546 satoshis
     OutputBelowDustLimit(usize),
+    /// Assembled transaction exceeds [`bitcoin::policy::MAX_STANDARD_TX_WEIGHT`].
+    ///
+    /// The reported `weight` is the estimated signed weight (unsigned transaction plus each
+    /// input's satisfaction weight). Standard mempools reject transactions above this limit,
+    /// so building them is treated as an error.
+    TxWeightLimitExceeded {
+        /// Estimated signed transaction weight.
+        weight: Weight,
+        /// Standardness weight limit that was exceeded.
+        limit: Weight,
+    },
     /// There was an error with coin selection
     CoinSelection(coin_selection::InsufficientFunds),
     /// Cannot build a tx without recipients
@@ -268,6 +279,12 @@ impl fmt::Display for CreateTxError {
             }
             CreateTxError::OutputBelowDustLimit(limit) => {
                 write!(f, "Output below the dust limit: {limit}")
+            }
+            CreateTxError::TxWeightLimitExceeded { weight, limit } => {
+                write!(
+                    f,
+                    "Transaction weight {weight} exceeds the standardness limit of {limit}"
+                )
             }
             CreateTxError::CoinSelection(e) => e.fmt(f),
             CreateTxError::NoRecipients => {
@@ -387,6 +404,17 @@ pub enum CreatePsbtError {
     /// After coin selection, all outputs fell below the dust threshold and were
     /// dropped to fees.
     AllOutputsBelowDust,
+    /// Assembled transaction exceeds [`bitcoin::policy::MAX_STANDARD_TX_WEIGHT`].
+    ///
+    /// The reported `weight` is the estimated signed weight (unsigned transaction plus each
+    /// input's satisfaction weight). Standard mempools reject transactions above this limit,
+    /// so building them is treated as an error.
+    TxWeightLimitExceeded {
+        /// Estimated signed transaction weight.
+        weight: Weight,
+        /// Standardness weight limit that was exceeded.
+        limit: Weight,
+    },
     /// Non-sufficient funds.
     InsufficientFunds(bdk_coin_select::InsufficientFunds),
     /// In order to use the [`add_global_xpubs`] option, every extended key in the descriptor must
@@ -414,6 +442,12 @@ impl fmt::Display for CreatePsbtError {
             Self::InsufficientFunds(e) => write!(f, "{e}"),
             Self::NoRecipients => write!(f, "no output destinations were configured"),
             Self::AllOutputsBelowDust => write!(f, "all outputs are below the dust threshold",),
+            Self::TxWeightLimitExceeded { weight, limit } => {
+                write!(
+                    f,
+                    "transaction weight {weight} exceeds the standardness limit of {limit}"
+                )
+            }
             Self::MissingKeyOrigin(e) => write!(f, "missing key origin: {e}"),
             Self::Plan(op) => write!(f, "failed to create a plan for txout with outpoint {op}"),
             Self::Psbt(e) => write!(f, "{e}"),

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -1505,6 +1505,12 @@ impl Wallet {
             }
         };
 
+        let satisfaction_by_outpoint: HashMap<OutPoint, Weight> = required_utxos
+            .iter()
+            .chain(optional_utxos.iter())
+            .map(|weighted| (weighted.utxo.outpoint(), weighted.satisfaction_weight))
+            .collect();
+
         // Get drain script.
         let mut drain_index = Option::<(KeychainKind, u32)>::None;
         let drain_script = match params.drain_to {
@@ -1598,6 +1604,18 @@ impl Wallet {
 
         // Sort inputs/outputs according to the chosen algorithm.
         params.ordering.sort_tx_with_aux_rand(&mut tx, rng);
+
+        // Reject transactions that would exceed the standardness weight limit once signed.
+        // `tx.weight()` is the unsigned weight (empty witnesses); add each input's satisfaction
+        // weight so we compare against the same limit mempools enforce on the final tx.
+        let satisfaction_weights = tx.input.iter().map(|txin| {
+            satisfaction_by_outpoint
+                .get(&txin.previous_output)
+                .copied()
+                .unwrap_or_else(|| self.satisfaction_weight_for_outpoint(txin.previous_output))
+        });
+        check_max_standard_tx_weight(&tx, satisfaction_weights)
+            .map_err(|(weight, limit)| CreateTxError::TxWeightLimitExceeded { weight, limit })?;
 
         let psbt = self.complete_transaction(tx, coin_selection.selected, params)?;
 
@@ -2944,6 +2962,48 @@ impl Wallet {
             })
             .collect()
     }
+
+    /// Satisfaction weight used to estimate the signed size of spending `outpoint`.
+    ///
+    /// Local wallet UTXOs use the descriptor's [`max_weight_to_satisfy`]. Foreign or unknown
+    /// outpoints return [`Weight::ZERO`], which underestimates; callers that still have the
+    /// original [`WeightedUtxo`] should prefer that value.
+    ///
+    /// [`max_weight_to_satisfy`]: miniscript::Descriptor::max_weight_to_satisfy
+    fn satisfaction_weight_for_outpoint(&self, outpoint: OutPoint) -> Weight {
+        self.get_utxo(outpoint)
+            .and_then(|utxo| {
+                self.public_descriptor(utxo.keychain)
+                    .max_weight_to_satisfy()
+                    .ok()
+            })
+            .unwrap_or(Weight::ZERO)
+    }
+}
+
+/// Estimate the signed weight of an assembled unsigned transaction and reject it when it
+/// exceeds [`bitcoin::policy::MAX_STANDARD_TX_WEIGHT`].
+///
+/// `tx` is unsigned (empty witnesses). `satisfaction_weights` are the additional scriptSig /
+/// witness weights for each input. Empty-witness transactions serialize without the 2-WU
+/// segwit marker/flag; that is added once any satisfaction weight is present.
+fn check_max_standard_tx_weight(
+    tx: &Transaction,
+    satisfaction_weights: impl IntoIterator<Item = Weight>,
+) -> Result<(), (Weight, Weight)> {
+    let satisfaction: Weight = satisfaction_weights.into_iter().sum();
+    let segwit_marker = if satisfaction > Weight::ZERO {
+        Weight::from_wu(2)
+    } else {
+        Weight::ZERO
+    };
+    let weight = tx.weight() + satisfaction + segwit_marker;
+    let limit = Weight::from_wu(u64::from(bitcoin::policy::MAX_STANDARD_TX_WEIGHT));
+    if weight > limit {
+        Err((weight, limit))
+    } else {
+        Ok(())
+    }
 }
 
 /// Methods to construct sync/full-scan requests for spk-based chain sources.
@@ -3220,6 +3280,7 @@ impl Wallet {
     /// - A manually selected input is missing from the wallet, or could not be planned
     /// - The input value is insufficient to fund the outputs
     /// - Failure to complete coin selection
+    /// - The assembled transaction exceeds [`bitcoin::policy::MAX_STANDARD_TX_WEIGHT`]
     /// - Failure to create or update the PSBT.
     ///
     /// # Change address
@@ -3423,6 +3484,14 @@ impl Wallet {
                 rng,
             )
             .map_err(CreatePsbtError::Psbt)?;
+
+        let satisfaction_weights = psbt
+            .unsigned_tx
+            .input
+            .iter()
+            .map(|txin| self.satisfaction_weight_for_outpoint(txin.previous_output));
+        check_max_standard_tx_weight(&psbt.unsigned_tx, satisfaction_weights)
+            .map_err(|(weight, limit)| CreatePsbtError::TxWeightLimitExceeded { weight, limit })?;
 
         // Add global xpubs.
         if params.add_global_xpubs {

--- a/tests/create_psbt.rs
+++ b/tests/create_psbt.rs
@@ -1,6 +1,8 @@
 //! Integration tests for the unstable `create_psbt` and `replace_by_fee` APIs.
 #![cfg(all(bdk_wallet_unstable, feature = "bdk-tx"))]
 
+use std::str::FromStr;
+
 use bdk_chain::{BlockId, ConfirmationBlockTime};
 use bdk_tx::{ChangeScript, bdk_coin_select};
 use bdk_wallet::bitcoin;
@@ -9,8 +11,8 @@ use bdk_wallet::{
     KeychainKind, PsbtParams, SelectionStrategy, Wallet, error::CreatePsbtError, psbt,
 };
 use bitcoin::{
-    Amount, FeeRate, Network, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, absolute,
-    hashes::Hash,
+    Address, Amount, BlockHash, FeeRate, Network, OutPoint, ScriptBuf, Sequence, Transaction, TxIn,
+    TxOut, Weight, absolute, hashes::Hash, transaction,
 };
 use miniscript::plan::Assets;
 
@@ -1210,4 +1212,78 @@ fn test_add_planned_psbt_input() -> anyhow::Result<()> {
     );
 
     Ok(())
+}
+
+/// Fund `wallet` with `n` confirmed outputs of `value` in a single transaction.
+fn fund_wallet_with_n_utxos(wallet: &mut Wallet, n: u32, value: Amount) {
+    let last_index = n.saturating_sub(1);
+    let _revealed: Vec<_> = wallet
+        .reveal_addresses_to(KeychainKind::External, last_index)
+        .collect();
+
+    let outputs = (0..n)
+        .map(|i| TxOut {
+            script_pubkey: wallet
+                .peek_address(KeychainKind::External, i)
+                .script_pubkey(),
+            value,
+        })
+        .collect();
+
+    let tx = Transaction {
+        version: transaction::Version::ONE,
+        lock_time: absolute::LockTime::ZERO,
+        input: vec![],
+        output: outputs,
+    };
+
+    let height = wallet.latest_checkpoint().height() + 1;
+    let mut hash_bytes = [0u8; 32];
+    hash_bytes[0] = 0x42;
+    hash_bytes[1] = (height % 256) as u8;
+    insert_tx_anchor(
+        wallet,
+        tx,
+        BlockId {
+            height,
+            hash: BlockHash::from_byte_array(hash_bytes),
+        },
+    );
+}
+
+#[test]
+fn test_create_psbt_rejects_over_max_standard_tx_weight() {
+    let (desc, change_desc) = get_test_wpkh_and_change_desc();
+    let mut wallet = Wallet::create(desc, change_desc)
+        .network(Network::Regtest)
+        .create_wallet_no_persist()
+        .unwrap();
+
+    // ~1,500 P2WPKH inputs ≈ 408k WU once satisfied (issue #543).
+    const N_UTXOS: u32 = 1_500;
+    fund_wallet_with_n_utxos(&mut wallet, N_UTXOS, Amount::from_sat(1_000));
+    assert_eq!(wallet.list_unspent().count(), N_UTXOS as usize);
+
+    let drain_addr = Address::from_str("bcrt1q3qtze4ys45tgdvguj66zrk4fu6hq3a3v9pfly5")
+        .unwrap()
+        .assume_checked();
+
+    let mut params = PsbtParams::default();
+    params.fee_rate(FeeRate::BROADCAST_MIN);
+    params.coin_selection(SelectionStrategy::All);
+    params.change_script(ChangeScript::from_script(
+        drain_addr.script_pubkey(),
+        Weight::from_wu(107),
+    ));
+
+    let err = wallet.create_psbt(params).expect_err("overweight drain");
+    assert!(
+        matches!(
+            err,
+            CreatePsbtError::TxWeightLimitExceeded { weight, limit }
+                if weight > limit
+                    && limit == Weight::from_wu(u64::from(bitcoin::policy::MAX_STANDARD_TX_WEIGHT))
+        ),
+        "expected TxWeightLimitExceeded, got: {err:?}"
+    );
 }

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -24,7 +24,7 @@ use bitcoin::sighash::{EcdsaSighashType, TapSighashType};
 use bitcoin::taproot::TapNodeHash;
 use bitcoin::{
     Address, Amount, BlockHash, FeeRate, Network, OutPoint, ScriptBuf, Sequence, SignedAmount,
-    Transaction, TxIn, TxOut, Txid, absolute, transaction,
+    Transaction, TxIn, TxOut, Txid, WPubkeyHash, Weight, absolute, psbt, transaction,
 };
 use miniscript::descriptor::KeyMapWrapper;
 use rand::SeedableRng;
@@ -3696,4 +3696,118 @@ fn test_create_and_spend_from_truc_tx() -> anyhow::Result<()> {
     );
 
     Ok(())
+}
+
+/// Fund `wallet` with `n` confirmed outputs of `value` in a single transaction.
+fn fund_wallet_with_n_utxos(wallet: &mut Wallet, n: u32, value: Amount) {
+    let last_index = n.saturating_sub(1);
+    let _revealed: Vec<_> = wallet
+        .reveal_addresses_to(KeychainKind::External, last_index)
+        .collect();
+
+    let outputs = (0..n)
+        .map(|i| TxOut {
+            script_pubkey: wallet
+                .peek_address(KeychainKind::External, i)
+                .script_pubkey(),
+            value,
+        })
+        .collect();
+
+    let tx = Transaction {
+        version: transaction::Version::ONE,
+        lock_time: absolute::LockTime::ZERO,
+        input: vec![],
+        output: outputs,
+    };
+
+    let height = wallet.latest_checkpoint().height() + 1;
+    let mut hash_bytes = [0u8; 32];
+    hash_bytes[0] = 0x42;
+    hash_bytes[1] = (height % 256) as u8;
+    insert_tx_anchor(
+        wallet,
+        tx,
+        BlockId {
+            height,
+            hash: BlockHash::from_byte_array(hash_bytes),
+        },
+    );
+}
+
+#[test]
+fn test_create_tx_rejects_over_max_standard_tx_weight() {
+    // A drain of many small P2WPKH UTXOs is the reported failure mode: the unsigned
+    // transaction stays under the limit, but the estimated signed weight does not.
+    let (desc, change_desc) = get_test_wpkh_and_change_desc();
+    let mut wallet = Wallet::create(desc, change_desc)
+        .network(Network::Regtest)
+        .create_wallet_no_persist()
+        .unwrap();
+
+    // ~1,500 P2WPKH inputs ≈ 408k WU once satisfied (issue #543).
+    const N_UTXOS: u32 = 1_500;
+    fund_wallet_with_n_utxos(&mut wallet, N_UTXOS, Amount::from_sat(1_000));
+    assert_eq!(wallet.list_unspent().count(), N_UTXOS as usize);
+
+    let drain_addr = Address::from_str("bcrt1q3qtze4ys45tgdvguj66zrk4fu6hq3a3v9pfly5")
+        .unwrap()
+        .assume_checked();
+    let mut builder = wallet.build_tx();
+    builder
+        .drain_wallet()
+        .drain_to(drain_addr.script_pubkey())
+        .fee_rate(FeeRate::BROADCAST_MIN);
+
+    assert_matches!(
+        builder.finish(),
+        Err(CreateTxError::TxWeightLimitExceeded { weight, limit })
+            if weight > limit
+                && limit == Weight::from_wu(u64::from(bitcoin::policy::MAX_STANDARD_TX_WEIGHT))
+    );
+}
+
+#[test]
+fn test_create_tx_rejects_over_max_standard_tx_weight_foreign_satisfaction() {
+    // Unit-level construction: a single foreign input whose satisfaction weight
+    // alone pushes the estimated signed weight over the standardness limit.
+    let (mut wallet, _) = get_funded_wallet_wpkh();
+    let addr = wallet.next_unused_address(KeychainKind::External);
+
+    let foreign_prev_tx = Transaction {
+        version: transaction::Version::TWO,
+        lock_time: absolute::LockTime::ZERO,
+        input: vec![],
+        output: vec![TxOut {
+            value: Amount::from_sat(100_000),
+            script_pubkey: ScriptBuf::new_p2wpkh(&WPubkeyHash::all_zeros()),
+        }],
+    };
+    let outpoint = OutPoint {
+        txid: foreign_prev_tx.compute_txid(),
+        vout: 0,
+    };
+    let psbt_input = psbt::Input {
+        witness_utxo: Some(foreign_prev_tx.output[0].clone()),
+        non_witness_utxo: Some(foreign_prev_tx),
+        ..Default::default()
+    };
+
+    let mut builder = wallet.build_tx();
+    builder
+        .add_recipient(addr.script_pubkey(), Amount::from_sat(25_000))
+        .only_witness_utxo()
+        .add_foreign_utxo(
+            outpoint,
+            psbt_input,
+            Weight::from_wu(u64::from(bitcoin::policy::MAX_STANDARD_TX_WEIGHT)),
+        )
+        .unwrap();
+
+    assert_matches!(
+        builder.finish(),
+        Err(CreateTxError::TxWeightLimitExceeded { weight, limit })
+            if weight > limit
+                && limit == Weight::from_wu(u64::from(bitcoin::policy::MAX_STANDARD_TX_WEIGHT))
+    );
 }


### PR DESCRIPTION
### Description

Neither `create_tx` nor `create_psbt` checked the assembled transaction against Bitcoin's standardness weight limit (`bitcoin::policy::MAX_STANDARD_TX_WEIGHT`, 400_000 WU). Dust was already rejected (`OutputBelowDustLimit`); weight was not.

A drain of many small UTXOs could therefore produce a fully signed PSBT over 400k WU. Every standardness-enforcing mempool rejects that transaction, but `sign` still returned `Ok(true)` — a misleading success.

**Root cause:** After coin selection the unsigned transaction is assembled with empty witnesses. `Transaction::weight()` on that value undercounts the final signed size by each input's satisfaction (witness / scriptSig) weight. No later check compared the estimated signed weight to the standardness limit.

**Fix:** After the unsigned tx is assembled, estimate the signed weight (`tx.weight()` plus each input's satisfaction weight, plus the 2-WU segwit marker when witnesses will be present) and reject when it exceeds `MAX_STANDARD_TX_WEIGHT`.

- New `CreateTxError::TxWeightLimitExceeded { weight, limit }` (stable `create_tx` path)
- New `CreatePsbtError::TxWeightLimitExceeded { weight, limit }` (unstable `create_psbt` / `create_psbt_from_selector` path, so RBF is covered too)

**Tests:**
- Drain of 1,500 small P2WPKH UTXOs (the reported case) via a single in-memory funding transaction — no Electrum/Esplora/RPC
- Unit-level foreign UTXO whose satisfaction weight alone exceeds the limit
- Matching `create_psbt` drain regression

Fixes #543

### Notes to the reviewers

- This is a **breaking change**: `CreateTxError` is exhaustive, so downstream `match`es must handle the new variant. `CreatePsbtError` is already `#[non_exhaustive]`.
- The check uses estimated signed weight, not raw unsigned `tx.weight()`. Checking only the unsigned weight would miss the 1,500-P2WPKH-input case (~246k WU unsigned vs ~408k WU signed).
- Satisfaction weights for `create_tx` come from the `WeightedUtxo`s used in coin selection (including foreign UTXOs). The `create_psbt` path looks up local descriptors via `max_weight_to_satisfy`.

### Changelog notice

- Fixed `create_tx` / `create_psbt` producing unrelayable transactions over `MAX_STANDARD_TX_WEIGHT` by returning `TxWeightLimitExceeded`.

### Before submitting

- [x] I followed the contribution guidelines
- [x] This PR breaks the existing API

Assistance: implementation drafted with Cursor (cloud agent); author is Cestercian. Commits are SSH-signed; GitHub may show Unverified if the cloud-agent SSH signing key is not registered on the account as a signing key.